### PR TITLE
docs: correct AGENTS.md and the README against what the code now is [skip ci]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ pytest -v                        # Verbose output
 pytest tests/test_tools_recipes.py  # Single file
 ```
 
-Tests live in `tests/` (18 test modules total) and cover:
+Tests live in `tests/` (66 test modules) and cover:
 - **Config & Auth:** `test_config.py`, `test_auth.py`, `test_config_router.py`
 - **End-to-end:** `test_e2e_oidc.py`, `test_e2e_custom_recipes.py`
 - **Routers:** `test_router_custom_files.py`, `test_router_custom_recipes.py`
@@ -91,9 +91,8 @@ Tests live in `tests/` (18 test modules total) and cover:
 - **System:** `test_service.py`, `test_mock_system.py`
 
 ### CI (GitHub Actions)
-- **`unit-tests.yml`** — on PR and main push: installs Node + Python deps, builds frontend, runs pytest
+- **`unit-tests.yml`** — on pull request: separate jobs for Python unit tests, frontend build + UI unit tests, Playwright e2e, and a pre-commit job (black/ruff, eslint, `tsc --noEmit`)
 - **`release.yml`** — on push to `main`: uses `semantic-release` (npm) for version bump + changelog, then publishes to PyPI
-- **`pre-commit.yml`** — runs pre-commit hooks on PRs
 - **`pr-title.yml`** — validates PR title format for semantic-release
 
 ## Frontend Structure
@@ -101,13 +100,18 @@ Tests live in `tests/` (18 test modules total) and cover:
 The React frontend (`web/src/`) includes:
 
 ### Pages
-- **RecipesPage** — Browse and manage deployment recipes
-- **JobsPage** — View and manage active deployments
-- **CachePage** — Monitor and clean HuggingFace cache
-- **MCPPage** — MCP server documentation and tooling
-- **MemoryPage** — Project memory and context management
-- **SettingsPage** — System configuration and preferences
-- **LoginPage** — OIDC authentication (when enabled)
+- **RecipesPage** (`/`) — Browse and manage deployment recipes
+- **InferencePage** (`/jobs`) — View and manage active deployments
+- **ClusterPage** (`/cluster`) — Node registry plus the deployments running across it
+- **BenchmarkingPage** (`/benchmarking`) — Gated by `benchmarking_enabled`; redirects to `/` otherwise
+- **MemoryPage** (`/monitoring`) — Live GPU/CPU/RAM/disk monitoring
+- **ModelsPage** (`/models`) — Hugging Face model cache management
+- **ImagesPage** (`/images`) — Engine image inventory and pulls
+- **CachePage** (`/cache`) — Monitor and clean HuggingFace cache
+- **MCPPage** (`/mcp`) — MCP server documentation and tooling
+- **OciRegistryPage** (`/oci`) — Browse, install and update recipe collections from OCI registries
+- **SettingsPage** (`/settings`) — System configuration and preferences
+- **LoginPage** (`/login`) — OIDC authentication (when enabled)
 
 ### Key Components
 - **Layout** — Main app shell with navigation
@@ -115,7 +119,7 @@ The React frontend (`web/src/`) includes:
 - **CustomRecipeDrawer**, **CustomModDrawer** — Custom recipe and mod management
 - **NewRecipeModal**, **NewModModal** — Creation dialogs
 - **LazyCodeEditor** — Code editor component (lazy-loaded)
-- **SlideDrawer**, **Modal**, **Notifications** — Common UI primitives
+- **SlideDrawer**, **ConfirmModal**, **AlertModal** — Common UI primitives
 - **StatusBadge**, **BaseCard** — Status indicators and card layout
 
 ## Development Conventions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Spark Pulse
 
-Spark Pulse is a web control plane for [spark-vllm-docker](https://github.com/eugr/spark-vllm-docker). It brings recipe discovery, deployment management, live monitoring, cache cleanup, and configuration into one interface for NVIDIA DGX Spark hardware.
+Spark Pulse is a web control plane for deploying inference engines (vLLM, SGLang) on NVIDIA DGX Spark hardware. It drives Docker directly from Python through its own engine plugins — there is no dependency on [spark-vllm-docker](https://github.com/eugr/spark-vllm-docker) to deploy. A spark-vllm-docker checkout is optional and, when configured, is used only as a read-only source for importing existing recipes and browsing mods/example launch scripts.
+
+It brings recipe discovery, deployment management, live monitoring, cache cleanup, and configuration into one interface. Multi-node deployment is supported by the same deploy path, but it has not yet been exercised on more than one physical machine — treat it as unproven until a real two-node bring-up validates it.
 
 **License:** [MIT](LICENSE) — Copyright © 2026 Kharkevich Engineering Lab
 
@@ -81,7 +83,8 @@ Spark Pulse reads settings from `config.yaml` (bundled with the package) and mer
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `spark_vllm_path` | string | `/tmp/spark-vllm-docker` | Absolute path to the spark-vllm-docker installation directory. |
+| `runtime` | string | `native` | Deployment runtime. `native` (Spark Pulse drives Docker itself via the engine registry) is the only one — there is no upstream runtime any more. |
+| `spark_vllm_path` | string | `/tmp/spark-vllm-docker` | Optional path to a spark-vllm-docker checkout. Nothing is executed out of it; it is only read for importing existing recipes and for read-only mod/launch-script discovery. Unset, missing, or wrong just means those sources are unavailable. |
 | `webui_port` | int | `8100` | TCP port the web UI listens on. |
 | `default_container` | string | `vllm-node` | Default Docker container name for deployments. |
 | `default_gpu_mem_util` | float | `0.8` | Default GPU memory utilization fraction (0.0–1.0). |

--- a/tests/test_config_router.py
+++ b/tests/test_config_router.py
@@ -76,3 +76,22 @@ class TestApiConfigEndpoint:
         client = TestClient(app)
 
         assert client.get("/api/config").json()["cluster_experimental"] is False
+
+    def test_config_reports_simulation_mode_from_is_simulation(self, monkeypatch):
+        """simulation_mode must reflect tools.is_simulation(), not a hardcoded constant.
+
+        Would fail if the endpoint returned a literal ``True``/``False`` instead
+        of calling through to ``is_simulation()``.
+        """
+        import spark_pulse.routers.config as config_router
+
+        app = create_app()
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+
+        monkeypatch.setattr(config_router, "is_simulation", lambda: False)
+        assert client.get("/api/config").json()["simulation_mode"] is False
+
+        monkeypatch.setattr(config_router, "is_simulation", lambda: True)
+        assert client.get("/api/config").json()["simulation_mode"] is True


### PR DESCRIPTION
## The config flag was already fixed

I put it on the remaining-work list by reading section 6 of the plan without
reading its strike-throughs — phase 4 struck it off with "Done: it reports
`is_simulation()`", and it does. What was missing is a test that would notice if
it ever reverted to a constant, so that is what this adds: monkeypatch
`is_simulation` false then true, assert the endpoint follows.

## The documents were stale, and not only from the recent deletions

`AGENTS.md`, verified path by path against the actual tree rather than trusted:

- claimed **18 test modules**; there are 66
- named a `pre-commit.yml` workflow that does not exist — black, ruff, eslint
  and tsc run as a job inside `unit-tests.yml`
- said `unit-tests.yml` triggers on PR *and* main push; it is `pull_request`
  only (that trigger belongs to `release.yml`)
- named a `JobsPage`; the component at `/jobs` is `InferencePage`
- omitted `ClusterPage`, `BenchmarkingPage`, `ModelsPage`, `ImagesPage` and
  `OciRegistryPage`, all real routes in `App.tsx`
- listed `Modal` and `Notifications` under key components; neither exists —
  `Modal.tsx` exports `ConfirmModal` and `AlertModal`, and there is no
  notifications component at all

`README.md` still described Spark Pulse as a control plane *for*
spark-vllm-docker. It deploys through its own engine plugins now and the
checkout is optional, used for importing v1 recipes and read-only mod discovery.
The new text says multi-node exists but has never run on two machines, rather
than leaving a reader to assume it is proven. The config table gained `runtime`,
whose absence was itself misleading in a README that used to describe an
upstream-only tool.

## Found and deliberately left

- `CLAUDE.md`'s pages list omits `/models` and `/images`, both real routes.
- `pyproject.toml`'s package description carries the same stale "Web UI for
  spark-vllm-docker" framing, but it is versioned packaging metadata.

Both are outside what this PR is for; say the word and they are a two-line
follow-up.

pytest 1572 · vitest 191 · black/ruff/eslint/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXcT5wARDv1Jcs3wGdTHe1
