### PR TITLE
feat: label cluster orchestration as experimental

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ spark_pulse/ui/
 web/playwright-report/
 web/test-results/
 .ralph/
+.claude/

--- a/docs/native-runtime-plan.md
+++ b/docs/native-runtime-plan.md
@@ -449,7 +449,7 @@ proven through the same path:
 
 Still open before the native path becomes the default:
 
-- **Native cluster (phase 4).** Multi-node is still refused under `runtime: native`. This is the last thing standing between us and deleting the `run-recipe.sh` fork.
+- **Native cluster (phase 4), blocked on hardware.** Multi-node is refused under `runtime: native`, and the upstream cluster path has never been run on two machines because only one DGX Spark is available. Rather than ship orchestration on faith, cluster orchestration is now labelled experimental in the UI, driven by the `cluster_experimental` config flag so it can be flipped the day a two-node bring-up is actually verified. Every defect found so far surfaced within minutes of touching real hardware and none were caught by simulation, which is the whole argument for not writing multi-node blind.
 - **Recipe v2 coverage.** Only three bundled recipes are engine-neutral; everything imported from upstream is a v1 vLLM command and therefore vLLM-only by construction.
 
 ## 6. Things to fix regardless of the plan

--- a/spark_pulse/config.py
+++ b/spark_pulse/config.py
@@ -117,6 +117,11 @@ class _Config:
         return bool(self._data.get("cluster_enabled", False))
 
     @property
+    def cluster_experimental(self) -> bool:
+        """Whether the UI should mark cluster orchestration as unproven."""
+        return bool(self._data.get("cluster_experimental", True))
+
+    @property
     def job_retention_days(self) -> int:
         return int(self._data.get("job_retention_days", 7))
 

--- a/spark_pulse/config.yaml
+++ b/spark_pulse/config.yaml
@@ -1,6 +1,9 @@
 auth_enabled: false
 benchmarking_enabled: false
 cluster_enabled: false
+# Multi-node orchestration has never been exercised on real hardware, so the UI
+# labels it experimental. Flip this once a two-node bring-up has been verified.
+cluster_experimental: true
 default_container: vllm-node
 job_retention_days: 7
 # Deployment runtime: "upstream" forks spark-vllm-docker's run-recipe.sh,

--- a/spark_pulse/routers/config.py
+++ b/spark_pulse/routers/config.py
@@ -24,6 +24,7 @@ def get_config():
         "auth_enabled": config.auth_enabled,
         "mcp_enabled": config.mcp_enabled,
         "cluster_enabled": config.cluster_enabled,
+        "cluster_experimental": config.cluster_experimental,
         "runtime": config.runtime,
         "benchmarking_enabled": config.benchmarking_enabled,
         "simulation_mode": is_simulation(),

--- a/tests/test_config_router.py
+++ b/tests/test_config_router.py
@@ -52,3 +52,27 @@ class TestApiConfigEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["cluster_enabled"] is True
+
+    def test_config_reports_cluster_as_experimental_by_default(self):
+        """Multi-node has never run on hardware, so the UI must say so.
+
+        The flag ships true and is meant to be flipped once a two-node
+        bring-up has actually been verified.
+        """
+        app = create_app()
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+
+        data = client.get("/api/config").json()
+        assert data["cluster_experimental"] is True
+
+    def test_cluster_experimental_can_be_turned_off(self, monkeypatch):
+        monkeypatch.setitem(config._data, "cluster_experimental", False)
+
+        app = create_app()
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+
+        assert client.get("/api/config").json()["cluster_experimental"] is False

--- a/web/src/components/Experimental.tsx
+++ b/web/src/components/Experimental.tsx
@@ -1,0 +1,53 @@
+import { FlaskConical } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** A small "experimental" chip, for nav entries and section headings.
+ *
+ * Kept deliberately quiet: it marks a feature as unproven without dressing it
+ * up as an error, because the feature still works as far as it has been taken.
+ */
+export function ExperimentalBadge({ className, title }: { className?: string; title?: string }) {
+  return (
+    <span
+      title={title ?? "Experimental: not yet verified on real hardware"}
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+        "bg-warning/15 text-warning",
+        className,
+      )}
+    >
+      exp
+    </span>
+  );
+}
+
+/** A page-level notice saying what is unproven and why.
+ *
+ * `reason` should say plainly what has and has not been exercised, so an
+ * operator can judge the risk instead of guessing at the word "experimental".
+ */
+export function ExperimentalBanner({
+  title = "Experimental feature",
+  reason,
+  className,
+}: {
+  title?: string;
+  reason: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="note"
+      className={cn(
+        "flex items-start gap-3 rounded-xl border border-warning/30 bg-warning/10 p-4",
+        className,
+      )}
+    >
+      <FlaskConical size={18} className="mt-0.5 shrink-0 text-warning" />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-warning">{title}</p>
+        <p className="mt-1 text-sm text-text-muted">{reason}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useAuth } from "@/lib/auth";
 import { doRefresh } from "@/lib/refresh";
 import { type ThemeMode, getTheme, setTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
+import { ExperimentalBadge } from "@/components/Experimental";
 import { useConfig } from "@/lib/config";
 import { Activity, Bot, Boxes, Copyright, Database, Flame, Layers, ListChecks, LogOut, Menu, Moon, MoonStar, Package, RotateCw, Settings, Sun, User, X, Zap, Server } from "lucide-react";
 import { SiGithub, SiPypi } from "@icons-pack/react-simple-icons";
@@ -39,10 +40,10 @@ function SSEConnectionIndicator() {
   );
 }
 
-const NAV = [
+const NAV: { href: string; label: string; icon: typeof Zap; experimental?: boolean }[] = [
   { href: "/", label: "Recipes & Mods", icon: Zap },
   { href: "/jobs", label: "Inference", icon: ListChecks },
-  { href: "/cluster", label: "Cluster", icon: Server },
+  { href: "/cluster", label: "Cluster", icon: Server, experimental: true },
   { href: "/benchmarking", label: "Benchmarking", icon: Flame },
   { href: "/monitoring", label: "Monitoring", icon: Activity },
   { href: "/models", label: "Models", icon: Boxes },
@@ -121,6 +122,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const [version, setVersion] = useState("");
   const { config } = useConfig();
   const benchmarkingEnabled = config?.benchmarking_enabled ?? false;
+  const clusterExperimental = config?.cluster_experimental ?? true;
 
   useEffect(() => {
     fetch("/version")
@@ -186,7 +188,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 )}
               >
                 <Icon size={18} />
-                {item.label}
+                <span className="flex-1">{item.label}</span>
+                {item.experimental && clusterExperimental && (
+                  <ExperimentalBadge title="Cluster orchestration is experimental: multi-node has not been run on real hardware" />
+                )}
               </Link>
             );
           })}

--- a/web/src/lib/config.tsx
+++ b/web/src/lib/config.tsx
@@ -10,6 +10,7 @@ export interface AppConfig {
   auth_enabled: boolean;
   mcp_enabled: boolean;
   cluster_enabled: boolean;
+  cluster_experimental: boolean;
   benchmarking_enabled: boolean;
   simulation_mode: boolean;
   /** "upstream" (run-recipe.sh) or "native" (containers we drive ourselves). */
@@ -20,6 +21,7 @@ const DEFAULT_CONFIG: AppConfig = {
   auth_enabled: false,
   mcp_enabled: true,
   cluster_enabled: false,
+  cluster_experimental: true,
   benchmarking_enabled: false,
   simulation_mode: true,
   runtime: "upstream",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -231,6 +231,7 @@ export interface Settings {
   default_port_range_end: number;
   webui_port: number;
   cluster_enabled: boolean;
+  cluster_experimental: boolean;
   job_retention_days: number;
   benchmarking_enabled: boolean;
   runtime?: string;

--- a/web/src/pages/ClusterPage.tsx
+++ b/web/src/pages/ClusterPage.tsx
@@ -38,6 +38,8 @@ import {
 import { setRefresh } from "@/lib/refresh";
 import type { ClusterState, ClusterValidationResult } from "@/lib/types";
 import type { DeploymentEvent } from "@/lib/operations";
+import { ExperimentalBanner } from "@/components/Experimental";
+import { useConfig } from "@/lib/config";
 
 export default function ClusterPage() {
   const { data: clusters, loading, error, refetch } = useQuery(listClusters);
@@ -273,8 +275,18 @@ export default function ClusterPage() {
 
   const selectedDetail = selectedCluster ? clusterDetail : null;
 
+  const { config } = useConfig();
+  const experimental = config?.cluster_experimental ?? true;
+
   return (
     <div className="space-y-6">
+      {experimental && (
+      <ExperimentalBanner
+        title="Cluster orchestration is experimental"
+        reason="Multi-node bring-up has never been run on real hardware: no second DGX Spark was available to verify it. Single-node deployment is verified and lives on the Inference page. Under runtime: native a cluster deploy is refused outright; the upstream runtime will attempt it, untested."
+      />
+      )}
+
       {/* Reconciliation Notification */}
       {!reconciliationLoading && reconciliationResult && (
         <ReconciliationNotification

--- a/web/src/tests/components/Experimental.test.tsx
+++ b/web/src/tests/components/Experimental.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ExperimentalBadge, ExperimentalBanner } from "@/components/Experimental";
+
+describe("ExperimentalBadge", () => {
+  it("carries a tooltip saying why the feature is marked", () => {
+    render(<ExperimentalBadge title="multi-node has not been run on hardware" />);
+    expect(screen.getByTitle("multi-node has not been run on hardware")).toBeInTheDocument();
+  });
+
+  it("falls back to a general explanation", () => {
+    render(<ExperimentalBadge />);
+    // A bare "exp" chip with no explanation leaves the operator guessing.
+    expect(screen.getByTitle(/not yet verified on real hardware/i)).toBeInTheDocument();
+  });
+});
+
+describe("ExperimentalBanner", () => {
+  it("states plainly what has not been exercised", () => {
+    render(<ExperimentalBanner reason="Multi-node bring-up has never been run on real hardware." />);
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "Multi-node bring-up has never been run on real hardware.",
+    );
+  });
+});


### PR DESCRIPTION
Multi-node orchestration has never been run on real hardware: only one DGX Spark is available. Rather than let it look as finished as the single-node path, the UI now says so.

Every defect found in this project so far surfaced within minutes of touching real hardware, and none were caught by simulation. That is the argument for marking multi-node unproven instead of shipping it quietly.

## What this adds

- A reusable `ExperimentalBadge` and `ExperimentalBanner`. The sidebar Cluster entry carries a small chip with a tooltip; the Cluster page carries a banner.
- The banner says exactly what is unproven: multi-node bring-up has never run on hardware, single-node deployment is verified and lives on the Inference page, and under `runtime: native` a cluster deploy is refused outright while the upstream runtime will attempt it untested.
- A `cluster_experimental` config flag exposed through `/api/config`, so both markers are backend-driven and can be turned off the day a two-node bring-up is actually verified, with no code change.

## Verification

- 1073 pytest, 178 vitest, black, ruff, eslint and `tsc --noEmit` all clean.
- Confirmed on a real DGX Spark that the running instance serves `cluster_experimental: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXcT5wARDv1Jcs3wGdTHe1