### PR TITLE
feat: retire the ssh-per-operation seam

### DIFF
--- a/spark_pulse/agent/bootstrap.py
+++ b/spark_pulse/agent/bootstrap.py
@@ -400,6 +400,7 @@ async def install_agent(
     username: str,
     control_host: str,
     name: str = "",
+    node_id: str = "",
     port: int = 22,
     connector: Connector | None = None,
     private_key: bytes | None = None,
@@ -417,6 +418,9 @@ async def install_agent(
     ``scope`` is ``"auto"`` (prefer a rootless user unit), ``"user"`` or
     ``"system"``. An explicit scope is never quietly downgraded: if it cannot
     be had, the call fails naming the capability that is missing.
+
+    ``node_id`` pins the identity to mint, for a caller that has already put
+    the machine in the node registry. Omitted, enrolment mints a fresh one.
     """
     connector = connector or AsyncSSHConnector()
     report = InstallReport(host=host, username=username, name=name or host)
@@ -489,6 +493,7 @@ async def install_agent(
             username=username,
             control_host=control_host,
             name=name or host,
+            node_id=node_id,
             login_password=password,
             sudo_password_prompt=sudo_password_prompt,
             scope=scope,
@@ -512,6 +517,7 @@ async def _install_over(
     username: str,
     control_host: str,
     name: str,
+    node_id: str,
     login_password: str | None,
     sudo_password_prompt: Prompt | None,
     scope: str,
@@ -561,6 +567,7 @@ async def _install_over(
             report=report,
             control_host=control_host,
             name=name,
+            node_id=node_id,
             bundle=bundle,
             include_runtime=include_runtime,
             offer_sudoers=offer_sudoers,
@@ -750,6 +757,7 @@ async def _place_agent(
     report: InstallReport,
     control_host: str,
     name: str,
+    node_id: str,
     bundle: AgentBundle | None,
     include_runtime: bool,
     offer_sudoers: bool,
@@ -781,6 +789,7 @@ async def _place_agent(
             report=report,
             control_host=control_host,
             name=name,
+            node_id=node_id,
         )
 
     await _write_unit(session, runner, paths, control_host, server, name, report)
@@ -896,9 +905,10 @@ async def _enrol(
     report: InstallReport,
     control_host: str,
     name: str,
+    node_id: str = "",
 ) -> str:
     """Mint, deliver, redeem, shred, invalidate. Steps 5, 7 and 8 of §3.1."""
-    token = server.mint_token(name)
+    token = server.mint_token(name, node_id=node_id)
     token_file = f"{paths.staging}/token"
     bundle_file = f"{paths.staging}/ca.pem"
     try:

--- a/spark_pulse/agent/enrollment.py
+++ b/spark_pulse/agent/enrollment.py
@@ -133,6 +133,13 @@ class TokenGrant:
     expires_at: float
     used_at: float = 0.0
     node_id: str = ""
+    #: The identity this token will mint, chosen by the *control plane* at
+    #: mint time rather than at redemption. Empty means "mint a fresh one".
+    #: The rule it protects is unchanged — the node still never proposes an
+    #: identity — and what it buys is one id per machine instead of two: the
+    #: node registry has already minted one by the time an install starts, and
+    #: a second uuid for the same machine is a join waiting to go wrong.
+    assign_node_id: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -194,10 +201,16 @@ class EnrollmentLedger:
 
     # ── Tokens ───────────────────────────────────────────────────────────
 
-    def mint_token(self, name: str, *, ttl: int = TOKEN_TTL_SECONDS) -> str:
+    def mint_token(
+        self, name: str, *, ttl: int = TOKEN_TTL_SECONDS, node_id: str = ""
+    ) -> str:
         """Mint a single-use token scoped to one node, and return the secret.
 
         The secret is returned once and never stored; only its hash is kept.
+
+        ``node_id`` pins the identity this token will mint. A caller that has
+        already registered the machine passes the registry's id so the two
+        stores agree; a caller that has not omits it and redemption mints.
         """
         secret = secrets.token_urlsafe(32)
         now = time.time()
@@ -208,6 +221,7 @@ class EnrollmentLedger:
                 name=name,
                 created_at=now,
                 expires_at=now + ttl,
+                assign_node_id=node_id,
             )
             self._save()
         return secret
@@ -220,8 +234,10 @@ class EnrollmentLedger:
         operator debugging a failed install needs to know whether to wait or
         to mint another.
 
-        The uuid is minted *here*, on redemption. The node never proposes an
-        identity and cannot choose one.
+        The uuid is minted *here*, on redemption — unless the control plane
+        already chose one when it minted the token. Either way the node never
+        proposes an identity and cannot choose one, which is the property that
+        matters.
         """
         now = now if now is not None else time.time()
         with self._lock:
@@ -239,7 +255,7 @@ class EnrollmentLedger:
                     f"enrollment token for {grant.name!r} expired "
                     f"{int(now - grant.expires_at)}s ago"
                 )
-            node_id = mint_node_id()
+            node_id = grant.assign_node_id or mint_node_id()
             grant.used_at = now
             grant.node_id = node_id
             self._state.nodes[node_id] = LedgerEntry(

--- a/spark_pulse/agent/hub.py
+++ b/spark_pulse/agent/hub.py
@@ -337,6 +337,19 @@ class AgentHub:
         finally:
             connection.discard(command.command_id)
 
+    def cancel_command(self, node_id: str, command_id: str) -> None:
+        """Ask a node to stop a running command, without giving up on it.
+
+        This is deliberately not the same as cancelling the await. The caller
+        still wants the node's answer — a cancelled pull comes back as a
+        ``PullCancelled`` *failure*, which is a definite outcome — and
+        abandoning the future here would turn that definite outcome into
+        "unknown". A node that is not connected has nothing to cancel.
+        """
+        connection = self._connections.get(node_id)
+        if connection is not None:
+            connection.cancel_command(command_id)
+
     async def shutdown(self) -> None:
         """Abandon every connection, reporting every in-flight call unknown."""
         for connection in list(self._connections.values()):

--- a/spark_pulse/agent/local.py
+++ b/spark_pulse/agent/local.py
@@ -74,6 +74,7 @@ async def start_local_agent(
     docker_service: Any | None = None,
     host: str = "127.0.0.1",
     name: str = CONTROL_NODE_NAME,
+    node_id: str = "",
     heartbeat_interval: float | None = None,
     wait: float | None = 10.0,
 ) -> LocalAgent:
@@ -87,11 +88,18 @@ async def start_local_agent(
     """
     directory = Path(directory) if directory else server.directory / "local-agent"
     identity = AgentIdentity.load(directory)
-    if identity is None or server.ledger.get(identity.node_id) is None:
-        # Either never enrolled, or enrolled against a CA/ledger that is gone —
-        # a fresh control-plane state directory, say. Both need a new identity,
-        # and both go through the same enrollment a remote node goes through.
-        token = server.mint_token(name)
+    stale = identity is not None and bool(node_id) and identity.node_id != node_id
+    if identity is None or server.ledger.get(identity.node_id) is None or stale:
+        # Never enrolled; enrolled against a CA/ledger that is gone (a fresh
+        # control-plane state directory, say); or holding an identity the node
+        # registry no longer agrees with. All three need a new identity, and
+        # all three go through the same enrollment a remote node goes through.
+        #
+        # Re-enrolling *ourselves* is safe in a way re-enrolling a peer is not:
+        # the identity lives on this disk, the transport is loopback, and no
+        # other machine has to be told. That asymmetry is why re-enrolment is
+        # automatic here and never automatic there.
+        token = server.mint_token(name, node_id=node_id)
         identity = await enroll(
             server.enrollment_target(host),
             token,

--- a/spark_pulse/agent/operations.py
+++ b/spark_pulse/agent/operations.py
@@ -314,6 +314,15 @@ class NodeOperations:
         downgrade it to unknown. A caller that cancels a pull knows the pull
         did not happen; it should not have to guess.
         """
+        if cancel is not None and cancel():
+            # Already withdrawn before anything was sent. Sending it anyway and
+            # then chasing it with a Cancel is strictly worse — it starts work
+            # on the node that nobody wants, and whether the Cancel wins the
+            # race decides what the caller sees. Refusing here is the same
+            # outcome, deterministically, with no bytes on the wire.
+            raise NodeOperationError(
+                self.node_id, "PullCancelled", f"pull of {ref} cancelled"
+            )
         message = pb.PullImage(ref=ref, want_progress=progress is not None)
         codec.set_optional(message, "interval", interval)
         codec.set_optional(message, "stall_timeout", stall_timeout)
@@ -348,7 +357,6 @@ class NodeOperations:
         """
         period = min(interval or CANCEL_POLL_INTERVAL, CANCEL_POLL_INTERVAL)
         while True:
-            await asyncio.sleep(period)
             try:
                 fired = bool(cancel())
             except Exception as exc:  # pragma: no cover — a caller's callback
@@ -357,6 +365,11 @@ class NodeOperations:
             if fired:
                 self.hub.cancel_command(self.node_id, command_id)
                 return
+            # Polled *before* sleeping: a caller that cancels before the pull
+            # has begun — a teardown racing a deploy — must not have to wait
+            # out a poll interval first, and a fast pull must not finish
+            # inside one and report success for work the caller withdrew.
+            await asyncio.sleep(period)
 
     async def remove_image(self, ref: str, force: bool | None = None) -> bool:
         message = pb.RemoveImage(ref=ref)

--- a/spark_pulse/agent/operations.py
+++ b/spark_pulse/agent/operations.py
@@ -23,8 +23,10 @@ vocabulary are all settled here.
 
 from __future__ import annotations
 
+import asyncio
 import gzip
 import io
+import logging
 import os
 import tarfile
 from pathlib import Path
@@ -36,7 +38,14 @@ from spark_pulse.agent.errors import NodeOperationError
 from spark_pulse.agent.hub import AgentHub
 from spark_pulse.tools.docker import ContainerInfo, ContainerMetadata, ExecResult
 
-__all__ = ["NodeOperations", "NODE_OPERATIONS"]
+logger = logging.getLogger(__name__)
+
+__all__ = ["NodeOperations", "NODE_OPERATIONS", "CANCEL_POLL_INTERVAL"]
+
+#: How often a ``cancel`` callback is polled while a pull is in flight. A
+#: teardown wants the pull to stop promptly; the callback is cheap, and the
+#: node stops on the first Cancel it sees.
+CANCEL_POLL_INTERVAL = 0.5
 
 #: Every operation the protocol carries, in the order they appear below. The
 #: fifteen ``NodeService`` methods plus ``copy_dir_to_container`` and
@@ -288,6 +297,7 @@ class NodeOperations:
         interval: float | None = None,
         stall_timeout: float | None = None,
         timeout: float | None = None,
+        cancel: Callable[[], bool] | None = None,
     ) -> dict[str, Any]:
         """Pull an image onto the node, streaming progress back as it goes.
 
@@ -296,13 +306,57 @@ class NodeOperations:
         messages on the same stream the command went out on. A progress
         message is never an outcome: the pull is finished when — and only when
         — the result arrives.
+
+        ``cancel`` is polled here and, when it turns true, a Cancel is sent to
+        the node — and then we **keep waiting**. That is the whole subtlety:
+        the node answers a cancelled pull with a ``PullCancelled`` failure,
+        which is a definite outcome, and giving up on the await instead would
+        downgrade it to unknown. A caller that cancels a pull knows the pull
+        did not happen; it should not have to guess.
         """
         message = pb.PullImage(ref=ref, want_progress=progress is not None)
         codec.set_optional(message, "interval", interval)
         codec.set_optional(message, "stall_timeout", stall_timeout)
         command = self.hub.new_command(pull_image=message)
-        outcome = await self._call(command, "pull", timeout=timeout, progress=progress)
+        call = asyncio.ensure_future(
+            self._call(command, "pull", timeout=timeout, progress=progress)
+        )
+        watcher = (
+            None
+            if cancel is None
+            else asyncio.ensure_future(
+                self._watch_for_cancel(command.command_id, cancel, interval)
+            )
+        )
+        try:
+            outcome = await call
+        finally:
+            if watcher is not None:
+                watcher.cancel()
         return codec.decode_pull_outcome(outcome)
+
+    async def _watch_for_cancel(
+        self,
+        command_id: str,
+        cancel: Callable[[], bool],
+        interval: float | None,
+    ) -> None:
+        """Poll ``cancel`` and send one Cancel to the node when it fires.
+
+        One, not one per tick: the agent records the id and the second message
+        would be about a command it has already stopped.
+        """
+        period = min(interval or CANCEL_POLL_INTERVAL, CANCEL_POLL_INTERVAL)
+        while True:
+            await asyncio.sleep(period)
+            try:
+                fired = bool(cancel())
+            except Exception as exc:  # pragma: no cover — a caller's callback
+                logger.warning("cancel callback for %s raised: %s", self.node_id, exc)
+                return
+            if fired:
+                self.hub.cancel_command(self.node_id, command_id)
+                return
 
     async def remove_image(self, ref: str, force: bool | None = None) -> bool:
         message = pb.RemoveImage(ref=ref)

--- a/spark_pulse/agent/runtime.py
+++ b/spark_pulse/agent/runtime.py
@@ -1,0 +1,233 @@
+"""The running control plane, findable from synchronous code.
+
+Everything the agent transport needs at run time — the server, its hub, the
+control node's own agent, and the event loop all three live on — is one object
+here, held once per process. Synchronous callers reach it through
+:func:`current`; that is the whole reason the module exists.
+
+**Why a process-wide handle rather than dependency injection.** The callers
+that need a node service are not endpoints. They are ``reconcile_all()`` at
+startup, the orchestrator deep inside a deploy, the image cache, the health
+validator — reached through four or five frames of synchronous code that a
+router does not thread anything through. Passing the runtime down all of them
+would mean changing every signature between the router and the docker call,
+which is the change this design exists to avoid making twice. So it is looked
+up, in exactly one function, and every test that needs a different one uses
+:func:`use` to install it for the duration.
+
+**Why the node id join lives here.** A machine has one identity: the id the
+node registry minted for it. Enrolment is told that id rather than minting a
+second one, so ``NodeRecord.id``, the enrolment ledger's key and the agent's
+own ``node_id`` are the same string. :meth:`ControlPlaneRuntime.node_id_for`
+is where that is relied on, and it is the only place — if the join ever has to
+change, it changes once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator
+
+from contextlib import contextmanager
+
+from spark_pulse.agent.hub import AgentHub, Liveness
+from spark_pulse.agent.local import CONTROL_NODE_NAME, LocalAgent, start_local_agent
+from spark_pulse.agent.server import ControlPlaneServer
+from spark_pulse.agent.sync_service import AgentNodeService
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from spark_pulse.tools.node_service import Node
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ControlPlaneRuntime",
+    "current",
+    "set_current",
+    "use",
+    "start_runtime",
+    "stop_runtime",
+]
+
+
+class ControlPlaneRuntime:
+    """The server, the hub, the control node's agent, and their loop."""
+
+    def __init__(
+        self,
+        server: ControlPlaneServer,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        local: LocalAgent | None = None,
+    ):
+        self.server = server
+        self.loop = loop
+        self.local = local
+
+    @property
+    def hub(self) -> AgentHub:
+        return self.server.hub
+
+    @property
+    def control_node_id(self) -> str:
+        """The control node's own identity, or "" before its agent is up."""
+        return self.local.node_id if self.local is not None else ""
+
+    # ── Resolution ───────────────────────────────────────────────────────
+
+    def node_id_for(self, node: Node) -> str:
+        """The agent identity behind a :class:`Node`, or "" if there is none.
+
+        Three ways in, in order of how much they can be trusted:
+
+        1. ``node.is_self`` — the control node, whose agent this process runs.
+           No lookup: the runtime holds the id directly, so this answer cannot
+           be wrong even if the registry file is missing.
+        2. ``node.id`` already being an enrolled identity. Callers that got
+           their ``Node`` from the registry are here.
+        3. The address, matched against the registry. Callers holding an IP
+           out of a container label are here, and this is the weakest of the
+           three — an address is not an identity and can be reassigned — so
+           it is last rather than first.
+        """
+        if node.is_self:
+            return self.control_node_id
+        if node.id and self.server.ledger.get(node.id) is not None:
+            return node.id
+        return self._by_address(node.address)
+
+    def _by_address(self, address: str) -> str:
+        """The enrolled identity of whatever machine ``address`` names."""
+        if not address:
+            return ""
+        try:
+            from spark_pulse.tools import node_registry
+
+            for record in node_registry.list_nodes():
+                if record.address == address:
+                    return record.id
+        except Exception as exc:  # pragma: no cover — the registry is advisory
+            logger.debug("could not consult the node registry for %s: %s", address, exc)
+        return ""
+
+    def service_for(self, node: Node) -> AgentNodeService:
+        """The synchronous container service bound to ``node``.
+
+        Raises :class:`LookupError` when the node has no agent. That is a
+        deliberate refusal rather than a fallback: there is no second way to
+        reach a node any more, and quietly substituting the control plane's
+        own docker daemon for a node we cannot reach is the exact bug
+        ``docs/transport-reexamined.md`` §5.1 recorded thirteen instances of.
+        """
+        node_id = self.node_id_for(node)
+        if not node_id:
+            raise LookupError(
+                f"{node.label} has no enrolled agent, so there is no way to "
+                "reach it. Install one with the node installer."
+            )
+        return AgentNodeService(self.hub, node_id, self.loop, label=node.label)
+
+    def liveness(self, node: Node) -> Liveness:
+        """Healthy, unknown or dead — for a node that may not be enrolled."""
+        node_id = self.node_id_for(node)
+        return self.hub.liveness(node_id) if node_id else Liveness.DEAD
+
+
+# ── The process-wide handle ──────────────────────────────────────────────────
+
+_current: ControlPlaneRuntime | None = None
+
+
+def current() -> ControlPlaneRuntime | None:
+    """The running control plane, or ``None`` before startup."""
+    return _current
+
+
+def set_current(runtime: ControlPlaneRuntime | None) -> None:
+    """Install (or clear) the process-wide runtime."""
+    global _current
+    _current = runtime
+
+
+@contextmanager
+def use(runtime: ControlPlaneRuntime | None) -> Iterator[ControlPlaneRuntime | None]:
+    """Install ``runtime`` for the duration of the block, then put back what was.
+
+    Restores rather than clears, so nesting works and a test that forgets to
+    tear down does not silently disarm the next one.
+    """
+    previous = _current
+    set_current(runtime)
+    try:
+        yield runtime
+    finally:
+        set_current(previous)
+
+
+# ── Lifecycle ────────────────────────────────────────────────────────────────
+
+
+async def start_runtime(
+    *,
+    directory: Path | str,
+    node_id: str = "",
+    name: str = CONTROL_NODE_NAME,
+    host: str = "0.0.0.0",
+    loopback: str = "127.0.0.1",
+    docker_service: Any | None = None,
+    session_port: int | None = None,
+    enrollment_port: int | None = None,
+    wait: float | None = 10.0,
+    install: bool = True,
+) -> ControlPlaneRuntime:
+    """Start the listeners and the control node's own agent.
+
+    The enrollment listener is **not** started here. It is opened only for the
+    seconds an install needs it (``bootstrap.enrollment_window``), so a token
+    endpoint is not reachable for the life of the process.
+    """
+    ports: dict[str, int] = {}
+    if session_port is not None:
+        ports["session_port"] = session_port
+    if enrollment_port is not None:
+        ports["enrollment_port"] = enrollment_port
+    server = ControlPlaneServer(directory=directory, host=host, **ports)
+    await server.start()
+    runtime = ControlPlaneRuntime(server, asyncio.get_running_loop())
+    if install:
+        set_current(runtime)
+    try:
+        runtime.local = await start_local_agent(
+            server,
+            docker_service=docker_service,
+            host=loopback,
+            name=name,
+            node_id=node_id,
+            wait=wait,
+        )
+    except Exception:
+        # A control plane whose own agent will not start is not a control
+        # plane: every node service, including this machine's, goes through
+        # it. Unwind rather than leave a half-started server listening.
+        if install:
+            set_current(None)
+        await server.stop()
+        raise
+    return runtime
+
+
+async def stop_runtime(runtime: ControlPlaneRuntime | None = None) -> None:
+    """Stop the control node's agent and both listeners."""
+    runtime = runtime or _current
+    if runtime is None:
+        return
+    if _current is runtime:
+        set_current(None)
+    if runtime.local is not None:
+        try:
+            await runtime.local.stop()
+        except Exception as exc:  # pragma: no cover — shutdown is best effort
+            logger.warning("the control node's agent did not stop cleanly: %s", exc)
+    await runtime.server.stop()

--- a/spark_pulse/agent/server.py
+++ b/spark_pulse/agent/server.py
@@ -212,10 +212,13 @@ class ControlPlaneServer:
         """End a token's life, redeemed or not. §3.1 step 8."""
         return self.ledger.revoke_token(secret)
 
-    def mint_token(self, name: str) -> str:
+    def mint_token(self, name: str, *, node_id: str = "") -> str:
         """A single-use enrollment token for one node, valid ten minutes.
 
         This is what the SSH installer carries to the node, alongside the
         trust bundle and its pin. Those three things are the entire handoff.
+
+        ``node_id`` pins the identity the token will mint, for a caller that
+        has already put the machine in the node registry.
         """
-        return self.ledger.mint_token(name)
+        return self.ledger.mint_token(name, node_id=node_id)

--- a/spark_pulse/agent/sync_service.py
+++ b/spark_pulse/agent/sync_service.py
@@ -157,11 +157,59 @@ class AgentNodeService:
         name: str,
         env_vars: dict[str, str],
         metadata: ContainerMetadata,
-        **kwargs: Any,
+        privileged: bool = True,
+        memory_limit_gb: float | None = None,
+        shm_size_gb: float = 64,
+        pids_limit: int = 4096,
+        nofile_limit: int = 1048576,
+        cache_dirs: list[str] | None = None,
+        port_mappings: list[str] | None = None,
+        entrypoint_clear: bool = True,
+        detach: bool = True,
+        command: str | list[str] | None = None,
+        mounts: dict[str, str] | None = None,
+        network_host: bool | None = None,
+        ipc_host: bool = False,
+        devices: list[str] | None = None,
+        cap_add: list[str] | None = None,
+        ulimits: dict[str, str] | None = None,
+        auto_remove: bool = True,
     ) -> ContainerInfo:
-        """Build and start a container carrying spark-pulse labels."""
+        """Build and start a container carrying spark-pulse labels.
+
+        Written out rather than taking ``**kwargs``, and every value forwarded
+        rather than left to the node's default. The signature *is* the
+        interface — a caller holds one of these without knowing which
+        implementation it has, so a default that differs between them is a
+        divergence nothing at the call site would reveal, and the contract
+        test compares names and defaults for exactly that reason. Sending each
+        value explicitly is what makes the two ends agree by construction
+        instead of by both happening to hold the same constant.
+        """
         return self._run(
-            self.ops.run_container(image, name, env_vars, metadata, **kwargs)
+            self.ops.run_container(
+                image,
+                name,
+                env_vars,
+                metadata,
+                privileged=privileged,
+                memory_limit_gb=memory_limit_gb,
+                shm_size_gb=shm_size_gb,
+                pids_limit=pids_limit,
+                nofile_limit=nofile_limit,
+                cache_dirs=cache_dirs,
+                port_mappings=port_mappings,
+                entrypoint_clear=entrypoint_clear,
+                detach=detach,
+                command=command,
+                mounts=mounts,
+                network_host=network_host,
+                ipc_host=ipc_host,
+                devices=devices,
+                cap_add=cap_add,
+                ulimits=ulimits,
+                auto_remove=auto_remove,
+            )
         )
 
     def ensure_directories(self, paths: Iterable[str]) -> list[str]:

--- a/spark_pulse/agent/sync_service.py
+++ b/spark_pulse/agent/sync_service.py
@@ -1,0 +1,279 @@
+"""The synchronous face of :class:`NodeOperations`.
+
+The control plane's callers — the orchestrator, reconciliation, the health
+validator, the image cache — are synchronous, and run on the AnyIO worker
+threads FastAPI hands to sync endpoints and ``run_in_threadpool``. The agent
+transport is asynchronous and lives on the app's event loop. This file is the
+bridge between them, and it is the *only* one: every other module keeps the
+shape it already has.
+
+**Why a bridge rather than two implementations.** A second, synchronous client
+speaking the same protocol is exactly the arrangement
+``docs/transport-reexamined.md`` §5.1 measured the cost of — thirty semantic
+divergences between two hand-written services, three of them live bugs. There
+is one client. :class:`AgentNodeService` builds no commands, parses no
+results, and knows nothing about the wire; it forwards to
+:class:`~spark_pulse.agent.operations.NodeOperations` and waits.
+
+**Why it refuses to run on the loop thread.** ``run_coroutine_threadsafe``
+blocks the calling thread until the coroutine finishes. Called from the thread
+running the loop, that thread is the one that has to *make* it finish, so it
+hangs — silently, with no traceback, until something times out. A hang that
+takes an hour to diagnose is worse than an exception that names the mistake,
+so calling from a thread with a running loop raises immediately and says to
+await :class:`NodeOperations` directly.
+
+**Three outcomes, still three.** ``NodeUnreachable`` and ``NodeOperationError``
+cross this boundary untouched, because the distinction between them is the
+reason the transport exists. The one thing translated is a small, explicit set
+of failures that are part of the container service's contract — a cancelled
+pull is ``PullCancelled`` here just as it is on the node — so a caller written
+against ``DockerService`` behaves identically against a remote node.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable
+from concurrent.futures import Future, TimeoutError as FutureTimeout
+from typing import Any, Callable, Coroutine
+
+from spark_pulse.agent.errors import NodeOperationError
+from spark_pulse.agent.hub import DEFAULT_COMMAND_TIMEOUT, AgentHub
+from spark_pulse.agent.operations import NodeOperations
+from spark_pulse.tools.docker import (
+    PULL_PROGRESS_INTERVAL,
+    ContainerInfo,
+    ContainerMetadata,
+    ExecResult,
+    PullCancelled,
+    PullStalled,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AgentNodeService", "CONTRACT_EXCEPTIONS", "RESULT_MARGIN"]
+
+#: Remote failures that are part of the container service's published
+#: contract, and the local class each is re-raised as. Callers already catch
+#: these by type — ``native_runtime`` catches ``PullCancelled`` in two places
+#: and ``images`` in a third — so a remote pull that is cancelled has to look
+#: the same as a local one or those handlers stop firing.
+#:
+#: Everything absent from this table stays a :class:`NodeOperationError`. That
+#: is deliberate: a table that grew to cover every exception would be a second
+#: copy of the node's error taxonomy, drifting from it.
+CONTRACT_EXCEPTIONS: dict[str, type[BaseException]] = {
+    "PullCancelled": PullCancelled,
+    "PullStalled": PullStalled,
+}
+
+#: Added to a command's own deadline before the *thread* stops waiting. The
+#: hub already resolves every call within its deadline, so this margin is only
+#: ever spent if the hub itself is wedged — in which case a thread that waits
+#: forever is a leaked worker, and this turns it into an error.
+RESULT_MARGIN = 30.0
+
+
+class AgentNodeService:
+    """Container operations on one node, over its agent, synchronously.
+
+    Satisfies :class:`~spark_pulse.tools.node_service.NodeService`. Built for
+    one node at construction; no method takes a node.
+    """
+
+    def __init__(
+        self,
+        hub: AgentHub,
+        node_id: str,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        timeout: float | None = None,
+        label: str = "",
+    ):
+        self.ops = NodeOperations(hub, node_id, timeout=timeout)
+        self.node_id = node_id
+        self.loop = loop
+        self.label = label or node_id
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<AgentNodeService {self.label}>"
+
+    # ── The bridge ───────────────────────────────────────────────────────
+
+    def _run(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        """Run ``coro`` on the control plane's loop and wait for its value.
+
+        The coroutine is closed rather than leaked if the guard below fires,
+        so a misuse does not also produce a "never awaited" warning pointing
+        somewhere unhelpful.
+        """
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is not None:
+            coro.close()
+            raise RuntimeError(
+                f"AgentNodeService.{coro.__qualname__.split('.')[-1]} was called from "
+                "a thread with a running event loop, which would deadlock. Await "
+                "spark_pulse.agent.operations.NodeOperations directly instead, or "
+                "call this from a worker thread (asyncio.to_thread)."
+            )
+        future: Future[Any] = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        deadline = (
+            (self.ops.timeout or DEFAULT_COMMAND_TIMEOUT)
+            if timeout is None
+            else timeout
+        )
+        try:
+            return future.result(deadline + RESULT_MARGIN)
+        except NodeOperationError as exc:
+            translated = CONTRACT_EXCEPTIONS.get(exc.error_type)
+            if translated is None:
+                raise
+            raise translated(exc.error_message) from None
+        except FutureTimeout:
+            # Not NodeUnreachable: the hub guarantees it resolves within the
+            # command deadline, so arriving here means the hub did not, and
+            # saying "the node is unreachable" would blame the wrong machine.
+            future.cancel()
+            raise RuntimeError(
+                f"the control plane's event loop did not answer within "
+                f"{deadline + RESULT_MARGIN:g}s for {self.label}"
+            ) from None
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    def run_container(
+        self,
+        image: str,
+        name: str,
+        env_vars: dict[str, str],
+        metadata: ContainerMetadata,
+        **kwargs: Any,
+    ) -> ContainerInfo:
+        """Build and start a container carrying spark-pulse labels."""
+        return self._run(
+            self.ops.run_container(image, name, env_vars, metadata, **kwargs)
+        )
+
+    def ensure_directories(self, paths: Iterable[str]) -> list[str]:
+        """Create bind-mount sources on the node. Returns the ones that failed."""
+        return self._run(self.ops.ensure_directories(paths))
+
+    def stop_container(self, name: str, timeout: int = 30) -> bool:
+        """Stop and remove a container by name."""
+        return self._run(self.ops.stop_container(name, timeout))
+
+    def get_container_status(self, name: str) -> dict[str, Any]:
+        """Return ``{status, running, id, state, error}`` for a container."""
+        return self._run(self.ops.get_container_status(name))
+
+    def exec_in_container(
+        self,
+        container: str | Any,
+        command: str | list[str],
+        detach: bool = False,
+        timeout: int | None = None,
+    ) -> ExecResult:
+        """Execute a command inside a running container."""
+        name = getattr(container, "name", container)
+        return self._run(
+            self.ops.exec_in_container(str(name), command, detach, timeout)
+        )
+
+    def get_logs(self, name: str, tail: int = 200) -> str:
+        """Return the tail of a container's logs."""
+        return self._run(self.ops.get_logs(name, tail))
+
+    # ── Copying ──────────────────────────────────────────────────────────
+
+    def copy_to_container(
+        self,
+        container: str,
+        local_path: str,
+        remote_path: str,
+        timeout: int = 120,
+    ) -> bool:
+        """Copy a file (or a directory) into a container on the node."""
+        return self._run(
+            self.ops.copy_to_container(container, local_path, remote_path, timeout)
+        )
+
+    # ── Inspection ───────────────────────────────────────────────────────
+
+    def list_managed_containers(
+        self, labels: dict[str, str] | None = None
+    ) -> list[ContainerInfo]:
+        """Every spark-pulse managed container on the node, filtered by label."""
+        return self._run(self.ops.list_managed_containers(labels))
+
+    def get_container_by_deployment(self, deployment: str) -> ContainerInfo | None:
+        """The container carrying a deployment label, or None."""
+        return self._run(self.ops.get_container_by_deployment(deployment))
+
+    def get_container_by_recipe(self, recipe: str) -> list[ContainerInfo]:
+        """Every container carrying a recipe label."""
+        return self._run(self.ops.get_container_by_recipe(recipe))
+
+    # ── Images ───────────────────────────────────────────────────────────
+
+    def image_exists(self, ref: str) -> bool:
+        """Whether the image reference resolves on the node."""
+        return self._run(self.ops.image_exists(ref))
+
+    def image_info(self, ref: str) -> dict[str, Any] | None:
+        """``{id, size_bytes, created, repo_tags, repo_digests}`` or None."""
+        return self._run(self.ops.image_info(ref))
+
+    def list_images(self) -> list[dict[str, Any]]:
+        """Every image on the node, shaped like :meth:`image_info`."""
+        return self._run(self.ops.list_images())
+
+    def pull_image(
+        self,
+        ref: str,
+        progress: Any | None = None,
+        interval: float = PULL_PROGRESS_INTERVAL,
+        cancel: Callable[[], bool] | None = None,
+        stall_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Pull an image onto the node, reporting aggregated progress.
+
+        ``progress`` is invoked on the control plane's **event loop** thread,
+        not this one. Every current callback publishes an event or updates a
+        dict, which is safe; a callback that blocks would stall the loop, so
+        it must not.
+        """
+        return self._run(
+            self.ops.pull_image(
+                ref,
+                progress=progress,
+                interval=interval,
+                stall_timeout=stall_timeout,
+                cancel=cancel,
+            )
+        )
+
+    def remove_image(self, ref: str, force: bool = False) -> bool:
+        """Remove an image from the node. False when it was not there."""
+        return self._run(self.ops.remove_image(ref, force))
+
+    # ── Beyond the container service ─────────────────────────────────────
+
+    def get_facts(self) -> Any:
+        """Ask the node to describe itself, now, rather than reading a cache.
+
+        Not part of :class:`NodeService`: nothing that holds a service
+        generically calls it. It is here because a caller that has already
+        resolved a node should not have to reach past the service it was
+        handed to ask that node a question.
+        """
+        return self._run(self.ops.get_facts())

--- a/spark_pulse/app.py
+++ b/spark_pulse/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 
+from spark_pulse.agent import runtime as agent_runtime
 from spark_pulse.config import config
 from spark_pulse.routers import (
     recipes,
@@ -43,6 +44,16 @@ from spark_pulse.tools.oci_registry import (
 from spark_pulse.tools.reconciliation import reconcile_all
 from spark_pulse.version import get_version
 from spark_pulse.mcp_http import handle_mcp, MCP_PATH
+
+
+def agent_state_dir() -> Path:
+    """Where the control plane keeps its CA, its ledger and its own identity.
+
+    Beside the node registry, because they describe the same thing from two
+    sides, and outside anything a package upgrade replaces.
+    """
+    return Path.home() / ".config" / "spark-pulse" / "agent"
+
 
 # ── SPA serving ──────────────────────────────────────────────────────────────
 
@@ -166,7 +177,40 @@ async def lifespan(app: FastAPI):
                 f"{', '.join(tools.discovery.real_interface_names()) or 'no interface'}"
             )
     except Exception as e:
+        this_node = None
         print(f"Warning: could not register this node: {e}")
+
+    # Bring up the agent transport, and with it this machine's own agent.
+    #
+    # Every node operation goes through it, this machine's included, so it has
+    # to be up before reconciliation asks anything about a container. The
+    # control node is enrolled under the id the registry just minted rather
+    # than a second one of its own — one machine, one identity.
+    #
+    # The enrollment listener is deliberately *not* opened here. It is opened
+    # only for the seconds an install needs it, so a token endpoint is not
+    # reachable for the life of the process.
+    #
+    # In simulation the resolver is the mock and never consults this, but it
+    # is started anyway, on ephemeral ports: a transport only production
+    # exercises is a transport nothing exercises.
+    try:
+        app.state.control_plane = await agent_runtime.start_runtime(
+            directory=agent_state_dir(),
+            node_id=this_node.id if this_node is not None else "",
+            docker_service=tools.docker._get_service() if is_simulation() else None,
+            session_port=0 if is_simulation() else None,
+        )
+        print(
+            "Agent transport listening on "
+            f"{app.state.control_plane.server.session_port}; control node is "
+            f"{app.state.control_plane.control_node_id[:8]}"
+        )
+    except Exception as e:
+        app.state.control_plane = None
+        print(f"FATAL: could not start the agent transport: {e}")
+        print("FATAL: without it no node — including this one — can be reached.")
+        raise
 
     # Start OCI background update checker
     start_background_updater()
@@ -207,6 +251,11 @@ async def lifespan(app: FastAPI):
 
     # Cleanup on shutdown
     stop_background_updater()
+
+    try:
+        await agent_runtime.stop_runtime(getattr(app.state, "control_plane", None))
+    except Exception as e:  # pragma: no cover — shutdown is best effort
+        print(f"Warning: could not stop the agent transport: {e}")
 
     try:
         tools.engine_metrics.stop_sampler()

--- a/spark_pulse/mock/docker.py
+++ b/spark_pulse/mock/docker.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from docker import errors as _docker_errors
+
 # Import real types so isinstance checks work across mock/real boundary
 from spark_pulse.tools.docker import (
     ContainerInfo,
@@ -122,10 +124,12 @@ _MOCK_PULL_TICK = 0.05
 class MockImagesManager:
     """Simulates ``docker.DockerClient.images``."""
 
-    def __init__(self):
+    def __init__(self, seeded: bool = True, daemon: Any = None):
+        self.daemon = daemon or _Daemon()
         self._images: dict[str, MockImage] = {}
-        for ref, image_id, size, created in _SEED_IMAGES:
-            self.add(ref, image_id=image_id, size=size, created=created)
+        if seeded:
+            for ref, image_id, size, created in _SEED_IMAGES:
+                self.add(ref, image_id=image_id, size=size, created=created)
 
     def add(
         self,
@@ -136,16 +140,23 @@ class MockImagesManager:
     ) -> MockImage:
         """Register an image as present on the simulated host."""
         repo, tag = split_ref(ref)
+        pinned = tag.startswith("sha256:")
         image = MockImage(
             id=image_id or ("sha256:" + uuid.uuid4().hex * 2),
-            tags=[f"{repo}:{tag}"] if not tag.startswith("sha256:") else [],
+            tags=[] if pinned else [f"{repo}:{tag}"],
         )
+        # A digest-pinned pull records *that* digest, not the image's own id.
+        # Docker keeps the two apart — ``Id`` is the config digest, a repo
+        # digest is the manifest's — and conflating them made simulation kinder
+        # than the daemon in the one place distribution depends on: a node that
+        # pulled ``repo@sha256:D`` has to be able to say it holds ``sha256:D``,
+        # or every seeded image looks like it needs pulling again.
         image.attrs = {
             "Id": image.id,
             "Size": size,
             "Created": created or datetime.now(timezone.utc).isoformat(),
             "RepoTags": list(image.tags),
-            "RepoDigests": [f"{repo}@{image.id}"],
+            "RepoDigests": [f"{repo}@{tag}" if pinned else f"{repo}@{image.id}"],
         }
         self._images[ref] = image
         if not tag.startswith("sha256:"):
@@ -153,18 +164,21 @@ class MockImagesManager:
         return image
 
     def get(self, ref: str) -> MockImage:
+        self.daemon.check()
         image = self._images.get(ref)
         if image is None:
             raise ImageNotFound(f"No such image: {ref}")
         return image
 
     def list(self, **_kwargs: Any) -> list[MockImage]:
+        self.daemon.check()
         seen: dict[str, MockImage] = {}
         for image in self._images.values():
             seen[image.id] = image
         return list(seen.values())
 
     def remove(self, ref: str, force: bool = False, **_kwargs: Any) -> None:
+        self.daemon.check()
         image = self._images.get(ref)
         if image is None:
             raise ImageNotFound(f"No such image: {ref}")
@@ -215,10 +229,42 @@ class MockLowLevelAPI:
         yield {"status": f"Status: Downloaded newer image for {ref}"}
 
 
+class DaemonDown(_docker_errors.APIError):
+    """What a client raises when the Docker daemon is not answering.
+
+    A real ``docker.errors.APIError``, deliberately: ``DockerService`` catches
+    that type by name and turns it into ``unknown``, and the whole point of
+    this state is that it reaches *that* branch. A bespoke exception here
+    would fall through to the substring fallback instead, which is a different
+    code path from the one production takes — and simulation that exercises a
+    different branch is worse than none.
+
+    It comes from the *client*, not from the transport, because that is where
+    a real daemon refuses. What runs above it is then ``DockerService``'s own
+    handling: ``unknown`` from a status, ``False`` from ``image_exists``, a
+    raise from a listing.
+    """
+
+
+class _Daemon:
+    """Whether this simulated node's Docker is answering. Shared by managers."""
+
+    def __init__(self) -> None:
+        self.down = False
+
+    def check(self) -> None:
+        if self.down:
+            raise DaemonDown(
+                "Cannot connect to the Docker daemon at "
+                "unix:///var/run/docker.sock. Is the docker daemon running?"
+            )
+
+
 class MockContainersManager:
     """Simulates docker.DockerClient.containers."""
 
-    def __init__(self):
+    def __init__(self, daemon: Any = None):
+        self.daemon = daemon or _Daemon()
         self._containers: dict[str, MockContainer] = {}
 
     def run(
@@ -235,6 +281,7 @@ class MockContainersManager:
         **_kwargs: Any,
     ) -> MockContainer:
         """Simulate running a container."""
+        self.daemon.check()
         container = MockContainer(
             id=uuid.uuid4().hex[:12],
             name=name,
@@ -249,6 +296,7 @@ class MockContainersManager:
 
     def get(self, name: str) -> MockContainer:
         """Get a container by name."""
+        self.daemon.check()
         if name not in self._containers:
             raise NotFound(f"Container {name} not found")
         container = self._containers[name]
@@ -260,6 +308,7 @@ class MockContainersManager:
         self, all: bool = False, filters: dict[str, Any] | None = None
     ) -> list[MockContainer]:
         """List containers with optional label filters."""
+        self.daemon.check()
         containers = [c for c in self._containers.values() if not c._removed]
         if not all:
             containers = [c for c in containers if c.status == "running"]
@@ -300,9 +349,10 @@ class MockContainersManager:
 class MockDockerClient:
     """Simulates docker.DockerClient for testing without Docker daemon."""
 
-    def __init__(self):
-        self.containers = MockContainersManager()
-        self.images = MockImagesManager()
+    def __init__(self, seeded_images: bool = True):
+        self.daemon = _Daemon()
+        self.containers = MockContainersManager(daemon=self.daemon)
+        self.images = MockImagesManager(seeded=seeded_images, daemon=self.daemon)
         self.api = MockLowLevelAPI(self.images)
 
     def version(self) -> dict[str, str]:

--- a/spark_pulse/mock/images.py
+++ b/spark_pulse/mock/images.py
@@ -128,6 +128,7 @@ def presence(
     nodes: list[str],
     ssh_user: str | None = None,
     timeout: int = 30,
+    services: Any | None = None,
 ) -> dict[str, Any]:
     """Every other node is pretended to have the image, with a matching ID."""
     entry = get_image(ref)

--- a/spark_pulse/mock/node_service.py
+++ b/spark_pulse/mock/node_service.py
@@ -1,43 +1,44 @@
-"""Mock node services — the real implementations over simulated transports.
+"""Node-bound container services, simulated.
 
-This module used to be ``spark_pulse.mock.remote_docker``: a second, hand-
-written copy of the remote container service that had drifted from the real
-one (different label matching, no image-info shape, a ``ray status`` answer
-baked into ``exec``). A parallel implementation cannot catch a bug in the
-implementation it is standing in for.
+This module used to be a second, hand-written copy of a remote container
+service, which had drifted from the real one — different label matching, no
+image-info shape, a ``ray status`` answer baked into ``exec``. A parallel
+implementation cannot catch a bug in the implementation it is standing in for,
+so it was replaced by the *real* docker-over-SSH service driven through a
+simulated SSH transport.
 
-So there is no parallel implementation any more. Simulation runs the *real*
-:class:`~spark_pulse.tools.node_service.RemoteNodeService` with a simulated
-SSH transport underneath it, exactly the way ``mock/native_runtime.py`` runs
-the real native runtime over the mock container service. The command building,
-the label filtering, the JSON parsing and the local/peer branch are all the
-production code; only the bytes on the wire are invented.
+That transport is gone too, and for a better reason than drift: **production
+does not run docker over SSH any more.** Every operation goes to a node's
+agent, and the agent's own executor is a ``DockerService`` on the far side. So
+what a peer looks like from here is not a command line to parse — it is a
+container service with its own state. That is exactly what
+:class:`~spark_pulse.mock.docker.MockDockerService` is.
 
-Only the resolver differs from the real module: the control node gets
-:class:`~spark_pulse.mock.docker.MockDockerService`, and a peer gets the real
-remote service over :class:`SimulatedDockerSSHClient`.
+The one property worth preserving from the old transport is preserved, and it
+is the important one: **every node has its own Docker.** When all nodes read
+one daemon, an answer for the wrong node is indistinguishable from the right
+answer, which is how thirteen call sites came to query the control node while
+claiming to reach a worker (``docs/transport-reexamined.md`` §5.1). Here, a
+node that answers for another node answers with the wrong containers, loudly.
+
+Only the resolver differs from the real module. Everything else — the node
+record, the interface, the address logic — is imported from it unchanged.
 """
 
 from __future__ import annotations
 
-import json
-import os
-import shlex
-import uuid
 from typing import Any, Callable
 
 from spark_pulse.tools.docker import DockerService
 from spark_pulse.tools.node_service import (
     CONTROL_NODE_ID as CONTROL_NODE_ID,
-    DAEMON_PROBE_COMMAND as DAEMON_PROBE_COMMAND,
-    DOCKER_STATES as DOCKER_STATES,
     LOOPBACK_ADDRESSES as LOOPBACK_ADDRESSES,
     NODE_SERVICE_METHODS as NODE_SERVICE_METHODS,
     STATUS_PROBE_TIMEOUT as STATUS_PROBE_TIMEOUT,
+    NoAgent as NoAgent,
     Node as Node,
     NodeService as NodeService,
     NodeServices as _NodeServices,
-    RemoteNodeService as RemoteNodeService,
     control_node as control_node,
     is_local_address as is_local_address,
     local_addresses as local_addresses,
@@ -46,616 +47,150 @@ from spark_pulse.tools.node_service import (
     reset_local_addresses as reset_local_addresses,
     run_kwargs_from_docker_config as run_kwargs_from_docker_config,
 )
-from spark_pulse.tools.ssh import SSHClient, SSHError, SSHErrorType, SSHResult
 
 DEFAULT_IMAGE_SIZE = 26_843_545_600
 
-
-def _flag_value(parts: list[str], flag: str) -> str:
-    """Value following ``flag`` in an argv list, or ""."""
-    if flag in parts:
-        index = parts.index(flag)
-        if index + 1 < len(parts):
-            return parts[index + 1].strip("'\"")
-    return ""
+#: One simulated Docker per peer, keyed by whatever identifies that peer.
+#: Never keyed by name — two nodes may share a name, and the failure that
+#: causes is two machines sharing a container list.
+_peers: dict[str, Any] = {}
 
 
-def _container_id(host: str, name: str) -> str:
-    """A stable, full-length container id for ``name`` on ``host``.
+def _key(node: Node) -> str:
+    """How a peer is identified here: its id, or its address if it has none."""
+    return node.id or node.address
 
-    Docker's ids are 64 hex characters and ``docker run -d`` prints all of
-    them; a 12-character stand-in would have hidden the truncation the real
-    ``docker ps`` applies unless asked for ``--no-trunc``.
+
+def docker_for(node: Node) -> Any:
+    """The simulated Docker belonging to ``node``, created on first ask.
+
+    This is the seam a test uses to look at, or prime, one node's containers
+    without going through the service — the replacement for reaching into the
+    old simulated SSH transport, and a much smaller one.
     """
-    return uuid.uuid5(uuid.NAMESPACE_URL, f"{host}/{name}").hex * 2
+    from spark_pulse.mock.docker import MockDockerClient, MockDockerService
+
+    if node.is_self:
+        from spark_pulse.mock.docker import _get_service
+
+        return _get_service()
+    key = _key(node)
+    service = _peers.get(key)
+    if service is None:
+        # No seeded images. A node that has just been added has not pulled
+        # anything, and a simulation that pretends otherwise makes every
+        # preflight report a 26 GB download as already done — the one answer
+        # that check exists to give.
+        service = MockDockerService(MockDockerClient(seeded_images=False))
+        _peers[key] = service
+    return service
 
 
-def _top_level_clauses(command: str) -> list[str]:
-    """Split a command on ``&&`` that a shell would act on.
+#: Peers whose agent is not connected. Every operation on one is *unknown*.
+unreachable: set[str] = set()
 
-    Quote-aware, and it has to be: ``_apply_mods`` runs
-    ``docker exec … bash -lc 'cd /mods/x && … bash run.sh'``, whose ``&&``
-    belongs to the *inner* shell and is one argument as far as the outer one is
-    concerned. Splitting on it blindly produces two halves of a quoted string
-    and ``shlex`` refuses both.
-    """
-    clauses: list[str] = []
-    current: list[str] = []
-    quote = ""
-    index = 0
-    while index < len(command):
-        character = command[index]
-        if quote:
-            current.append(character)
-            if character == quote:
-                quote = ""
-        elif character in "'\"":
-            quote = character
-            current.append(character)
-        elif command.startswith("&&", index):
-            clauses.append("".join(current))
-            current = []
-            index += 2
-            continue
-        else:
-            current.append(character)
-        index += 1
-    clauses.append("".join(current))
-    return [clause.strip() for clause in clauses if clause.strip()]
+#: Peers that answer, whose Docker daemon does not. Reachable, and the failure
+#: is definite — which is the distinction the whole transport exists to keep,
+#: so simulation has to be able to produce both.
+daemon_down: set[str] = set()
 
-
-def _label_filter_matches(labels: dict[str, str], term: str) -> bool:
-    """Whether ``labels`` satisfies one ``docker ps --filter label=`` term.
-
-    ``key`` matches presence; ``key=value`` matches the value — the same rule
-    the daemon applies.
-    """
-    key, sep, value = term.partition("=")
-    if not sep:
-        return key in labels
-    return labels.get(key) == value
-
-
-class SimulatedDockerSSHClient(SSHClient):
-    """An SSH transport that answers the docker CLI out of memory.
-
-    One store per host, so a container started on ``10.0.0.2`` is invisible on
-    ``10.0.0.3`` — which is the property the empty-host bug destroyed and the
-    property a simulation has to preserve to be worth anything.
-
-    Every command it is asked to run is recorded in :attr:`commands`, so a test
-    can assert that an operation aimed at a peer actually left the machine.
-
-    :attr:`fail_hosts` is the unreachable set, and it is a plain mutable set on
-    purpose: a node can be made unreachable *during* an operation, which is the
-    failure the gang semantics exist for. A host in it raises
-    :class:`~spark_pulse.tools.ssh.SSHError`, exactly as ``OpenSSHClient`` does
-    on ssh's own exit 255 — never a non-zero :class:`SSHResult`. That
-    distinction is the whole contract: an ``SSHResult`` means the node answered
-    and the outcome is definite, so returning one for a dead node would let
-    ``docker inspect`` read as "no such container" and a rank that is still
-    holding a GPU be confirmed gone on inference rather than on evidence.
-
-    :attr:`daemon_down_hosts` is the other half of that contract, and it is a
-    different failure entirely: the node answers SSH perfectly well and its
-    Docker daemon does not answer *it*. Real docker exits 1 with ``Cannot
-    connect to the Docker daemon`` — the same exit code a container that does
-    not exist produces — so a host in this set is how a test reaches the one
-    case where the exit status alone cannot tell "gone" from "unknown".
-    """
-
-    def __init__(
-        self,
-        images: dict[str, int] | None = None,
-        fail_hosts: list[str] | None = None,
-        daemon_down_hosts: list[str] | None = None,
-    ):
-        """Simulate docker over SSH.
-
-        Args:
-            images: Image references every host starts with, mapped to size in
-                bytes.
-            fail_hosts: Hosts that are unreachable. Mutate :attr:`fail_hosts`
-                to make a node go away mid-operation.
-            daemon_down_hosts: Hosts that are reachable but whose Docker
-                daemon is not. Mutate :attr:`daemon_down_hosts` to kill a
-                daemon mid-operation.
-        """
-        self.commands: list[dict[str, Any]] = []
-        self.copies: list[dict[str, Any]] = []
-        #: Per-host container environment, so the NCCL consistency check has
-        #: something that can genuinely differ between nodes.
-        self.env: dict[str, dict[str, str]] = {}
-        #: Per-host directories a ``mkdir -p`` was asked for, in order.
-        self.directories: dict[str, list[str]] = {}
-        self._containers: dict[str, dict[str, dict[str, Any]]] = {}
-        self._images: dict[str, dict[str, dict[str, Any]]] = {}
-        self._seed_images = dict(images or {})
-        #: Hosts that are unreachable right now. Mutable by design.
-        self.fail_hosts: set[str] = set(fail_hosts or [])
-        #: Hosts reachable over SSH whose Docker daemon is down. Mutable too.
-        self.daemon_down_hosts: set[str] = set(daemon_down_hosts or [])
-
-    # ── Store ────────────────────────────────────────────────────────────
-
-    def containers_on(self, host: str) -> dict[str, dict[str, Any]]:
-        """The container store for ``host``, created on first touch."""
-        return self._containers.setdefault(host, {})
-
-    def images_on(self, host: str) -> dict[str, dict[str, Any]]:
-        """The image store for ``host``, seeded on first touch."""
-        store = self._images.get(host)
-        if store is None:
-            store = {
-                ref: {
-                    "Id": f"sha256:{uuid.uuid5(uuid.NAMESPACE_URL, ref).hex}",
-                    "Size": size,
-                    "Created": "2026-01-01T00:00:00Z",
-                    "RepoTags": [ref],
-                    "RepoDigests": [],
-                }
-                for ref, size in self._seed_images.items()
-            }
-            self._images[host] = store
-        return store
-
-    def env_on(self, host: str) -> dict[str, str]:
-        """The simulated container environment on ``host``."""
-        return self.env.setdefault(host, {"NCCL_SOCKET_IFNAME": "eth0"})
-
-    def hosts_seen(self) -> list[str]:
-        """Every host this client was asked to reach, in order."""
-        seen: list[str] = []
-        for entry in self.commands + self.copies:
-            if entry["host"] not in seen:
-                seen.append(entry["host"])
-        return seen
-
-    # ── SSHClient ────────────────────────────────────────────────────────
-
-    def _raise_if_unreachable(self, host: str) -> None:
-        """Fail the way the real transport does when the node is gone."""
-        if host in self.fail_hosts:
-            raise SSHError(
-                error_type=SSHErrorType.NETWORK,
-                host=host,
-                message=f"unreachable: {host}",
-                stderr=f"ssh: connect to host {host}: No route to host",
-            )
-
-    def exec(
-        self,
-        host: str,
-        command: str,
-        timeout: int = 30,
-        batch_mode: bool = True,
-    ) -> SSHResult:
-        """Answer a docker CLI invocation for ``host``.
-
-        ``&&`` is honoured rather than ignored. This used to keep only the text
-        before the first ``&&`` and answer that, which meant the simulation
-        could not see the difference between ``docker stop x`` and ``docker
-        stop x && docker rm -f x`` — the difference that leaked an orphan on
-        every peer teardown in production while every test here passed. Now
-        each clause runs in turn, a non-zero clause short-circuits the rest the
-        way a shell's ``&&`` does, and the outputs are concatenated.
-        """
-        self.commands.append({"host": host, "command": command, "timeout": timeout})
-        self._raise_if_unreachable(host)
-
-        stdout: list[str] = []
-        result = SSHResult(returncode=0, stdout="", stderr="")
-        for clause in _top_level_clauses(command):
-            result = self._exec_one(host, clause)
-            if result.stdout:
-                stdout.append(result.stdout)
-            if result.returncode != 0:
-                return SSHResult(
-                    returncode=result.returncode,
-                    stdout="".join(stdout),
-                    stderr=result.stderr,
-                )
-        return SSHResult(
-            returncode=result.returncode, stdout="".join(stdout), stderr=result.stderr
-        )
-
-    def _exec_one(self, host: str, command: str) -> SSHResult:
-        """Answer a single command — one clause of what :meth:`exec` was given."""
-        # ``2>&1`` is a shell redirection, not an argument: the container
-        # service appends it to ``docker logs`` so a peer's stderr reaches the
-        # log pane. Only a *trailing* one is ours — a ``2>&1`` inside a quoted
-        # ``bash -lc`` belongs to the inner shell and stays in the argument.
-        merged = command.rstrip().endswith("2>&1")
-        if merged:
-            command = command.rstrip()[: -len("2>&1")]
-        parts = shlex.split(command)
-        if not parts:
-            return SSHResult(returncode=0, stdout="", stderr="")
-        if parts[:2] == ["mkdir", "-p"]:
-            # Upstream creates the cache bind sources before ``docker run``
-            # (launch-cluster.sh line 1104). Simulation records the paths
-            # rather than making directories on a developer's machine.
-            self.directories.setdefault(host, []).extend(parts[2:])
-            return SSHResult(returncode=0, stdout="", stderr="")
-        if parts[0] == "rm":
-            # Staging cleanup after ``docker cp``; nothing was ever written.
-            return SSHResult(returncode=0, stdout="", stderr="")
-        if len(parts) < 2 or parts[0] != "docker":
-            return SSHResult(returncode=127, stdout="", stderr=f"not docker: {command}")
-
-        if host in self.daemon_down_hosts:
-            # Exactly what the CLI does when the socket is not answering, exit
-            # code included: 1, the same code `no such object` uses. Measured
-            # on a GB10 running Docker 29.2.1, docs/rank-state-transport.md
-            # §2.4. Every docker verb fails this way, `version` included —
-            # which is what makes the daemon probe a real probe.
-            return SSHResult(
-                returncode=1,
-                stdout="",
-                stderr=(
-                    "Cannot connect to the Docker daemon at "
-                    "unix:///var/run/docker.sock. Is the docker daemon running?"
-                ),
-            )
-
-        verb = parts[1]
-        handler = getattr(self, f"_docker_{verb.replace('-', '_')}", None)
-        if handler is None:
-            return SSHResult(returncode=1, stdout="", stderr=f"unsupported: {command}")
-        answer = handler(host, parts, command)
-        if merged and answer.stderr and not answer.returncode:
-            # ``2>&1``: the container's stderr arrives on stdout.
-            return SSHResult(
-                returncode=0, stdout=answer.stdout + answer.stderr, stderr=""
-            )
-        return answer
-
-    def remote_shell_command(
-        self, host: str, remote_command: str | None = None
-    ) -> list[str]:
-        """Argv that would run ``remote_command`` on ``host``."""
-        args = ["ssh", "-o", "BatchMode=yes", host]
-        if remote_command:
-            args.append(remote_command)
-        return args
-
-    def copy(
-        self,
-        local_path: str,
-        host: str,
-        remote_path: str,
-        timeout: int = 30,
-    ) -> None:
-        """Record a file transfer to ``host``.
-
-        A directory is **refused**, because ``scp`` without ``-r`` refuses one:
-        ``not a regular file``. This class used to accept anything, which is
-        why nothing noticed that ``copy_to_container`` staged mod directories
-        through the non-recursive path — a mod with a subdirectory worked on
-        the control node and failed on every peer, and the simulation agreed
-        with the control node.
-        """
-        self._raise_if_unreachable(host)
-        if os.path.isdir(local_path):
-            raise RuntimeError(f"scp: {local_path}: not a regular file")
-        self.copies.append(
-            {
-                "host": host,
-                "local": local_path,
-                "remote": remote_path,
-                "recursive": False,
-            }
-        )
-
-    def copy_dir(
-        self,
-        local_dir: str,
-        host: str,
-        remote_dir: str,
-        timeout: int = 60,
-    ) -> None:
-        """Record a directory transfer to ``host``."""
-        self._raise_if_unreachable(host)
-        self.copies.append(
-            {
-                "host": host,
-                "local": local_dir,
-                "remote": remote_dir,
-                "recursive": True,
-            }
-        )
-
-    # ── docker verbs ─────────────────────────────────────────────────────
-
-    def _docker_run(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        name = _flag_value(parts, "--name")
-        labels: dict[str, str] = {}
-        for index, part in enumerate(parts):
-            if part == "--label" and index + 1 < len(parts):
-                key, _, value = parts[index + 1].strip("'\"").partition("=")
-                labels[key] = value
-        container_id = _container_id(host, name)
-        record = {
-            "ID": container_id,
-            "Names": name,
-            "Image": parts[-1],
-            "State": "running",
-            "Labels": ",".join(f"{k}={v}" for k, v in labels.items()),
-        }
-        self.containers_on(host)[name] = record
-        # ``docker run -d`` prints the full 64-hex id, which is what the SDK
-        # path's ``container.id`` is, so a cross-node id comparison is a
-        # comparison of like with like.
-        return SSHResult(returncode=0, stdout=f"{container_id}\n", stderr="")
-
-    def _docker_ps(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        wanted: list[str] = [
-            parts[index + 1]
-            for index, part in enumerate(parts[:-1])
-            if part == "--filter" and parts[index + 1].startswith("label=")
-        ]
-        show_all = "--all" in parts or "-a" in parts
-        truncate = "--no-trunc" not in parts
-        records = []
-        for record in self.containers_on(host).values():
-            if not show_all and record["State"] != "running":
-                continue
-            labels = dict(
-                pair.split("=", 1)
-                for pair in record["Labels"].split(",")
-                if "=" in pair
-            )
-            if all(_label_filter_matches(labels, term[6:]) for term in wanted):
-                row = dict(record)
-                if truncate:
-                    # Without ``--no-trunc`` the CLI prints 12 hex characters.
-                    row["ID"] = row["ID"][:12]
-                records.append(row)
-        lines = "\n".join(json.dumps(c) for c in records)
-        return SSHResult(returncode=0, stdout=lines, stderr="")
-
-    def _docker_stop(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        """Stop a container — and *keep* it, which is what docker does.
-
-        This used to delete the record, so simulation could not witness the
-        difference between stopping a container and removing one. Production
-        stopped without removing on every peer, the stopped container went on
-        answering ``docker inspect``, ``_is_confirmed_gone`` never confirmed
-        it, and every multi-node teardown leaked an orphan holding its ports —
-        while this class quietly made the tests pass.
-        """
-        name = parts[-1]
-        record = self.containers_on(host).get(name)
-        if record is None:
-            return SSHResult(returncode=1, stdout="", stderr="No such container")
-        record["State"] = "exited"
-        return SSHResult(returncode=0, stdout=name, stderr="")
-
-    def _docker_rm(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        """Remove a container. Without ``-f``, a running one is refused."""
-        name = parts[-1]
-        record = self.containers_on(host).get(name)
-        if record is None:
-            return SSHResult(
-                returncode=1, stdout="", stderr=f"Error: No such container: {name}"
-            )
-        forced = "-f" in parts or "--force" in parts
-        if record["State"] == "running" and not forced:
-            return SSHResult(
-                returncode=1,
-                stdout="",
-                stderr=(
-                    f"Error response from daemon: cannot remove container "
-                    f"{name}: container is running"
-                ),
-            )
-        del self.containers_on(host)[name]
-        return SSHResult(returncode=0, stdout=f"{name}\n", stderr="")
-
-    def _docker_exec(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        argv = [p for p in parts[2:] if not p.startswith("-")]
-        name = argv[0] if argv else ""
-        if name not in self.containers_on(host):
-            return SSHResult(returncode=1, stdout="", stderr="No such container")
-        if "-d" in parts or "--detach" in parts:
-            # ``docker exec -d`` prints nothing and returns at once, which is
-            # what the SDK path's detached branch also returns.
-            return SSHResult(returncode=0, stdout="", stderr="")
-        inner = " ".join(parts[parts.index(name) + 1 :])
-        if "ray" in inner and "status" in inner:
-            return SSHResult(returncode=0, stdout="Cluster is ready. OK", stderr="")
-        if "nvidia-smi" in inner:
-            return SSHResult(returncode=0, stdout="1", stderr="")
-        if inner.strip() == "env":
-            body = "\n".join(f"{k}={v}" for k, v in self.env_on(host).items())
-            return SSHResult(returncode=0, stdout=body, stderr="")
-        return SSHResult(returncode=0, stdout=inner, stderr="")
-
-    def _docker_cp(self, host: str, _parts: list[str], _raw: str) -> SSHResult:
-        _ = host
-        return SSHResult(returncode=0, stdout="", stderr="")
-
-    def _docker_logs(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        name = parts[-1]
-        if name not in self.containers_on(host):
-            return SSHResult(returncode=1, stdout="", stderr="No such container")
-        # Engines write most of their output to stderr, so the simulated log
-        # has a line on each stream: a caller that reads only stdout loses
-        # half of it, which is what the peer path used to do.
-        return SSHResult(
-            returncode=0,
-            stdout=f"[simulated logs for {name}]",
-            stderr=f"[simulated stderr for {name}]",
-        )
-
-    def _docker_version(self, host: str, _parts: list[str], _raw: str) -> SSHResult:
-        """The daemon-liveness probe. Reached only when the daemon is up.
-
-        A host in :attr:`daemon_down_hosts` never gets here — ``exec`` fails
-        every verb for it — which is the whole point: this answers only when
-        there is a daemon to answer.
-        """
-        _ = host
-        return SSHResult(returncode=0, stdout="29.2.1\n", stderr="")
-
-    def _docker_inspect(self, host: str, parts: list[str], raw: str) -> SSHResult:
-        name = parts[-1]
-        record = self.containers_on(host).get(name)
-        if record is None:
-            # The real message, so a test that asserts on the error text is
-            # asserting against what the CLI actually says.
-            return SSHResult(
-                returncode=1, stdout="", stderr=f"Error: No such object: {name}"
-            )
-        state = {"Running": record["State"] == "running", "Status": record["State"]}
-        body = json.dumps(state)
-        if ".Id" in raw:
-            # ``--format '{{json .State}}\t{{.Id}}'``: both facts, one inspect.
-            body = f"{body}\t{record['ID']}"
-        return SSHResult(returncode=0, stdout=body, stderr="")
-
-    def _docker_image(self, host: str, parts: list[str], raw: str) -> SSHResult:
-        if len(parts) < 3:
-            return SSHResult(returncode=1, stdout="", stderr=f"unsupported: {raw}")
-        if parts[2] in ("ls", "list"):
-            return self._docker_image_ls(host, parts, raw)
-        if parts[2] != "inspect":
-            return SSHResult(returncode=1, stdout="", stderr=f"unsupported: {raw}")
-
-        refs = [part for part in parts[3:] if not part.startswith("-")]
-        # ``--format`` takes the token after it; drop that one.
-        for index, part in enumerate(parts):
-            if part == "--format" and index + 1 < len(parts):
-                refs = [ref for ref in refs if ref != parts[index + 1]]
-        store = self.images_on(host)
-        by_id = {entry["Id"]: entry for entry in store.values()}
-        found = []
-        for ref in refs:
-            entry = store.get(ref) or by_id.get(ref)
-            if entry is None:
-                return SSHResult(
-                    returncode=1, stdout="", stderr=f"No such image: {ref}"
-                )
-            found.append(entry)
-        if not found:
-            return SSHResult(returncode=1, stdout="", stderr="No such image")
-        if ".Id" in raw:
-            return SSHResult(
-                returncode=0,
-                stdout="".join(f"{entry['Id']}\n" for entry in found),
-                stderr="",
-            )
-        if ".Size" in raw:
-            return SSHResult(
-                returncode=0,
-                stdout="".join(f"{entry['Size']}\n" for entry in found),
-                stderr="",
-            )
-        return SSHResult(
-            returncode=0,
-            stdout="\n".join(json.dumps(entry) for entry in found),
-            stderr="",
-        )
-
-    def _docker_image_ls(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        """``docker image ls -q``: one id per line, repeated per tag."""
-        quiet = "--quiet" in parts or "-q" in parts
-        truncate = "--no-trunc" not in parts
-        if not quiet:
-            return self._docker_images(host, parts, _raw)
-        lines = []
-        for entry in self.images_on(host).values():
-            image_id = entry["Id"]
-            # Truncated, the CLI prints 12 hex with no ``sha256:`` prefix.
-            lines.append(image_id.partition(":")[2][:12] if truncate else image_id)
-        return SSHResult(returncode=0, stdout="\n".join(lines), stderr="")
-
-    def _docker_images(self, host: str, _parts: list[str], _raw: str) -> SSHResult:
-        lines = []
-        for ref, entry in self.images_on(host).items():
-            repository, _, tag = ref.rpartition(":")
-            lines.append(
-                json.dumps(
-                    {
-                        "ID": entry["Id"],
-                        "Repository": repository or ref,
-                        "Tag": tag or "latest",
-                        "CreatedAt": entry["Created"],
-                        "Digest": "",
-                    }
-                )
-            )
-        return SSHResult(returncode=0, stdout="\n".join(lines), stderr="")
-
-    def _docker_pull(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        ref = parts[2]
-        repository, _, digest = ref.partition("@")
-        # A digest-pinned pull is content-addressed, so every node that pulls
-        # it ends up with the *same* image ID and the digest it asked for.
-        # Inventing a per-node ID here would hide the very property the
-        # registry path exists to preserve.
-        image_id = (
-            f"sha256:{digest.partition(':')[2]}"
-            if digest
-            else f"sha256:{uuid.uuid5(uuid.NAMESPACE_URL, ref).hex}"
-        )
-        self.images_on(host)[ref] = {
-            "Id": image_id,
-            "Size": DEFAULT_IMAGE_SIZE,
-            "Created": "2026-01-01T00:00:00Z",
-            "RepoTags": [] if digest else [ref],
-            "RepoDigests": [f"{repository}@{digest}"] if digest else [],
-        }
-        return SSHResult(returncode=0, stdout=f"Downloaded {ref}\n", stderr="")
-
-    def _docker_rmi(self, host: str, parts: list[str], _raw: str) -> SSHResult:
-        ref = parts[-1]
-        if self.images_on(host).pop(ref, None) is None:
-            return SSHResult(returncode=1, stdout="", stderr=f"No such image: {ref}")
-        return SSHResult(returncode=0, stdout=f"Untagged: {ref}", stderr="")
-
-
-_default_ssh_client: SimulatedDockerSSHClient | None = None
-
-
-def default_ssh_client() -> SimulatedDockerSSHClient:
-    """The process-wide simulated SSH transport."""
-    global _default_ssh_client
-    if _default_ssh_client is None:
-        _default_ssh_client = SimulatedDockerSSHClient()
-    return _default_ssh_client
+#: Every operation asked of a peer, in order: ``{"host", "op", "args"}``.
+#: Simulation's replacement for a command log. It records *operations* rather
+#: than command lines because there are no command lines any more — which is
+#: also why it is shorter and cannot drift from a parser.
+calls: list[dict[str, Any]] = []
 
 
 def reset() -> None:
-    """Drop the simulated transport, and with it every simulated node."""
-    global _default_ssh_client
-    _default_ssh_client = None
+    """Forget every simulated peer, and with it every container on one."""
+    _peers.clear()
+    unreachable.clear()
+    daemon_down.clear()
+    calls.clear()
+
+
+def containers_on(host: str) -> list[str]:
+    """The managed containers a simulated peer is holding, by name."""
+    docker = docker_for(peer_node(host))
+    return sorted(c.name for c in docker.list_managed_containers())
+
+
+def hosts_seen() -> list[str]:
+    """Every peer anything was asked of, in first-contact order."""
+    seen: list[str] = []
+    for entry in calls:
+        if entry["host"] not in seen:
+            seen.append(entry["host"])
+    return seen
+
+
+def operations_on(host: str) -> list[str]:
+    """The names of the operations asked of one peer, in order."""
+    return [entry["op"] for entry in calls if entry["host"] == host]
+
+
+class SimulatedPeerService:
+    """A peer's container service, over a transport that can fail two ways.
+
+    Every method is generated rather than written out, and that is safe here
+    in a way it would not be in production: this class adds no behaviour of
+    its own, so there is no signature for a caller to depend on beyond the one
+    ``MockDockerService`` already publishes. What it *does* add is the two
+    failure modes a real node has and an in-memory service does not — no
+    answer at all, and an answer that says no — because a simulation that can
+    only succeed cannot exercise the code that tells those apart.
+    """
+
+    def __init__(self, host: str, docker: Any):
+        self.host = host
+        self.docker = docker
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<SimulatedPeerService {self.host}>"
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_") or name not in NODE_SERVICE_METHODS:
+            raise AttributeError(name)
+        method = getattr(self.docker, name)
+
+        def _call(*args: Any, **kwargs: Any) -> Any:
+            calls.append({"host": self.host, "op": name, "args": args})
+            if self.host in unreachable:
+                from spark_pulse.agent.errors import NodeUnreachable
+
+                raise NodeUnreachable(self.host)
+            # A refusing daemon refuses at the *client*, not here, so what
+            # runs above it is ``DockerService``'s own handling of that —
+            # ``unknown`` from a status, ``False`` from ``image_exists``, a
+            # raise from a listing. Raising from the transport instead would
+            # exercise a branch production never takes.
+            self.docker.client.daemon.down = self.host in daemon_down
+            try:
+                return method(*args, **kwargs)
+            finally:
+                self.docker.client.daemon.down = False
+
+        return _call
 
 
 def service_for(
     node: Node,
     *,
-    ssh_client: SSHClient | None = None,
     docker_service: DockerService | None = None,
+    **_ignored: Any,
 ) -> NodeService:
     """The simulated container service bound to ``node``.
 
-    The control node gets the in-memory Docker service every other simulated
-    tool already shares. A peer gets the *real* remote service over a
-    simulated SSH transport, so the command building and parsing under test
-    are the production ones.
+    The control node gets the in-memory Docker every other simulated tool
+    already shares, so a container started through ``tools.docker`` and one
+    started through a node service are the same container. A peer gets its
+    own.
     """
+    if docker_service is not None:
+        return docker_service
     if node.is_self:
-        if docker_service is not None:
-            return docker_service
-        from spark_pulse.mock.docker import _get_service
-
-        return _get_service()
-    return RemoteNodeService(
-        node,
-        ssh_client=ssh_client or default_ssh_client(),
-        docker_service=None,
-    )
+        return docker_for(node)
+    return SimulatedPeerService(_key(node), docker_for(node))
 
 
 class NodeServices(_NodeServices):
@@ -663,12 +198,10 @@ class NodeServices(_NodeServices):
 
     def __init__(
         self,
-        ssh_client: SSHClient | None = None,
         docker_service: DockerService | None = None,
         resolver: Callable[..., NodeService] | None = None,
     ):
         super().__init__(
-            ssh_client=ssh_client,
             docker_service=docker_service,
             resolver=resolver or service_for,
         )
@@ -677,16 +210,22 @@ class NodeServices(_NodeServices):
 __all__ = [
     "CONTROL_NODE_ID",
     "DEFAULT_IMAGE_SIZE",
-    "DOCKER_STATES",
     "LOOPBACK_ADDRESSES",
     "NODE_SERVICE_METHODS",
+    "STATUS_PROBE_TIMEOUT",
+    "NoAgent",
     "Node",
     "NodeService",
     "NodeServices",
-    "RemoteNodeService",
-    "SimulatedDockerSSHClient",
+    "SimulatedPeerService",
+    "calls",
+    "containers_on",
     "control_node",
-    "default_ssh_client",
+    "daemon_down",
+    "docker_for",
+    "hosts_seen",
+    "operations_on",
+    "unreachable",
     "is_local_address",
     "local_addresses",
     "node_for",

--- a/spark_pulse/tools/images.py
+++ b/spark_pulse/tools/images.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shlex
 import threading
 import time
 import uuid
@@ -32,7 +31,6 @@ from typing import Any, Callable
 from spark_pulse.engines import get_registry
 from spark_pulse.tools.docker import PullCancelled, split_ref
 from spark_pulse.tools.events import DeploymentEvent, EventType
-from spark_pulse.tools.ssh import OpenSSHClient, SSHClient, SSHError
 
 logger = logging.getLogger(__name__)
 
@@ -309,30 +307,40 @@ def presence(
     nodes: list[str],
     ssh_user: str | None = None,
     timeout: int = 30,
-    client: SSHClient | None = None,
+    services: Any | None = None,
 ) -> dict[str, Any]:
-    """Report which nodes carry ``ref``, and with which image ID."""
+    """Report which nodes carry ``ref``, and with which image ID.
+
+    Asked through each node's own container service — the same
+    ``image_info`` every other caller uses — rather than by parsing a
+    ``docker image inspect`` this function composed itself. A node whose agent
+    is not there is *unknown*, and says so, rather than being reported absent:
+    "we could not ask" and "it is not there" are different answers, and only
+    the second one is a reason to pull.
+    """
     docker = _docker()
     info = docker.image_info(ref) or {}
     local_id = str(info.get("id") or "")
-    ssh = client or _make_ssh_client(ssh_user)
-    inspect = f"docker image inspect {shlex.quote(ref)} --format '{{{{.Id}}}}'"
+    resolve = _node_services(services)
 
-    def _one(node: str) -> dict[str, Any]:
+    def _one(address: str) -> dict[str, Any]:
+        from spark_pulse import tools
+
         try:
-            result = ssh.exec(node, inspect, timeout=timeout)
-        except (SSHError, OSError) as exc:
+            node = tools.node_service.node_for(address, ssh_user=ssh_user or "")
+            remote = resolve(node).image_info(ref) or {}
+        except Exception as exc:
             return {
-                "node": node,
+                "node": address,
                 "present": False,
                 "image_id": "",
                 "matches": False,
                 "error": str(exc)[:500],
             }
-        remote_id = (result.stdout or "").strip()
+        remote_id = str(remote.get("id") or "")
         return {
-            "node": node,
-            "present": bool(result.returncode == 0 and remote_id),
+            "node": address,
+            "present": bool(remote_id),
             "image_id": remote_id,
             "matches": bool(remote_id and remote_id == local_id),
             "error": None,
@@ -594,25 +602,18 @@ def delete_image(ref: str, force: bool = False) -> dict[str, Any]:
 # ── Distribution ─────────────────────────────────────────────────────────────
 
 
-def _make_ssh_client(ssh_user: str | None) -> SSHClient:
-    """Build the SSH client used for distribution (overridable in tests)."""
-    return OpenSSHClient(user=ssh_user or None, host_key_policy="strict")
-
-
-def _node_services(
-    client: SSHClient | None, services: Any | None = None
-) -> Callable[[Any], Any]:
+def _node_services(services: Any | None = None) -> Callable[[Any], Any]:
     """The resolver distribution reaches nodes through.
 
-    Node-bound services, not raw ssh: the transport, the local/peer branch and
-    the command building are then the ones every other remote operation uses,
-    and simulation swaps them at the resolver.
+    Node-bound services: the transport and the command building are then the
+    ones every other node operation uses, and simulation swaps them at the
+    resolver rather than at this call site.
     """
     if services is not None:
         return services
     from spark_pulse import tools
 
-    return tools.node_service.NodeServices(ssh_client=client)
+    return tools.node_service.NodeServices()
 
 
 def _node_has(info: dict[str, Any] | None, digest: str, image_id: str) -> bool:
@@ -638,7 +639,6 @@ def sync_to_nodes(
     nodes: list[str],
     ssh_user: str | None = None,
     timeout: int = 3600,
-    client: SSHClient | None = None,
     services: Any | None = None,
     digest: str = "",
 ) -> dict[str, Any]:
@@ -662,7 +662,6 @@ def sync_to_nodes(
         nodes: Node addresses to seed.
         ssh_user: SSH login for the nodes.
         timeout: Per-operation timeout, in seconds.
-        client: SSH transport override (tests, simulation).
         services: Node-service resolver override (tests, simulation).
         digest: The advertised digest, when the caller knows it.
 
@@ -688,7 +687,7 @@ def sync_to_nodes(
     pull_ref = str(seeded["pull_ref"])
     seed_digest = str(seeded["digest"])
 
-    resolve = _node_services(client, services)
+    resolve = _node_services(services)
 
     def _one(address: str) -> dict[str, Any]:
         started = time.monotonic()
@@ -715,12 +714,12 @@ def sync_to_nodes(
             service = resolve(node)
             if _node_has(service.image_info(pull_ref), seed_digest, local_id):
                 return _result(True, True, None)
-        except (SSHError, OSError, RuntimeError) as exc:
+        except (OSError, RuntimeError) as exc:
             return _result(False, False, str(exc))
 
         try:
             service.pull_image(pull_ref)
-        except (SSHError, OSError, RuntimeError) as exc:
+        except (OSError, RuntimeError) as exc:
             return _result(False, False, str(exc))
         return _result(True, False, None)
 

--- a/spark_pulse/tools/launch_script.py
+++ b/spark_pulse/tools/launch_script.py
@@ -363,18 +363,21 @@ class LaunchScriptManager:
 class LaunchScriptDistributor:
     """Distributes patched scripts to cluster nodes.
 
-    Uses SSHClient plus a node resolver handing out node-bound container
-    services. No duplicated SCP logic.
+    One code path, because there is one transport: the node-bound container
+    service copies the script in, and the service knows which node it belongs
+    to. What this replaces had two — ``docker cp`` on the head and
+    ``scp``-then-``docker cp`` on a worker — and the head branch copied from
+    ``/tmp/exec-script.sh`` *inside the container*, a path nothing had put
+    anything at. It could only ever have worked by accident.
     """
 
     def __init__(
         self,
-        ssh_client: Any = None,
         services: Any = None,
+        **_legacy: Any,
     ):
         from spark_pulse.tools.node_service import NodeServices
 
-        self._ssh = ssh_client
         self._services = services or NodeServices()
 
     def _service(self, address: str) -> Any:
@@ -389,40 +392,16 @@ class LaunchScriptDistributor:
         script: Path,
         container_name: str,
     ) -> None:
-        """Deploy a patched script to a node's container.
-
-        Local node: docker cp script container:/workspace/exec-script.sh
-        Remote node: scp to node, then docker cp into container
+        """Copy a patched script into a node's container.
 
         Args:
             node: ClusterNode with ip, role, container_name attributes
             script: Path to the patched script
             container_name: Name of the target container
         """
-        remote_path = "/workspace/exec-script.sh"
-        service = self._service(node.ip)
-
-        if node.role == "head" and node.ip == "127.0.0.1":
-            # Local node: docker cp
-            service.exec_in_container(
-                container=container_name,
-                command=["cp", "/tmp/exec-script.sh", remote_path],
-            )
-        else:
-            # Remote node: scp to host, then docker cp into container
-            if self._ssh is None:
-                raise RuntimeError(
-                    "LaunchScriptDistributor requires an SSHClient for remote nodes"
-                )
-            self._ssh.copy(
-                host=node.ip,
-                local_path=str(script),
-                remote_path="/tmp/exec-script.sh",
-            )
-            service.exec_in_container(
-                container=container_name,
-                command=["cp", "/tmp/exec-script.sh", remote_path],
-            )
+        self._service(node.ip).copy_to_container(
+            container_name, str(script), "/workspace/exec-script.sh"
+        )
 
     def deploy_to_cluster(
         self,

--- a/spark_pulse/tools/native_runtime.py
+++ b/spark_pulse/tools/native_runtime.py
@@ -1732,8 +1732,26 @@ def _create_rank(
 
 
 def _launch_rank(docker: Any, plan_obj: DeployPlan, rank_plan: RankPlan) -> None:
-    """Exec one rank's rendered script in the container already created for it."""
-    _deploy_script(docker, rank_plan)
+    """Exec one rank's rendered script in the container already created for it.
+
+    Raises :class:`NativeRuntimeError` for anything that goes wrong, including
+    a node that stopped answering between creating its container and launching
+    it. That last case used to arrive here as a ``False`` return from
+    ``copy_to_container``, because the transport could not tell "the copy
+    failed" from "the node is gone" and had to pick one. It can now, so the
+    conversion happens *here* — where the answer is the same either way (the
+    gang cannot start) and the rank's container is still recorded as
+    outstanding rather than assumed absent.
+    """
+    try:
+        _deploy_script(docker, rank_plan)
+    except NativeRuntimeError:
+        raise
+    except Exception as exc:
+        raise NativeRuntimeError(
+            f"could not launch {rank_plan.container.name} on "
+            f"{rank_plan.node or 'this machine'}: {exc}"
+        ) from exc
     logger.info(
         "rank %s of %s is running on %s",
         rank_plan.rank,

--- a/spark_pulse/tools/node_service.py
+++ b/spark_pulse/tools/node_service.py
@@ -12,31 +12,39 @@ compares ``NCCL_SOCKET_IFNAME`` across nodes compared the control node with
 itself. Node identity as a per-call argument with a falsy default is a defect
 generator, so it is gone.
 
-Three implementations satisfy the interface, and they are signature-identical
+**There is one transport, and it is the agent.** SSH does exactly one job in
+this system now — carrying the agent onto a node during bootstrap — and never
+runs an operation. The docker-CLI-over-SSH service that used to live in this
+file is gone, along with the local/peer branch inside it: this process runs an
+agent for *itself* and reaches it over loopback, so the control node is not a
+special case and there is no local branch left to go untested. That branch
+going untested is what made the thirteen call sites invisible.
+
+Two implementations satisfy the interface, and they are signature-identical
 because the interface *is* :class:`~spark_pulse.tools.docker.DockerService`'s
 own method set:
 
-* :class:`~spark_pulse.tools.docker.DockerService` — this machine, Docker SDK.
-* :class:`RemoteNodeService` — one node, via the docker CLI over SSH, or via
-  the local SDK when that node is this machine.
+* :class:`~spark_pulse.agent.sync_service.AgentNodeService` — one node, over
+  its agent. What the control plane holds for every node, including its own.
 * :class:`~spark_pulse.mock.docker.MockDockerService` — simulation, in memory.
+
+``DockerService`` itself is still the thing that talks to Docker; it is just
+on the far side now, as the agent's executor, one per node.
 
 :func:`service_for` is the resolver: hand it a :class:`Node`, get the service
 bound to it. ``spark_pulse.mock.node_service`` overrides only the resolver, so
 simulation mode swaps the implementation without changing any call site.
 
 :class:`Node` is deliberately minimal — an identifier, an address, whether it
-is this machine, an SSH user and the interface names. The full node registry
-of the cluster-agent plan's step one is later work; this is only the boundary
-that registry will later populate.
+is this machine, an SSH user and the interface names. It is a *reference* to a
+node, not a description of one; the node registry holds the description and
+:meth:`~spark_pulse.agent.runtime.ControlPlaneRuntime.node_id_for` is the one
+place the two are joined.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import shlex
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
@@ -47,13 +55,7 @@ from spark_pulse.tools.docker import (
     ContainerMetadata,
     DockerService,
     ExecResult,
-    PullCancelled,
-    _labels_match,
-    prepare_labels,
-    split_ref,
 )
-from spark_pulse.tools.labels import MANAGED_FILTER
-from spark_pulse.tools.ssh import OpenSSHClient, SSHClient
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ CONTROL_NODE_ID = "control"
 
 #: Addresses that always mean "the machine this process runs on". An empty
 #: address is included because the old API used it as the local sentinel, and
-#: a stray "" must resolve to the control node rather than to an SSH attempt.
+#: a stray "" must resolve to the control node rather than to some other one.
 LOOPBACK_ADDRESSES = frozenset(
     {"", "local", "localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}
 )
@@ -69,29 +71,18 @@ LOOPBACK_ADDRESSES = frozenset(
 #: Seconds a container-state probe waits for a node before giving up on it.
 #:
 #: This is a *liveness* timeout, not a work timeout, and the two want very
-#: different numbers. A node that is up answers ``docker inspect`` in 28.7 ms
-#: over a warm multiplexed connection, and pays about 500 ms when the control
-#: master has to be established first — both measured on a GB10
-#: (``docs/rank-state-transport.md`` §1.1-1.2). A node that is gone answers
-#: never, and the only thing a long wait buys is the wait: with ssh's own
-#: ``ConnectTimeout`` of 10 s, one silent node cost a full ten seconds on
-#: every probe, nine consecutive times over ninety seconds, and the poller
-#: learned nothing in between (§2.1). Three seconds is six times the cold
-#: handshake and a hundred times the warm answer, so it is only ever spent on
-#: a node that was not going to answer at all.
+#: different numbers. A node that is up answers an inspect in tens of
+#: milliseconds — 28.7 ms measured on a GB10 over a warm connection
+#: (``docs/rank-state-transport.md`` §1.1). A node that is gone answers never,
+#: and the only thing a long wait buys is the wait: one silent node used to
+#: cost a full ten seconds on every probe, nine consecutive times over ninety
+#: seconds, and the poller learned nothing in between (§2.1). Three seconds is
+#: a hundred times the warm answer, so it is only ever spent on a node that
+#: was not going to answer at all.
 #:
-#: Exceeding it raises :class:`~spark_pulse.tools.ssh.SSHError` from the
-#: transport, which is the honest outcome: unreachable, not missing.
+#: Exceeding it raises :class:`~spark_pulse.agent.errors.NodeUnreachable`,
+#: which is the honest outcome: unknown, not missing.
 STATUS_PROBE_TIMEOUT = 3
-
-#: A daemon-liveness probe, run only once an inspect has already failed.
-#:
-#: ``docker inspect`` exits 1 both for a container that is not there and for a
-#: daemon that is not there, so the exit code we already hold carries no
-#: signal. Asking the daemon for its *server* version does: it cannot fail on
-#: account of the container, and it exits zero only if a daemon answered. See
-#: :meth:`RemoteNodeService.get_container_status`.
-DAEMON_PROBE_COMMAND = "docker version --format '{{.Server.Version}}'"
 
 
 # ── The node record ──────────────────────────────────────────────────────────
@@ -361,92 +352,6 @@ NODE_SERVICE_METHODS: tuple[str, ...] = (
 )
 
 
-# ── Helpers shared by the SSH path ───────────────────────────────────────────
-
-
-def _to_exec_result(result: Any) -> ExecResult:
-    """Normalise an SSHResult (or ExecResult) into an ExecResult."""
-    if isinstance(result, ExecResult):
-        return result
-    return ExecResult(
-        returncode=getattr(result, "returncode", 1),
-        stdout=getattr(result, "stdout", "") or "",
-        stderr=getattr(result, "stderr", "") or "",
-    )
-
-
-def _argv(command: str | list[str]) -> str:
-    """Render a command as a single shell-safe string."""
-    if isinstance(command, str):
-        return command
-    return " ".join(shlex.quote(part) for part in command)
-
-
-def _image_info_from_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
-    """The ``image_info`` shape out of ``docker image inspect``'s JSON.
-
-    The SDK path builds the same dict out of ``image.attrs``, which is the
-    same daemon response — so there is one function rather than two spellings
-    of one mapping.
-    """
-    return {
-        "id": attrs.get("Id", ""),
-        "size_bytes": int(attrs.get("Size") or 0),
-        "created": attrs.get("Created"),
-        "repo_tags": list(attrs.get("RepoTags") or []),
-        "repo_digests": list(attrs.get("RepoDigests") or []),
-    }
-
-
-def _parse_cli_labels(raw: str) -> dict[str, str]:
-    """Parse the comma-separated ``key=value`` label list from ``docker ps``."""
-    labels: dict[str, str] = {}
-    for pair in (raw or "").split(","):
-        if "=" in pair:
-            key, value = pair.split("=", 1)
-            labels[key.strip()] = value.strip()
-    return labels
-
-
-#: Docker's own container status vocabulary, which is what the SDK path hands
-#: back verbatim as ``container.status``.
-DOCKER_STATES = frozenset(
-    {"created", "restarting", "running", "removing", "paused", "exited", "dead"}
-)
-
-
-def _normalize_cli_status(raw: str | None, running: bool = False) -> str:
-    """Map a ``docker ps``/``docker inspect`` state word onto Docker's own.
-
-    This used to collapse everything to ``running`` or ``stopped``, which is a
-    vocabulary the local path never speaks: ``DockerService`` returns
-    ``container.status``, so ``exited``, ``created``, ``paused`` and ``dead``
-    all reach a caller unchanged from the control node and never from a peer.
-    :func:`~spark_pulse.tools.reconciliation._clean_orphaned_containers` sweeps
-    on ``status == "exited"`` and so could not fire on a peer at all.
-
-    ``docker ps --format '{{json .}}'`` puts that same word in ``State``, and
-    ``docker inspect``'s ``State.Status`` is the identical field, so in practice
-    this passes it straight through. The ``Up 2 minutes`` / ``Exited (0) …``
-    prose of the ``Status`` column is the fallback, for a Docker old enough not
-    to publish ``State``.
-    """
-    text = (raw or "").strip().lower()
-    if text in DOCKER_STATES:
-        return text
-    if text.startswith("up"):
-        return "running"
-    if text.startswith("exited") or text.startswith("dead"):
-        return "exited"
-    if text.startswith("created"):
-        return "created"
-    if text.startswith("paused"):
-        return "paused"
-    if text.startswith("restarting"):
-        return "restarting"
-    return "running" if running else "exited"
-
-
 def run_kwargs_from_docker_config(docker_config: dict[str, Any] | None) -> dict:
     """Map the cluster ``docker_config`` dict onto ``run_container`` kwargs.
 
@@ -473,831 +378,55 @@ def run_kwargs_from_docker_config(docker_config: dict[str, Any] | None) -> dict:
     return kwargs
 
 
-# ── The node-bound remote service ────────────────────────────────────────────
-
-
-class RemoteNodeService(NodeService):
-    """The container service for one node, over SSH or over the local SDK.
-
-    The node is fixed at construction, so no *caller* ever chooses a
-    transport: the control node is served by :class:`DockerService` through
-    the Docker SDK, and a peer by the docker CLI over SSH. Both return the same
-    shapes, so callers never learn which one they hold.
-
-    The local branch exists so a size-one cluster runs the ordinary path
-    against loopback rather than through a special case, which is what every
-    orchestrator surveyed for the cluster-agent plan does.
-
-    What the branch is *not* is "picked once and for all". Every method below
-    branches on ``node.is_self`` again, so there are two implementations of one
-    interface speaking two languages about the same facts — the SDK's objects
-    and typed exceptions on one side, the CLI's text and exit codes on the
-    other — and each pair is a place they can disagree.
-    ``docs/transport-reexamined.md`` §5.1 audited them and found thirty
-    divergences, three of them live bugs, twenty-seven of them in methods no
-    test exercised. ``tests/test_container_service_contract.py`` now drives all
-    fifteen methods through every implementation and states the differences
-    that are deliberate, so a new one fails a test rather than a deployment.
-    The permanent fix is one implementation over two transports — the Docker
-    Engine API over a unix socket locally and over SSH remotely — which is that
-    document's recommendation and is not what this class is.
-    """
-
-    def __init__(
-        self,
-        node: Node,
-        ssh_client: SSHClient | None = None,
-        docker_service: DockerService | None = None,
-    ):
-        """Bind a container service to one node.
-
-        Args:
-            node: The node every operation runs against.
-            ssh_client: SSH transport, used only for a peer.
-            docker_service: Local Docker service, used only for the control
-                node. Built lazily so a peer-bound service never so much as
-                constructs a client for the local daemon.
-        """
-        self.node = node
-        self._ssh_client = ssh_client
-        self._docker_service = docker_service
-
-    # ── Transport ────────────────────────────────────────────────────────
-
-    @property
-    def is_local(self) -> bool:
-        """Whether this service runs against the local Docker daemon."""
-        return self.node.is_self
-
-    @property
-    def _local(self) -> DockerService:
-        """The local Docker service, built on first use."""
-        if not self.node.is_self:
-            raise RuntimeError(
-                f"node {self.node.label} is a peer; it has no local Docker daemon"
-            )
-        if self._docker_service is None:
-            self._docker_service = DockerService()
-        return self._docker_service
-
-    @property
-    def _ssh(self) -> SSHClient:
-        """The SSH transport, built on first use."""
-        if self.node.is_self:
-            raise RuntimeError(
-                f"node {self.node.label} is this machine; it is not reached over SSH"
-            )
-        if self._ssh_client is None:
-            self._ssh_client = OpenSSHClient(user=self.node.ssh_user or None)
-        return self._ssh_client
-
-    def _exec(self, command: str, timeout: int = 30) -> Any:
-        """Run a shell command on the node over SSH."""
-        return self._ssh.exec(self.node.address, command, timeout=timeout)
-
-    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
-        where = "local" if self.node.is_self else f"ssh {self.node.address}"
-        return f"<RemoteNodeService {self.node.id} ({where})>"
-
-    # ── Lifecycle ────────────────────────────────────────────────────────
-
-    def run_container(
-        self,
-        image: str,
-        name: str,
-        env_vars: dict[str, str],
-        metadata: ContainerMetadata,
-        privileged: bool = True,
-        memory_limit_gb: float | None = None,
-        shm_size_gb: float = 64,
-        pids_limit: int = 4096,
-        nofile_limit: int = 1048576,
-        cache_dirs: list[str] | None = None,
-        port_mappings: list[str] | None = None,
-        entrypoint_clear: bool = True,
-        detach: bool = True,
-        command: str | list[str] | None = None,
-        mounts: dict[str, str] | None = None,
-        network_host: bool | None = None,
-        ipc_host: bool = False,
-        devices: list[str] | None = None,
-        cap_add: list[str] | None = None,
-        ulimits: dict[str, str] | None = None,
-        auto_remove: bool = True,
-    ) -> ContainerInfo:
-        """Run a container on the node."""
-        if self.node.is_self:
-            return self._local.run_container(
-                image=image,
-                name=name,
-                env_vars=env_vars,
-                metadata=metadata,
-                privileged=privileged,
-                memory_limit_gb=memory_limit_gb,
-                shm_size_gb=shm_size_gb,
-                pids_limit=pids_limit,
-                nofile_limit=nofile_limit,
-                cache_dirs=cache_dirs,
-                port_mappings=port_mappings,
-                entrypoint_clear=entrypoint_clear,
-                detach=detach,
-                command=command,
-                mounts=mounts,
-                network_host=network_host,
-                ipc_host=ipc_host,
-                devices=devices,
-                cap_add=cap_add,
-                ulimits=ulimits,
-                auto_remove=auto_remove,
-            )
-
-        labels = prepare_labels(metadata, name, image)
-        cmd_parts = ["docker", "run"]
-        if detach:
-            cmd_parts.append("-d")
-
-        for key, value in (env_vars or {}).items():
-            cmd_parts.extend(["-e", shlex.quote(f"{key}={value}")])
-
-        if privileged:
-            cmd_parts.append("--privileged")
-        else:
-            # Same default as the SDK path: unprivileged still needs IPC_LOCK.
-            extra_caps = list(cap_add or [])
-            if "IPC_LOCK" not in extra_caps:
-                extra_caps.append("IPC_LOCK")
-            for capability in extra_caps:
-                cmd_parts.extend(["--cap-add", capability])
-        if memory_limit_gb:
-            cmd_parts.extend(["--memory", f"{memory_limit_gb}g"])
-            # The SDK path derives ``memswap_limit`` from the memory limit and
-            # for a long time this one did not, so a rank on a peer got the
-            # daemon's default (swap unlimited) where the control node's rank
-            # got limit + 10 GB. ``run_kwargs_from_docker_config`` drops the
-            # caller's ``memory_swap_limit_gb`` because "the container service
-            # derives swap from the memory limit itself, on both the SDK and
-            # CLI paths" — which was true of one path only.
-            memswap = DockerService._calc_memory_swap(memory_limit_gb)
-            if memswap is not None:
-                cmd_parts.extend(["--memory-swap", str(memswap)])
-        if pids_limit:
-            cmd_parts.extend(["--pids-limit", str(pids_limit)])
-        if shm_size_gb:
-            cmd_parts.extend(["--shm-size", f"{shm_size_gb}g"])
-        if nofile_limit:
-            cmd_parts.extend(["--ulimit", f"nofile={nofile_limit}"])
-        for ulimit_name, raw in (ulimits or {}).items():
-            if ulimit_name != "nofile":
-                cmd_parts.extend(["--ulimit", f"{ulimit_name}={raw}"])
-
-        for cache_dir in cache_dirs or []:
-            cmd_parts.extend(["-v", f"{cache_dir}:{cache_dir}:rw"])
-        for host_path, container_path in (mounts or {}).items():
-            cmd_parts.extend(["-v", f"{host_path}:{container_path}:rw"])
-
-        # The SDK path always requests every GPU; the CLI path now matches it.
-        cmd_parts.extend(["--gpus", "all"])
-
-        if network_host is None:
-            use_host_network = not port_mappings
-        else:
-            use_host_network = bool(network_host)
-        if use_host_network:
-            cmd_parts.extend(["--network", "host"])
-        for mapping in port_mappings or []:
-            cmd_parts.extend(["-p", mapping])
-        if ipc_host:
-            cmd_parts.extend(["--ipc", "host"])
-        for device in devices or []:
-            cmd_parts.extend(["--device", f"{device}:{device}:rwm"])
-        if auto_remove:
-            cmd_parts.append("--rm")
-        # Never restart — same reason as the SDK path: a rebooting node must
-        # not resurrect a rank into a torn-down deployment.
-        cmd_parts.extend(["--restart", "no"])
-
-        for key, value in labels.items():
-            cmd_parts.extend(["--label", shlex.quote(f"{key}={value}")])
-
-        cmd_parts.extend(["--name", name])
-        if entrypoint_clear:
-            cmd_parts.extend(["--entrypoint", '""'])
-
-        cmd_parts.append(image)
-        if command is not None:
-            cmd_parts.append(_argv(command))
-
-        result = self._exec(" ".join(cmd_parts), timeout=120)
-        if not result.ok:
-            raise RuntimeError(
-                f"docker run failed on {self.node.label}: {result.stderr}"
-            )
-
-        container_id = result.stdout.strip().split("\n")[0]
-        return ContainerInfo(
-            id=container_id,
-            name=name,
-            status="running",
-            image=image,
-            metadata=metadata,
-            labels=labels,
-        )
-
-    def ensure_directories(self, paths: Iterable[str]) -> list[str]:
-        """``mkdir -p`` every path on the node. Returns the ones that failed.
-
-        Upstream does exactly this before ``docker run``, locally at
-        ``launch-cluster.sh`` line 1094 and over SSH at line 1104, and for the
-        same reason: a bind source docker has to invent is created as root,
-        and these are the login user's caches. The runbook's whole
-        "Troubleshoot model-copy permissions" section is the aftermath.
-        """
-        # Stripped, like the local path: a trailing newline out of a config
-        # file would otherwise become part of a directory name on a peer and
-        # not on the control node.
-        wanted = [str(path).strip() for path in paths or [] if str(path).strip()]
-        if not wanted:
-            return []
-
-        if self.node.is_self:
-            failed: list[str] = []
-            for path in wanted:
-                try:
-                    os.makedirs(path, exist_ok=True)
-                except OSError as exc:
-                    logger.warning("could not create %s: %s", path, exc)
-                    failed.append(path)
-            return failed
-
-        quoted = " ".join(shlex.quote(path) for path in wanted)
-        result = self._exec(f"mkdir -p {quoted}", timeout=30)
-        if result.ok:
-            return []
-        logger.warning(
-            "could not create %s on %s: %s", quoted, self.node.label, result.stderr
-        )
-        return wanted
-
-    def stop_container(self, name: str, timeout: int = 30) -> bool:
-        """Stop **and remove** a container on the node.
-
-        The removal is not decoration. ``DockerService.stop_container`` does
-        ``container.stop()`` followed by ``container.remove(force=True)``, and
-        this path used to issue ``docker stop`` alone — the string ``docker
-        rm`` appeared nowhere in this module — while its docstring promised the
-        same thing. Containers are created with ``auto_remove=False``
-        (``native_runtime`` keeps them so ``docker logs`` survives a crash), so
-        nothing removed them afterwards either. A stopped-but-present container
-        still answers ``docker inspect``, so it never read as ``missing``,
-        :func:`~spark_pulse.tools.native_runtime._is_confirmed_gone` never
-        confirmed it, ``_confirm_gone`` spun for its full 30 s and **every
-        multi-node teardown recorded an outstanding orphan and held that rank's
-        ports for good** — per rank, per teardown, on every peer.
-
-        ``&&`` rather than ``;`` on purpose: it mirrors the local path, where a
-        ``stop`` that raises returns False without reaching the remove.
-        """
-        if self.node.is_self:
-            return self._local.stop_container(name, timeout=timeout)
-
-        quoted = shlex.quote(name)
-        result = self._exec(
-            f"docker stop -t {timeout} {quoted} && docker rm -f {quoted}",
-            timeout=timeout + 10,
-        )
-        if not result.ok:
-            logger.warning(
-                "Failed to stop and remove container %s on %s: %s",
-                name,
-                self.node.label,
-                result.stderr,
-            )
-        return bool(result.ok)
-
-    def _daemon_answered(self) -> bool:
-        """Whether this node's Docker daemon is there at all.
-
-        Raises :class:`~spark_pulse.tools.ssh.SSHError` if the node itself
-        cannot be reached — the caller must not turn that into an answer.
-        """
-        return bool(self._exec(DAEMON_PROBE_COMMAND, timeout=STATUS_PROBE_TIMEOUT).ok)
-
-    def _inspect_failed_status(self, name: str, stderr: str) -> dict[str, Any]:
-        """Tell "no such container" apart from "no daemon answered".
-
-        Both exit 1. Measured on a GB10 running Docker 29.2.1
-        (``docs/rank-state-transport.md`` §2.4): ``docker inspect`` against a
-        container that does not exist exits 1 with ``no such object``, and
-        ``docker inspect`` against an unreachable daemon exits 1 with ``Cannot
-        connect to the Docker daemon``. So the exit code carries no signal and
-        the only difference sitting in front of us is English prose.
-
-        Rather than read that prose and call it a fact, this asks the daemon a
-        question that cannot fail on account of the container: ``docker
-        version`` reports the *server* version, so it exits zero only when a
-        daemon answered. That exit status is structural, it costs one extra
-        round trip on a path that has already failed, and it is what this
-        branches on. The stderr text is carried into ``error`` for a human and
-        is never a decision input.
-
-        Getting this wrong in the "missing" direction is the expensive one:
-        :func:`native_runtime.sweep_orphans` clears an orphan — and with it
-        the ports the record was holding — on ``status == "missing"`` alone.
-        A rank we could not ask about must never produce it.
-        """
-        if self._daemon_answered():
-            return {
-                "status": "missing",
-                "running": False,
-                "id": None,
-                "state": {},
-                "error": f"Container '{name}' not found on {self.node.label}",
-            }
-        detail = stderr.strip() or "docker did not answer"
-        return {
-            # The same third state the local path reports as "error"
-            # (``DockerService.get_container_status``) and that ``_rank_status``
-            # names for a node it could not reach: we did not learn anything,
-            # which is not the same as learning the container is gone.
-            "status": "unknown",
-            "running": False,
-            "id": None,
-            "state": {},
-            "error": (
-                f"Docker on {self.node.label} did not answer, so the state of "
-                f"'{name}' is unknown: {detail}"
-            ),
-        }
-
-    def get_container_status(self, name: str) -> dict[str, Any]:
-        """Return the container's state on the node.
-
-        Three outcomes, never two: Docker's own status word when the daemon
-        described the container, ``missing`` when the daemon told us there is
-        no such container, and ``unknown`` when nobody told us anything. An
-        unreachable node raises instead, which is the fourth way of saying the
-        third thing.
-
-        The status word is ``State.Status`` verbatim — ``running``, ``exited``,
-        ``created``, ``paused``, ``restarting``, ``dead`` — because that is
-        what the local path returns and callers compare against it:
-        :func:`~spark_pulse.tools.reconciliation._clean_orphaned_containers`
-        sweeps on ``status == "exited"``, which a running/stopped collapse
-        could never match on a peer. ``id`` is asked for in the same inspect,
-        so a caller can compare a peer's container id with a local one.
-        """
-        if self.node.is_self:
-            return self._local.get_container_status(name)
-
-        result = self._exec(
-            # One inspect, both facts. ``.Id`` is the full 64-hex id, the same
-            # thing the SDK's ``container.id`` is.
-            f"docker inspect --format '{{{{json .State}}}}\t{{{{.Id}}}}' "
-            f"{shlex.quote(name)}",
-            timeout=STATUS_PROBE_TIMEOUT,
-        )
-        if not result.ok:
-            return self._inspect_failed_status(name, result.stderr or "")
-
-        raw_state, _, raw_id = (result.stdout or "").strip().partition("\t")
-        try:
-            state = json.loads(raw_state.strip())
-        except json.JSONDecodeError:
-            return {
-                "status": "unknown",
-                "running": False,
-                "id": None,
-                "state": {},
-                "error": f"Could not parse docker inspect output for '{name}'",
-            }
-
-        running = bool(state.get("Running", False))
-        return {
-            "status": _normalize_cli_status(state.get("Status"), running=running),
-            "running": running,
-            "id": raw_id.strip() or None,
-            "state": state,
-            "error": None,
-        }
-
-    # ── Exec / copy / logs ───────────────────────────────────────────────
-
-    def exec_in_container(
-        self,
-        container: str | Any,
-        command: str | list[str],
-        detach: bool = False,
-        timeout: int | None = None,
-    ) -> ExecResult:
-        """Execute a command inside a container on the node.
-
-        ``container`` may be a name or an object with a ``name`` — the SDK path
-        accepts a ``Container`` and this one used to interpolate whatever it
-        was handed straight into a shell command, which for an object is its
-        ``repr``.
-        """
-        if self.node.is_self:
-            return _to_exec_result(
-                self._local.exec_in_container(
-                    container, command, detach=detach, timeout=timeout
-                )
-            )
-
-        flags = " -d" if detach else ""
-        name = container if isinstance(container, str) else getattr(container, "name")
-        return _to_exec_result(
-            self._exec(
-                f"docker exec{flags} {shlex.quote(str(name))} {_argv(command)}",
-                timeout=timeout if timeout is not None else 30,
-            )
-        )
-
-    def copy_to_container(
-        self,
-        container: str,
-        local_path: str,
-        remote_path: str,
-        timeout: int = 120,
-    ) -> bool:
-        """Copy a file **or directory** from this machine into a container.
-
-        On a peer the path is staged in ``/tmp`` there first, then
-        ``docker cp``-ed into the container and removed.
-
-        The directory case is the one that was broken. ``docker cp`` takes
-        files and directories alike, and
-        :func:`~spark_pulse.tools.native_runtime._apply_mods` says so in a
-        comment while copying every entry of a mod directory — but the peer
-        path staged with :meth:`~spark_pulse.tools.ssh.SSHClient.copy`, which
-        is ``scp`` with no ``-r``, so a mod with a subdirectory worked on the
-        control node and failed on every peer. Directories go over
-        :meth:`~spark_pulse.tools.ssh.SSHClient.copy_dir` (rsync, or ``scp -r``
-        when there is no rsync), which is the transport's own recursive path.
-
-        Every failure — including an unreachable node — comes back as
-        ``False``, on both halves of the peer path. It used to come back as
-        ``False`` from the staging copy and as a raised
-        :class:`~spark_pulse.tools.ssh.SSHError` from the ``docker cp``, so one
-        method answered the same question two ways depending on which half of
-        it failed. ``False`` is the whole contract here and it is honest either
-        way: unlike an empty container list, it is not a claim about the state
-        of the node — only that the file is not in the container. The transport
-        detail goes to the log, and both callers
-        (:func:`~spark_pulse.tools.native_runtime._deploy_script` and
-        ``_apply_mods``) turn ``False`` into a fatal error naming the node.
-        """
-        if self.node.is_self:
-            return self._local.copy_to_container(
-                container, local_path, remote_path, timeout=timeout
-            )
-
-        basename = local_path.rstrip("/").rsplit("/", 1)[-1]
-        staged = f"/tmp/spark-pulse-{container}-{basename}"
-        try:
-            if os.path.isdir(local_path):
-                # rsync and ``scp -r`` both want the destination to exist.
-                self._exec(f"mkdir -p {shlex.quote(staged)}", timeout=timeout)
-                self._ssh.copy_dir(
-                    local_path, self.node.address, staged, timeout=timeout
-                )
-            else:
-                self._ssh.copy(local_path, self.node.address, staged, timeout=timeout)
-
-            result = self._exec(
-                f"docker cp {shlex.quote(staged)} "
-                f"{shlex.quote(container)}:{shlex.quote(remote_path)} "
-                f"&& rm -rf {shlex.quote(staged)}",
-                timeout=timeout,
-            )
-        except Exception as exc:
-            logger.error(
-                "Failed to copy %s into %s on %s: %s",
-                local_path,
-                container,
-                self.node.label,
-                exc,
-            )
-            return False
-
-        if not result.ok:
-            logger.error(
-                "docker cp into %s on %s failed: %s",
-                container,
-                self.node.label,
-                result.stderr,
-            )
-        return bool(result.ok)
-
-    def get_logs(self, name: str, tail: int = 200) -> str:
-        """Return the tail of a container's logs on the node.
-
-        ``2>&1`` is the whole point of the redirection. ``docker logs`` writes
-        the container's stdout to *its* stdout and the container's stderr to
-        *its* stderr, and this used to return ``result.stdout`` alone — so a
-        peer's log pane silently dropped every line the engine wrote to stderr,
-        which for vLLM and SGLang is most of them. The local path calls
-        ``container.logs()``, whose default is ``stdout=True, stderr=True``:
-        both streams, interleaved. This is that, over a shell.
-        """
-        if self.node.is_self:
-            return self._local.get_logs(name, tail=tail)
-
-        result = self._exec(
-            f"docker logs --tail {int(tail)} {shlex.quote(name)} 2>&1", timeout=30
-        )
-        if result.ok:
-            return result.stdout
-        # A failure here used to return "", which reads exactly like a
-        # container that started quietly. The local path says the container is
-        # not there, and raises for anything else; so does this, and it decides
-        # which by asking the daemon rather than by reading its prose.
-        if self._daemon_answered():
-            return f"Container '{name}' not found"
-        raise RuntimeError(
-            f"Docker on {self.node.label} did not answer, so the logs of "
-            f"'{name}' could not be read: {(result.stderr or '').strip()}"
-        )
-
-    # ── Inspection ───────────────────────────────────────────────────────
-
-    def list_managed_containers(
-        self,
-        labels: dict[str, str] | None = None,
-    ) -> list[ContainerInfo]:
-        """Managed containers on the node matching ``labels``.
-
-        Raises rather than returning ``[]`` when the node did not answer. An
-        empty list is a claim — "there is nothing here" — and this method used
-        to make it out of every failure, which is the same "we learned nothing,
-        therefore there is nothing" inference that
-        :meth:`_inspect_failed_status` exists to refuse, three methods away.
-        The consequences were not hypothetical:
-        :func:`~spark_pulse.tools.reconciliation._reconcile_clusters_real` and
-        ``_reconcile_deployments_real`` rebuild the world from this list, so a
-        peer whose daemon had died erased that peer's clusters and deployments
-        from the reconciled state; ``_clean_orphaned_containers`` saw nothing to
-        clean; and ``native_runtime._stale_names`` concluded there was no
-        earlier generation to reap and started a new one **on top of a rank
-        that may still hold the GPU** — the failure the reap path exists to
-        prevent. The local path lets the exception out, so this does too.
-        """
-        if self.node.is_self:
-            return self._local.list_managed_containers(labels)
-
-        filter_args = f" --filter label={MANAGED_FILTER}"
-        for key, value in (labels or {}).items():
-            filter_args += f" --filter label={key}" + (f"={value}" if value else "")
-
-        result = self._exec(
-            # --no-trunc so container ids are the full 64 hex the SDK path
-            # returns; a truncated id compares equal to nothing.
-            f"docker ps --all --no-trunc{filter_args} --format '{{{{json .}}}}'",
-            timeout=10,
-        )
-        if not result.ok:
-            detail = (result.stderr or "").strip() or "docker did not answer"
-            raise RuntimeError(
-                f"could not list containers on {self.node.label}: {detail}"
-            )
-
-        containers: list[ContainerInfo] = []
-        for line in result.stdout.strip().split("\n"):
-            if not line.strip():
-                continue
-            try:
-                info = json.loads(line.strip())
-            except json.JSONDecodeError:
-                continue
-
-            container_labels = _parse_cli_labels(info.get("Labels", ""))
-            if not _labels_match(container_labels, labels):
-                continue
-            containers.append(
-                ContainerInfo(
-                    id=info.get("ID", ""),
-                    # A container can carry several names; ``docker ps`` joins
-                    # them with commas and the SDK's ``container.name`` is the
-                    # first one.
-                    name=str(info.get("Names", "")).split(",")[0],
-                    status=_normalize_cli_status(
-                        info.get("State") or info.get("Status")
-                    ),
-                    image=info.get("Image", ""),
-                    metadata=ContainerMetadata.from_labels(container_labels),
-                    labels=container_labels,
-                )
-            )
-        return containers
-
-    def get_container_by_deployment(self, deployment: str) -> ContainerInfo | None:
-        """The container carrying ``deployment``'s label on the node."""
-        if self.node.is_self:
-            return self._local.get_container_by_deployment(deployment)
-        from spark_pulse.tools.labels import DEPLOYMENT_LABEL
-
-        found = self.list_managed_containers({DEPLOYMENT_LABEL: deployment})
-        return found[0] if found else None
-
-    def get_container_by_recipe(self, recipe: str) -> list[ContainerInfo]:
-        """Every container on the node carrying ``recipe``'s label."""
-        if self.node.is_self:
-            return self._local.get_container_by_recipe(recipe)
-        from spark_pulse.tools.labels import RECIPE_LABEL
-
-        return self.list_managed_containers({RECIPE_LABEL: recipe})
-
-    # ── Images ───────────────────────────────────────────────────────────
-
-    def image_exists(self, ref: str) -> bool:
-        """Whether ``ref`` is present on the node."""
-        if not ref:
-            return False
-        if self.node.is_self:
-            return self._local.image_exists(ref)
-        result = self._exec(
-            f"docker image inspect {shlex.quote(ref)} --format '{{{{.Id}}}}'",
-            timeout=30,
-        )
-        return bool(result.ok and result.stdout.strip())
-
-    def image_info(self, ref: str) -> dict[str, Any] | None:
-        """Image metadata for ``ref`` on the node, or None when absent."""
-        if self.node.is_self:
-            return self._local.image_info(ref)
-        result = self._exec(
-            f"docker image inspect {shlex.quote(ref)} --format '{{{{json .}}}}'",
-            timeout=30,
-        )
-        if not result.ok or not (result.stdout or "").strip():
-            return None
-        try:
-            attrs = json.loads(result.stdout.strip())
-        except json.JSONDecodeError:
-            return None
-        return _image_info_from_attrs(attrs)
-
-    def list_images(self) -> list[dict[str, Any]]:
-        """Every image on the node, shaped exactly like :meth:`image_info`.
-
-        Two commands, not one, and the second is why. ``docker images``
-        publishes ``Size`` only as prose — ``26.8GB`` — so this used to
-        hardcode ``"size_bytes": 0`` for every image on a peer while the local
-        path reported the real number: the Images page showed a fleet where the
-        control node had images with a size and every other node had images
-        weighing nothing, and disk arithmetic over the fleet was wrong by the
-        whole of it. ``docker image inspect`` answers with the same JSON the
-        SDK's ``image.attrs`` carries — exact ``Size``, full ``Id``, ISO
-        ``Created``, ``RepoTags`` and ``RepoDigests`` — so the peer's rows are
-        the local rows, field for field.
-        """
-        if self.node.is_self:
-            return self._local.list_images()
-        listing = self._exec("docker image ls --quiet --no-trunc", timeout=60)
-        if not listing.ok:
-            raise RuntimeError(
-                f"could not list images on {self.node.label}: {listing.stderr}"
-            )
-        ids: list[str] = []
-        for line in (listing.stdout or "").splitlines():
-            image_id = line.strip()
-            # ``docker image ls -q`` repeats an id once per tag.
-            if image_id and image_id not in ids:
-                ids.append(image_id)
-        if not ids:
-            return []
-
-        quoted = " ".join(shlex.quote(image_id) for image_id in ids)
-        details = self._exec(
-            f"docker image inspect {quoted} --format '{{{{json .}}}}'", timeout=60
-        )
-        if not details.ok:
-            raise RuntimeError(
-                f"could not inspect images on {self.node.label}: {details.stderr}"
-            )
-        out: list[dict[str, Any]] = []
-        for line in (details.stdout or "").strip().split("\n"):
-            if not line.strip():
-                continue
-            try:
-                attrs = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            out.append(_image_info_from_attrs(attrs))
-        return out
-
-    def pull_image(
-        self,
-        ref: str,
-        progress: Any | None = None,
-        interval: float = PULL_PROGRESS_INTERVAL,
-        cancel: Callable[[], bool] | None = None,
-        stall_timeout: float | None = None,
-    ) -> dict[str, Any]:
-        """Pull ``ref`` onto the node.
-
-        On the control node this is the SDK path, with real per-layer
-        aggregation, cancellation and the stall watchdog. Over SSH the docker
-        CLI runs non-interactively as one blocking command, so ``interval`` and
-        ``stall_timeout`` have nothing to act on: a single terminal snapshot is
-        reported when the pull finishes. Fetch-once on the control node
-        followed by a fan-out is the plan's answer to that, and it is later
-        work.
-
-        ``cancel`` is honoured, at the only two moments this shape has one: on
-        entry, and when the blocking pull returns. That is coarse — a cancel
-        raised mid-pull is not seen until the pull finishes — but the outcome
-        is the one that matters. ``native_runtime.start`` catches
-        :class:`~spark_pulse.tools.docker.PullCancelled` to record a deployment
-        torn down during its own image pull as ``stopped``; without it that
-        handler could only ever fire for the control node, and a teardown
-        during a peer's pull was recorded as ``error`` — the exact
-        miscategorisation the handler exists to prevent.
-        """
-        if not ref:
-            raise RuntimeError("pull_image needs an image reference")
-        if self.node.is_self:
-            return self._local.pull_image(
-                ref,
-                progress,
-                interval=interval,
-                cancel=cancel,
-                stall_timeout=stall_timeout,
-            )
-
-        if cancel is not None and cancel():
-            raise PullCancelled(f"pull of {ref} cancelled")
-        repo, tag = split_ref(ref)
-        result = self._exec(f"docker pull {shlex.quote(ref)}", timeout=7200)
-        if cancel is not None and cancel():
-            raise PullCancelled(f"pull of {ref} cancelled")
-        if not result.ok:
-            raise RuntimeError(
-                f"docker pull {ref} failed on {self.node.label}: "
-                f"{(result.stderr or result.stdout or '').strip()}"
-            )
-        info = self.image_info(ref) or {}
-        size = int(info.get("size_bytes") or 0)
-        snapshot = {
-            "ref": ref,
-            "status": "pull complete",
-            "layers": 0,
-            "bytes_done": size,
-            "bytes_total": size,
-            "percent": 100.0,
-        }
-        if progress is not None:
-            progress(snapshot)
-        return {
-            "ref": ref,
-            "repository": repo,
-            "tag": tag,
-            "bytes_done": size,
-            "bytes_total": size,
-            "percent": 100.0,
-            "id": str(info.get("id") or ""),
-            "size_bytes": size,
-        }
-
-    def remove_image(self, ref: str, force: bool = False) -> bool:
-        """Remove ``ref`` from the node. False when it was not there."""
-        if self.node.is_self:
-            return self._local.remove_image(ref, force=force)
-        flag = " -f" if force else ""
-        result = self._exec(f"docker rmi{flag} {shlex.quote(ref)}", timeout=120)
-        if result.ok:
-            return True
-        text = (result.stderr or "").lower()
-        if "no such image" in text or "not found" in text:
-            return False
-        raise RuntimeError(
-            f"could not remove image {ref} on {self.node.label}: {result.stderr}"
-        )
-
-
 # ── The resolver ─────────────────────────────────────────────────────────────
+
+
+class NoAgent(LookupError):
+    """There is no agent for this node, so there is no way to reach it.
+
+    A named error rather than a fallback. The alternative — quietly using the
+    control plane's own Docker daemon when a node cannot be reached — is not
+    hypothetical: ``docs/transport-reexamined.md`` §5.1 found thirteen call
+    sites doing exactly that, and every one of them read plausible answers off
+    the wrong machine.
+    """
 
 
 def service_for(
     node: Node,
     *,
-    ssh_client: SSHClient | None = None,
     docker_service: DockerService | None = None,
+    **_ignored: Any,
 ) -> NodeService:
-    """The container service bound to ``node``.
+    """The container service bound to ``node``, over that node's agent.
 
-    The control node gets the process-wide :class:`DockerService` — one
-    service, thread-local clients — and a peer gets a :class:`RemoteNodeService`
-    over SSH. ``spark_pulse.mock.node_service`` overrides this function to hand
-    back the simulation service instead, so simulation mode is one swap at the
-    resolver rather than a branch at every call site.
+    There is one transport now. The control node is not a special case: this
+    process runs an agent for itself and reaches it over loopback, exactly as
+    it reaches a peer, so there is no local branch here to leave untested.
+    That was the previous boundary's defining defect.
+
+    ``docker_service`` pins a service outright and skips resolution. It exists
+    for callers that already hold one — chiefly tests, and
+    ``native_runtime.rank_services(docker=...)`` — and never as a fallback.
+
+    ``spark_pulse.mock.node_service`` overrides this function, so simulation
+    is one swap at the resolver rather than a branch at every call site.
     """
-    if node.is_self:
-        if docker_service is not None:
-            return docker_service
-        from spark_pulse.tools.docker import _get_service
+    if docker_service is not None:
+        return docker_service
+    from spark_pulse.agent import runtime as agent_runtime
 
-        return _get_service()
-    return RemoteNodeService(node, ssh_client=ssh_client, docker_service=None)
+    current = agent_runtime.current()
+    if current is None:
+        raise NoAgent(
+            f"the control plane's agent transport is not running, so {node.label} "
+            "cannot be reached. This is a startup ordering problem: nothing "
+            "should resolve a node service before the runtime is up."
+        )
+    try:
+        return current.service_for(node)
+    except LookupError as exc:
+        raise NoAgent(str(exc)) from None
 
 
 class NodeServices:
@@ -1310,11 +439,9 @@ class NodeServices:
 
     def __init__(
         self,
-        ssh_client: SSHClient | None = None,
         docker_service: DockerService | None = None,
         resolver: Callable[..., NodeService] | None = None,
     ):
-        self._ssh_client = ssh_client
         self._docker_service = docker_service
         self._resolver = resolver or service_for
         self._cache: dict[str, NodeService] = {}
@@ -1324,11 +451,7 @@ class NodeServices:
         key = f"{node.id}\0{node.address}\0{node.is_self}"
         service = self._cache.get(key)
         if service is None:
-            service = self._resolver(
-                node,
-                ssh_client=self._ssh_client,
-                docker_service=self._docker_service,
-            )
+            service = self._resolver(node, docker_service=self._docker_service)
             self._cache[key] = service
         return service
 
@@ -1343,15 +466,13 @@ class NodeServices:
 
 __all__ = [
     "CONTROL_NODE_ID",
-    "DAEMON_PROBE_COMMAND",
-    "DOCKER_STATES",
     "LOOPBACK_ADDRESSES",
     "NODE_SERVICE_METHODS",
     "STATUS_PROBE_TIMEOUT",
+    "NoAgent",
     "Node",
     "NodeService",
     "NodeServices",
-    "RemoteNodeService",
     "control_node",
     "is_local_address",
     "local_addresses",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,82 @@ async def agent_fleet():
         await fleet.shutdown()
 
 
+class JoinedAgent:
+    """One enrolled agent, its task, and the Docker it speaks to."""
+
+    def __init__(self, agent, task, docker):
+        self.agent = agent
+        self.task = task
+        self.docker = docker
+
+    @property
+    def node_id(self) -> str:
+        return self.agent.node_id
+
+    async def close(self) -> None:
+        await self.agent.stop()
+        self.task.cancel()
+        try:
+            await self.task
+        except BaseException:
+            pass
+
+
+@pytest.fixture
+async def join_agent(agent_server, tmp_path):
+    """Enrol nodes against ``agent_server`` and hold their sessions.
+
+    Each node gets its **own** ``MockDockerService``. That is the point rather
+    than tidiness: when every node reads one daemon, an answer for the wrong
+    node looks exactly like the right answer, which is how thirteen call sites
+    queried the control node while claiming to reach a worker.
+    """
+    import asyncio
+
+    from spark_pulse.agent.executor import LocalExecutor
+    from spark_pulse.agent.node_agent import NodeAgent, enroll
+    from spark_pulse.mock.docker import MockDockerClient, MockDockerService
+
+    joined: list[JoinedAgent] = []
+
+    async def _join(
+        name: str, *, docker=None, node_id: str = "", heartbeat: float = 0.2
+    ):
+        docker = docker or MockDockerService(MockDockerClient())
+        identity = await enroll(
+            agent_server.enrollment_target(),
+            agent_server.mint_token(name, node_id=node_id),
+            trust_bundle_pem=agent_server.trust_bundle_pem,
+            trust_bundle_pin=agent_server.trust_bundle_pin,
+            directory=tmp_path / f"identity-{name}",
+            requested_name=name,
+            docker_service=docker,
+        )
+        agent = NodeAgent(
+            identity,
+            agent_server.session_target(),
+            executor=LocalExecutor(docker),
+            heartbeat_interval=heartbeat,
+        )
+        task = asyncio.create_task(agent.run_forever(), name=f"agent-{name}")
+        await agent.wait_connected(10)
+        node = JoinedAgent(agent, task, docker)
+        joined.append(node)
+        return node
+
+    try:
+        yield _join
+    finally:
+        for node in joined:
+            await node.close()
+
+
+@pytest.fixture
+async def agent_node(join_agent):
+    """One enrolled, connected agent."""
+    return await join_agent("spark-a")
+
+
 @pytest.fixture
 def agent_bundle():
     """An agent bundle with no vendored runtime.

--- a/tests/test_agent_sync_service.py
+++ b/tests/test_agent_sync_service.py
@@ -1,0 +1,346 @@
+"""The synchronous face of the agent, over a real loopback agent.
+
+Nothing here is stubbed between the call and the container: a test calls
+:class:`AgentNodeService` from a worker thread exactly as a FastAPI sync
+endpoint does, the call crosses to the event loop, goes out over real mTLS
+gRPC to a real enrolled agent, and lands in ``MockDockerService``. Only Docker
+is fake — which is the same boundary ``test_agent_transport`` draws, on
+purpose, so the two files cannot disagree about where reality stops.
+
+What is actually under test is the bridge's three obligations:
+
+* it returns what ``DockerService`` returns, unchanged;
+* it keeps ``NodeUnreachable`` and ``NodeOperationError`` apart, because
+  releasing a GPU on the first one is how two gangs end up on one device;
+* it refuses, loudly, to be called from the loop thread — where it would
+  deadlock silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from spark_pulse.agent.errors import NodeUnreachable, NodeOperationError
+from spark_pulse.agent.hub import Liveness
+from spark_pulse.agent.runtime import ControlPlaneRuntime, current, use
+from spark_pulse.agent.sync_service import (
+    CONTRACT_EXCEPTIONS,
+    RESULT_MARGIN,
+    AgentNodeService,
+)
+from spark_pulse.mock.docker import MockDockerClient, MockDockerService
+from spark_pulse.tools.docker import ContainerMetadata, PullCancelled
+from spark_pulse.tools.node_service import (
+    NODE_SERVICE_METHODS,
+    Node,
+    control_node,
+    peer_node,
+)
+
+pytestmark = pytest.mark.asyncio
+
+METADATA = ContainerMetadata(deployment="dep-1", recipe="r", image="img:1")
+
+
+def service_for_node(agent_server, agent_node, **kwargs) -> AgentNodeService:
+    return AgentNodeService(
+        agent_server.hub,
+        agent_node.node_id,
+        asyncio.get_running_loop(),
+        timeout=10,
+        **kwargs,
+    )
+
+
+async def call(service, method: str, *args, **kwargs):
+    """Invoke a sync service method from a worker thread, as FastAPI does."""
+    return await asyncio.to_thread(getattr(service, method), *args, **kwargs)
+
+
+# ── The interface ───────────────────────────────────────────────────────────
+
+
+async def test_it_implements_every_node_service_method(agent_server, agent_node):
+    """The ratchet: a method added to the interface must land here too."""
+    service = service_for_node(agent_server, agent_node)
+    missing = [
+        m for m in NODE_SERVICE_METHODS if not callable(getattr(service, m, None))
+    ]
+    assert missing == []
+
+
+async def test_a_container_runs_inspects_and_stops(agent_server, agent_node):
+    service = service_for_node(agent_server, agent_node)
+    info = await call(service, "run_container", "img:1", "c1", {"A": "b"}, METADATA)
+    assert info.name == "c1"
+
+    status = await call(service, "get_container_status", "c1")
+    assert status["running"] is True
+
+    listing = await call(service, "list_managed_containers")
+    assert [c.name for c in listing] == ["c1"]
+
+    assert await call(service, "stop_container", "c1") is True
+    assert (await call(service, "get_container_status", "c1"))["status"] == "missing"
+
+
+async def test_it_answers_for_its_own_node_and_no_other(agent_server, join_agent):
+    """Two nodes, two dockers: an answer for the wrong node is visibly wrong."""
+    a = await join_agent("spark-a")
+    b = await join_agent("spark-b")
+    try:
+        loop = asyncio.get_running_loop()
+        first = AgentNodeService(agent_server.hub, a.node_id, loop, timeout=10)
+        second = AgentNodeService(agent_server.hub, b.node_id, loop, timeout=10)
+        await call(first, "run_container", "img:1", "only-on-a", {}, METADATA)
+
+        assert [c.name for c in await call(first, "list_managed_containers")] == [
+            "only-on-a"
+        ]
+        assert await call(second, "list_managed_containers") == []
+    finally:
+        await a.close()
+        await b.close()
+
+
+async def test_exec_accepts_a_container_object_the_way_docker_service_does(
+    agent_server, agent_node
+):
+    """``native_runtime`` passes the ContainerInfo it just got back."""
+    service = service_for_node(agent_server, agent_node)
+    info = await call(service, "run_container", "img:1", "c1", {}, METADATA)
+    result = await call(service, "exec_in_container", info, ["echo", "hi"])
+    assert result.returncode == 0
+
+
+# ── The two failure kinds, kept apart ───────────────────────────────────────
+
+
+async def test_a_failed_operation_on_a_reachable_node_is_an_operation_error(
+    agent_server, join_agent
+):
+    """The node answered, and the answer was "no". Definite, and still here."""
+
+    class Broken(MockDockerService):
+        def list_images(self):
+            raise RuntimeError("the docker daemon is not running")
+
+    joined = await join_agent("spark-broken", docker=Broken(MockDockerClient()))
+    try:
+        service = AgentNodeService(
+            agent_server.hub, joined.node_id, asyncio.get_running_loop(), timeout=10
+        )
+        with pytest.raises(NodeOperationError) as caught:
+            await call(service, "list_images")
+        assert caught.value.error_type == "RuntimeError"
+        assert not isinstance(caught.value, NodeUnreachable)
+        # A failed command is not a lost node.
+        assert agent_server.hub.is_connected(joined.node_id)
+    finally:
+        await joined.close()
+
+
+async def test_a_node_that_never_connected_is_unreachable_not_failed(agent_server):
+    """The distinction the whole transport exists to keep."""
+    service = AgentNodeService(
+        agent_server.hub,
+        "node-that-is-not-there",
+        asyncio.get_running_loop(),
+        timeout=2,
+    )
+    with pytest.raises(NodeUnreachable) as caught:
+        await call(service, "get_container_status", "anything")
+    assert not isinstance(caught.value, NodeOperationError)
+
+
+async def test_a_dropped_connection_is_unreachable_not_missing(
+    agent_server, join_agent
+):
+    """A container on a node we lost is *unknown*, never reported as gone."""
+    joined = await join_agent("spark-a")
+    service = AgentNodeService(
+        agent_server.hub, joined.node_id, asyncio.get_running_loop(), timeout=2
+    )
+    await call(service, "run_container", "img:1", "c1", {}, METADATA)
+    await joined.close()
+    await asyncio.sleep(0.1)
+
+    with pytest.raises(NodeUnreachable):
+        await call(service, "get_container_status", "c1")
+
+
+# ── Contract exceptions ─────────────────────────────────────────────────────
+
+
+class SlowPull(MockDockerService):
+    """A Docker whose pull takes long enough to be cancelled, and honours it.
+
+    It polls ``cancel`` and raises ``PullCancelled`` because that is what
+    ``DockerService.pull_image`` does; Docker is the declared fake here, and
+    standing in for it means standing in for its contract too.
+    """
+
+    def pull_image(self, ref, progress=None, interval=0.0, cancel=None, **kwargs):
+        for _ in range(400):
+            if cancel is not None and cancel():
+                raise PullCancelled(f"pull of {ref} cancelled")
+            time.sleep(0.01)
+        return super().pull_image(ref, progress, interval=interval, cancel=cancel)
+
+
+async def test_a_cancelled_pull_travels_to_the_node_and_comes_back_as_pull_cancelled(
+    agent_server, join_agent
+):
+    """``native_runtime`` and ``images`` catch ``PullCancelled`` by type.
+
+    Two things at once, because they are one property: the Cancel reaches the
+    node (or the pull never ends), and the node's answer arrives as
+    ``PullCancelled`` rather than a generic failure — a remote pull that came
+    back as a plain ``NodeOperationError`` would slip past all three handlers
+    and be recorded as a deployment failure instead of a teardown.
+    """
+    joined = await join_agent("spark-slow", docker=SlowPull(MockDockerClient()))
+    try:
+        service = AgentNodeService(
+            agent_server.hub, joined.node_id, asyncio.get_running_loop(), timeout=30
+        )
+        cancelled = threading.Event()
+
+        async def trip():
+            await asyncio.sleep(0.3)
+            cancelled.set()
+
+        asyncio.create_task(trip())
+        with pytest.raises(PullCancelled):
+            await call(service, "pull_image", "slow:1", None, 0.05, cancelled.is_set)
+    finally:
+        await joined.close()
+
+
+async def test_a_pull_failure_the_table_does_not_name_stays_an_agent_error(
+    agent_server, join_agent
+):
+    """The table is a contract, not a general-purpose exception tunnel."""
+
+    class Refuses(MockDockerService):
+        def pull_image(self, ref, *args, **kwargs):
+            raise ValueError("no such registry")
+
+    joined = await join_agent("spark-refuses", docker=Refuses(MockDockerClient()))
+    try:
+        service = AgentNodeService(
+            agent_server.hub, joined.node_id, asyncio.get_running_loop(), timeout=10
+        )
+        with pytest.raises(NodeOperationError) as caught:
+            await call(service, "pull_image", "img:1")
+        assert caught.value.error_type == "ValueError"
+    finally:
+        await joined.close()
+
+
+async def test_the_translation_table_is_small_and_explicit():
+    """It maps contract failures only; everything else stays an agent error."""
+    assert set(CONTRACT_EXCEPTIONS) == {"PullCancelled", "PullStalled"}
+
+
+# ── The deadlock guard ──────────────────────────────────────────────────────
+
+
+async def test_calling_from_the_loop_thread_raises_instead_of_hanging(
+    agent_server, agent_node
+):
+    """The failure this guard replaces is a hang with no traceback."""
+    service = service_for_node(agent_server, agent_node)
+    with pytest.raises(RuntimeError) as caught:
+        service.get_container_status("c1")  # no to_thread: on the loop thread
+    message = str(caught.value)
+    assert "deadlock" in message
+    assert "NodeOperations" in message
+
+
+async def test_the_guard_does_not_leave_a_coroutine_un_awaited(
+    agent_server, agent_node, recwarn
+):
+    service = service_for_node(agent_server, agent_node)
+    with pytest.raises(RuntimeError):
+        service.image_exists("img:1")
+    assert not [w for w in recwarn if "never awaited" in str(w.message)]
+
+
+async def test_the_thread_side_deadline_is_longer_than_the_command_deadline():
+    """It bounds the *loop*, not the node, so it must never fire first."""
+    assert RESULT_MARGIN > 0
+
+
+# ── The runtime handle ──────────────────────────────────────────────────────
+
+
+class FakeLocal:
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+
+
+def runtime_for(agent_server, control_id: str = "") -> ControlPlaneRuntime:
+    runtime = ControlPlaneRuntime(agent_server, asyncio.get_event_loop())
+    if control_id:
+        runtime.local = FakeLocal(control_id)
+    return runtime
+
+
+async def test_the_control_node_resolves_without_consulting_the_registry(
+    agent_server, agent_node
+):
+    """No lookup can be wrong if no lookup happens."""
+    runtime = runtime_for(agent_server, control_id=agent_node.node_id)
+    assert runtime.node_id_for(control_node()) == agent_node.node_id
+    assert isinstance(runtime.service_for(control_node()), AgentNodeService)
+
+
+async def test_an_enrolled_id_resolves_to_itself(agent_server, agent_node):
+    runtime = runtime_for(agent_server)
+    record = Node(id=agent_node.node_id, address="10.0.0.2")
+    assert runtime.node_id_for(record) == agent_node.node_id
+
+
+async def test_a_node_with_no_agent_is_a_refusal_not_a_fallback(agent_server):
+    """The bug this prevents ran the control plane's own docker for a worker."""
+    runtime = runtime_for(agent_server)
+    with pytest.raises(LookupError) as caught:
+        runtime.service_for(peer_node("10.0.0.9"))
+    assert "no enrolled agent" in str(caught.value)
+
+
+async def test_liveness_of_an_unenrolled_node_is_dead_not_an_error(agent_server):
+    runtime = runtime_for(agent_server)
+    assert runtime.liveness(peer_node("10.0.0.9")) is Liveness.DEAD
+
+
+async def test_use_restores_the_previous_runtime(agent_server):
+    runtime = runtime_for(agent_server)
+    other = ControlPlaneRuntime(agent_server, asyncio.get_event_loop())
+    with use(runtime):
+        assert current() is runtime
+        with use(other):
+            assert current() is other
+        assert current() is runtime
+    assert current() is None
+
+
+async def test_an_address_resolves_through_the_node_registry(
+    agent_server, agent_node, monkeypatch
+):
+    """The weakest of the three joins, and the only one that can go stale."""
+    import spark_pulse.tools.node_registry as registry
+
+    class Record:
+        id = agent_node.node_id
+        address = "10.0.0.5"
+
+    monkeypatch.setattr(registry, "list_nodes", lambda: [Record()])
+    runtime = runtime_for(agent_server)
+    assert runtime.node_id_for(peer_node("10.0.0.5")) == agent_node.node_id
+    assert runtime.node_id_for(peer_node("10.0.0.6")) == ""

--- a/tests/test_container_service_contract.py
+++ b/tests/test_container_service_contract.py
@@ -2,9 +2,11 @@
 
 Spark Pulse has three implementations of one node-bound container service:
 
-* ``DockerService`` — this machine, Docker SDK.
-* ``RemoteNodeService`` — one node: the docker CLI over SSH for a peer, the
-  local SDK when the node it was built for is this machine.
+* ``DockerService`` — a Docker daemon, through the SDK. On the control plane
+  this is what an agent's executor holds; here it is driven directly.
+* ``AgentNodeService`` — one node, over its agent: a real mTLS gRPC stream to
+  a real agent whose executor is a ``DockerService``. What the control plane
+  actually holds for every node, including its own.
 * ``MockDockerService`` — simulation mode, in memory.
 
 They are used interchangeably (the orchestrator does not know which one it
@@ -18,17 +20,27 @@ daemon. With the node fixed at construction there is nothing to pass, and both
 branches are exercised here.
 
 Each implementation is driven through a fake at its own boundary — a mocked
-docker SDK client, and the simulated docker-over-SSH transport that simulation
-mode itself uses — so the production code paths, not stand-ins for them, run.
+docker SDK client, in every case including the agent's, whose executor holds
+one. Nothing between the call and that client is a stand-in: the agent path
+crosses a real TLS handshake, a real gRPC stream, the real codec and the real
+hub, on a loop in a background thread, which is precisely the arrangement
+production runs.
 
 **All fifteen interface methods, not six.** This file used to exercise six of
 :data:`NODE_SERVICE_METHODS`; ``docs/transport-reexamined.md`` §5.1 audited the
 seam method by method and found thirty semantic divergences between the two
 real implementations, three of them live bugs, and **twenty-seven of the thirty
 in the nine methods with no behavioural test at all**. The whole interface is
-under contract now, and where two implementations do not agree the difference
-is asserted from both sides in :class:`TestDeclaredDifferences` with the reason
-it is kept, rather than skipped.
+under contract now.
+
+**Most of those divergences no longer exist**, and that is the point of the
+change that removed them rather than a happy accident: they were divergences
+between the Docker SDK and a second implementation that drove the docker *CLI*
+over SSH, and there is no second implementation of Docker any more. One
+``DockerService`` runs on each node, and the agent carries its return value
+back as payload. :class:`TestDeclaredDifferences` records what is left — and
+:class:`TestDivergencesThatNoLongerExist` records what went, so that
+reintroducing any of them fails here.
 :meth:`TestImplementationsAreDistinct.test_every_interface_method_has_a_behavioural_contract`
 is the ratchet: adding a method to the interface without exercising it here
 fails, by name.
@@ -36,10 +48,14 @@ fails, by name.
 
 from __future__ import annotations
 
+import asyncio
 import importlib
+import shutil
 import subprocess
 import sys
+import tempfile
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -47,7 +63,6 @@ import pytest
 
 from spark_pulse.config import config
 from spark_pulse.mock.docker import MockDockerService, MockDockerClient
-from spark_pulse.mock.node_service import SimulatedDockerSSHClient
 from spark_pulse.tools.docker import (
     ContainerInfo,
     ContainerMetadata,
@@ -70,10 +85,11 @@ from spark_pulse.tools.labels import (
     ROLE_LABEL,
     WORLD_SIZE_LABEL,
 )
+from spark_pulse.agent.errors import NodeOperationError, NodeUnreachable
+from spark_pulse.agent.sync_service import AgentNodeService
 from spark_pulse.tools.node_service import (
     NODE_SERVICE_METHODS,
     Node,
-    RemoteNodeService,
     control_node,
     peer_node,
 )
@@ -81,7 +97,6 @@ from spark_pulse.tools.reconciliation import (
     _reconcile_clusters_real,
     _reconcile_deployments_real,
 )
-from spark_pulse.tools.ssh import SSHError, SSHResult
 
 # pytest-env forces SIMULATION_MODE=1, so the package attribute
 # ``spark_pulse.tools.docker`` is the mock re-export. ``copy_to_container`` is
@@ -244,10 +259,10 @@ def _fake_sdk_client() -> MagicMock:
 
 PEER_ADDRESS = "10.0.0.2"
 
-
-def _simulated_ssh() -> SimulatedDockerSSHClient:
-    """The docker-over-SSH transport simulation mode ships, seeded with IMAGE."""
-    return SimulatedDockerSSHClient(images={IMAGE: IMAGE_SIZE})
+NODES = {
+    "self": control_node(address="127.0.0.1"),
+    "peer": peer_node(PEER_ADDRESS),
+}
 
 
 def _mock_service(_node: Node):
@@ -262,25 +277,127 @@ def _sdk_service(_node: Node):
     return DockerService(client=_fake_sdk_client())
 
 
-def _remote_service(node: Node):
-    """The real node-bound service: SSH for a peer, the SDK for this machine."""
-    return RemoteNodeService(
-        node,
-        ssh_client=_simulated_ssh(),
-        docker_service=DockerService(client=_fake_sdk_client()),
-    )
+class AgentFleet:
+    """A control plane and one agent per node, on a loop in another thread.
+
+    Built once for the module because a TLS handshake and an enrolment per
+    test would dominate the run. What is *not* shared is state: every test
+    gets a brand new ``DockerService`` over a brand new fake SDK client behind
+    each agent, installed by :meth:`fresh`. The transport is reused; nothing
+    that answers a question is.
+
+    The loop runs on its own thread and the tests call from the main one,
+    which is not a testing convenience either — it is exactly how production
+    runs, and it is the arrangement the sync bridge exists to survive.
+    """
+
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(
+            target=self.loop.run_forever, name="contract-loop", daemon=True
+        )
+        self.thread.start()
+        self.directory = tempfile.mkdtemp(prefix="contract-agents-")
+        self.server = None
+        self.agents: dict[str, object] = {}
+        self.backing: dict[str, DockerService] = {}
+        self._submit(self._start())
+
+    def _submit(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(30)
+
+    async def _start(self) -> None:
+        from spark_pulse.agent.hub import AgentHub
+        from spark_pulse.agent.server import ControlPlaneServer
+
+        self.server = ControlPlaneServer(
+            directory=Path(self.directory) / "control",
+            host="127.0.0.1",
+            session_port=0,
+            enrollment_port=0,
+            hub=AgentHub(cluster_id="contract", epoch=1),
+        )
+        await self.server.start()
+        for name in NODES:
+            await self._join(name)
+
+    async def _join(self, name: str) -> None:
+        from spark_pulse.agent.executor import LocalExecutor
+        from spark_pulse.agent.node_agent import NodeAgent, enroll
+
+        identity = await enroll(
+            self.server.enrollment_target(),
+            self.server.mint_token(name),
+            trust_bundle_pem=self.server.trust_bundle_pem,
+            trust_bundle_pin=self.server.trust_bundle_pin,
+            directory=Path(self.directory) / name,
+            requested_name=name,
+            docker_service=DockerService(client=_fake_sdk_client()),
+        )
+        agent = NodeAgent(
+            identity,
+            self.server.session_target(),
+            executor=LocalExecutor(DockerService(client=_fake_sdk_client())),
+            heartbeat_interval=0.2,
+        )
+        task = asyncio.create_task(agent.run_forever(), name=f"contract-{name}")
+        await agent.wait_connected(20)
+        self.agents[name] = (agent, task)
+
+    def fresh(self, name: str) -> AgentNodeService:
+        """A service for ``name`` over an agent with a clean Docker behind it."""
+        agent, _task = self.agents[name]
+        backing = DockerService(client=_fake_sdk_client())
+        agent.executor._docker = backing
+        self.backing[name] = backing
+        service = AgentNodeService(
+            self.server.hub, agent.node_id, self.loop, timeout=20
+        )
+        service._fleet_name = name
+        service._fleet = self
+        return service
+
+    def close(self) -> None:
+        async def _shutdown():
+            for agent, task in self.agents.values():
+                await agent.stop()
+                task.cancel()
+            await self.server.stop(grace=0)
+
+        try:
+            self._submit(_shutdown())
+        finally:
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            self.thread.join(timeout=10)
+            shutil.rmtree(self.directory, ignore_errors=True)
+
+
+_FLEET: AgentFleet | None = None
+
+
+def _agent_service(node: Node):
+    """The node-bound service the control plane really holds: over the agent."""
+    assert _FLEET is not None, "the agent fleet fixture did not run"
+    return _FLEET.fresh("self" if node.is_self else "peer")
 
 
 IMPLEMENTATIONS = {
     "mock": _mock_service,
     "docker-sdk": _sdk_service,
-    "remote-ssh": _remote_service,
+    "agent": _agent_service,
 }
 
-NODES = {
-    "self": control_node(address="127.0.0.1"),
-    "peer": peer_node(PEER_ADDRESS),
-}
+
+@pytest.fixture(scope="module", autouse=True)
+def agent_fleet():
+    """Stand the agents up once for the module, and take them down after."""
+    global _FLEET
+    _FLEET = AgentFleet()
+    try:
+        yield _FLEET
+    finally:
+        _FLEET.close()
+        _FLEET = None
 
 
 @pytest.fixture(params=sorted(IMPLEMENTATIONS), ids=sorted(IMPLEMENTATIONS))
@@ -299,15 +416,6 @@ def node(request) -> Node:
 def service(implementation, node):
     """One container service, bound to one node. No method takes a host."""
     return implementation(node)
-
-
-class _MkdirRefused(SimulatedDockerSSHClient):
-    """A node whose ``mkdir -p`` is refused, everything else intact."""
-
-    def _exec_one(self, host: str, command: str):
-        if command.strip().startswith("mkdir"):
-            return SSHResult(returncode=1, stdout="", stderr="Permission denied")
-        return super()._exec_one(host, command)
 
 
 @pytest.fixture
@@ -336,10 +444,18 @@ def docker_cp(monkeypatch):
     the SDK, so this is the one method whose local implementation needs a
     process stubbed rather than a client injected.
     """
-    calls: list[list[str]] = []
+    calls: list[dict] = []
 
     def _run(args, **_kwargs):
-        calls.append(list(args))
+        # Snapshot the source *now*: the agent stages a copied tree in a
+        # temporary directory and removes it as soon as ``docker cp`` returns,
+        # so a test that looks afterwards finds nothing and would pass whether
+        # the tree arrived or not.
+        source = Path(args[2]) if len(args) > 2 else None
+        tree: list[str] = []
+        if source is not None and source.is_dir():
+            tree = sorted(str(child.relative_to(source)) for child in source.rglob("*"))
+        calls.append({"args": list(args), "tree": tree})
         return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(
@@ -360,9 +476,15 @@ def docker_cp(monkeypatch):
 
 
 def _backing_service(service):
-    """The :class:`DockerService` behind ``service``, or None for a peer."""
-    if isinstance(service, RemoteNodeService):
-        return None if not service.is_local else service._local
+    """The :class:`DockerService` that will actually answer ``service``.
+
+    For the agent that is the executor's Docker on the far side of the
+    stream — reachable here because both ends are in this process, which is
+    the whole reason the agent was built as an object with a stream rather
+    than a process you have to deploy before you can observe it.
+    """
+    if isinstance(service, AgentNodeService):
+        return service._fleet.backing[service._fleet_name]
     return service
 
 
@@ -373,9 +495,6 @@ def _exit_container(service, name: str) -> None:
     ``docker rm`` — the state that used to be permanent on every peer.
     """
     backing = _backing_service(service)
-    if backing is None:
-        service._ssh.containers_on(service.node.address)[name]["State"] = "exited"
-        return
     container = backing.client.containers.get(name)
     container.status = "exited"
     container.attrs["State"] = {"Status": "exited", "Running": False}
@@ -384,9 +503,6 @@ def _exit_container(service, name: str) -> None:
 def _stop_answering(service) -> None:
     """Make the node's daemon stop answering, without unmaking the node."""
     backing = _backing_service(service)
-    if backing is None:
-        service._ssh.daemon_down_hosts.add(service.node.address)
-        return
 
     def _refuse(*_args, **_kwargs):
         raise RuntimeError("Cannot connect to the Docker daemon at unix://...")
@@ -472,19 +588,22 @@ class TestImplementationsAreDistinct:
         ]
         assert len({id(service) for service in built}) == 6
 
-    def test_the_remote_service_takes_a_different_branch_per_node(self):
-        """The self node and the peer are not the same code path.
+    def test_the_control_node_is_reached_the_same_way_as_a_peer(self):
+        """There is no local branch left to leave untested, because there is none.
 
-        This is the assertion the old suite could not make: it hardcoded a
-        remote address, so the local branch never ran and the empty-host
-        default was never tested at all.
+        The old suite could not assert this: the remote service had a
+        ``is_local`` branch, the suite hardcoded a remote address, so the
+        local branch never ran and the empty-host default was never tested at
+        all. Now the control node runs an agent for itself and is reached over
+        loopback exactly as a peer is — same class, same transport, different
+        node id. A reader who cannot tell which of these is the control node
+        from the code that talks to it is reading it correctly.
         """
-        on_self = _remote_service(NODES["self"])
-        on_peer = _remote_service(NODES["peer"])
+        on_self = _agent_service(NODES["self"])
+        on_peer = _agent_service(NODES["peer"])
 
-        assert on_self.is_local is True
-        assert on_peer.is_local is False
-        assert on_self.node != on_peer.node
+        assert type(on_self) is type(on_peer) is AgentNodeService
+        assert on_self.node_id != on_peer.node_id
 
     def test_every_implementation_offers_the_whole_interface(self):
         """Signature-identical, which is what let the adapters be deleted."""
@@ -681,17 +800,24 @@ class TestRestartPolicy:
         kwargs = client.containers.run.call_args.kwargs
         assert kwargs["restart_policy"] == {"Name": "no"}
 
-    def test_the_ssh_path_asks_for_no_restart(self):
-        ssh = _simulated_ssh()
-        RemoteNodeService(NODES["peer"], ssh_client=ssh).run_container(
+    def test_a_peer_asks_for_no_restart_too(self):
+        """It is the same code deciding, on the node, so it cannot differ.
+
+        Kept as an assertion rather than deleted as tautological: the reason
+        it cannot differ is that there is one implementation, and this is
+        where that stops being true if someone adds a second.
+        """
+        service = _agent_service(NODES["peer"])
+        service.run_container(
             image=IMAGE,
             name="contract-restart-remote",
             env_vars={},
             metadata=_metadata("contract-restart-remote"),
         )
 
-        run = next(c["command"] for c in ssh.commands if " run " in c["command"])
-        assert "--restart no" in run
+        backing = _backing_service(service)
+        kwargs = backing.client.containers.run.call_args.kwargs
+        assert kwargs["restart_policy"] == {"Name": "no"}
 
 
 class TestImageContract:
@@ -807,8 +933,8 @@ class TestReconciliationContract:
         assert [d["id"] for d in deployments] == ["contract-reconcile-mock"]
 
     def test_reconcile_finds_a_cluster(self):
-        """A cluster container started over SSH is reconciled from its labels."""
-        remote = _remote_service(NODES["peer"])
+        """A cluster container on a peer is reconciled from its labels."""
+        remote = _agent_service(NODES["peer"])
         remote.run_container(
             image=IMAGE,
             name="contract-cluster-head",
@@ -1157,10 +1283,10 @@ class TestMemorySwapDerivation:
         kwargs = client.containers.run.call_args.kwargs
         assert kwargs["memswap_limit"] == int(110 * 1024 * 1024 * 1024)
 
-    def test_the_ssh_path_derives_the_same_swap_limit(self):
+    def test_a_peer_derives_the_same_swap_limit(self):
         """It used to derive none, so a peer's rank ran with swap unlimited."""
-        ssh = _simulated_ssh()
-        RemoteNodeService(NODES["peer"], ssh_client=ssh).run_container(
+        service = _agent_service(NODES["peer"])
+        service.run_container(
             image=IMAGE,
             name="contract-swap-remote",
             env_vars={},
@@ -1168,9 +1294,9 @@ class TestMemorySwapDerivation:
             memory_limit_gb=100,
         )
 
-        run = next(c["command"] for c in ssh.commands if " run " in c["command"])
-        assert "--memory 100g" in run
-        assert f"--memory-swap {int(110 * 1024 * 1024 * 1024)}" in run
+        kwargs = _backing_service(service).client.containers.run.call_args.kwargs
+        assert kwargs["mem_limit"] == 100 * 1024 * 1024 * 1024
+        assert kwargs["memswap_limit"] == int(110 * 1024 * 1024 * 1024)
 
 
 class TestStopRemoves:
@@ -1530,10 +1656,18 @@ class TestCopyIntoContainerContract:
             service.copy_to_container("contract-cp-dir", local_tree, "/tmp/mod") is True
         )
 
-    def test_a_directory_travels_over_the_recursive_transport(self, local_tree):
-        """The peer path, at the transport: ``copy_dir``, never ``copy``."""
-        ssh = _simulated_ssh()
-        service = RemoteNodeService(NODES["peer"], ssh_client=ssh)
+    def test_a_directory_arrives_on_a_peer_with_its_subdirectories(
+        self, local_tree, docker_cp
+    ):
+        """The shape that used to fail, asserted where it used to be lost.
+
+        The peer path staged with ``scp`` and no ``-r``, so a mod directory
+        never arrived and its ``run.sh`` failed on the far side of a fan-out.
+        The bytes now travel as a gzipped tar in the command itself, so what
+        is worth asserting is not a flag but the tree: every file, at its own
+        relative path, present on the node before ``docker cp`` runs.
+        """
+        service = _agent_service(NODES["peer"])
         service.run_container(
             image=IMAGE,
             name="contract-cp-recursive",
@@ -1545,21 +1679,28 @@ class TestCopyIntoContainerContract:
             "contract-cp-recursive", local_tree, "/tmp/mod"
         )
 
-        assert ssh.copies[-1]["recursive"] is True
+        assert docker_cp[-1]["tree"] == ["run.sh", "templates", "templates/chat.jinja"]
 
-    def test_a_file_travels_over_the_plain_transport(self, local_file):
-        ssh = _simulated_ssh()
-        service = RemoteNodeService(NODES["peer"], ssh_client=ssh)
+    def test_a_file_arrives_on_a_peer_as_a_file(self, local_file, docker_cp):
+        """A single file is not tarred, and its mode goes with it.
+
+        The thing most often copied this way is a serve script, which has to
+        be executable when it lands.
+        """
+        service = _agent_service(NODES["peer"])
         service.run_container(
             image=IMAGE,
             name="contract-cp-plain",
             env_vars={},
             metadata=_metadata("contract-cp-plain"),
         )
+        Path(local_file).chmod(0o755)
 
         assert service.copy_to_container("contract-cp-plain", local_file, "/tmp/f")
 
-        assert ssh.copies[-1]["recursive"] is False
+        staged = Path(docker_cp[-1]["args"][2])
+        assert docker_cp[-1]["tree"] == []
+        assert staged.name == "launch.sh"
 
 
 # ── Where the implementations differ, deliberately ──────────────────────────
@@ -1571,202 +1712,27 @@ class TestDeclaredDifferences:
     A contract test that skipped these would be a contract test that let them
     drift. Every one of them is asserted from both sides instead, so if either
     side changes, this file says so.
+
+    There are two left of the seven this class once held. The other five are
+    in :class:`TestDivergencesThatNoLongerExist`.
     """
 
-    def test_exec_timeout_binds_a_peer_and_is_advisory_locally(self):
-        """The SDK's exec has no per-call deadline; ``ssh`` does.
-
-        Kept because the argument is real on one transport and unavailable on
-        the other, and dropping it from the signature would mean a caller
-        could not bound a remote exec at all. ``DockerService`` documents the
-        asymmetry in its own docstring.
-        """
-        ssh = _simulated_ssh()
-        remote = RemoteNodeService(NODES["peer"], ssh_client=ssh)
-        remote.run_container(
-            image=IMAGE,
-            name="contract-timeout",
-            env_vars={},
-            metadata=_metadata("contract-timeout"),
-        )
-        remote.exec_in_container("contract-timeout", ["true"], timeout=7)
-        assert ssh.commands[-1]["timeout"] == 7
-
-        client = _fake_sdk_client()
-        local = DockerService(client=client)
-        local.run_container(
-            image=IMAGE,
-            name="contract-timeout",
-            env_vars={},
-            metadata=_metadata("contract-timeout"),
-        )
-        local.exec_in_container("contract-timeout", ["true"], timeout=7)
-        assert (
-            "timeout"
-            not in client.containers.get("contract-timeout").exec_run.call_args.kwargs
-        )
-
-    def test_exec_on_a_container_that_is_not_there(self):
-        """The SDK raises; the CLI returns a failed result.
-
-        Kept because both callers — ``_apply_mods`` and ``_launch_rank`` —
-        already fail the deploy on either, and turning the SDK's ``NotFound``
-        into a synthetic exit code would invent a return code Docker never
-        produced.
-        """
-        with pytest.raises(Exception):
-            DockerService(client=_fake_sdk_client()).exec_in_container(
-                "contract-nothing", ["true"]
-            )
-
-        remote = RemoteNodeService(NODES["peer"], ssh_client=_simulated_ssh())
-        result = remote.exec_in_container("contract-nothing", ["true"])
-        assert isinstance(result, ExecResult)
-        assert result.ok is False
-
-    def test_pull_progress_is_per_layer_locally_and_terminal_on_a_peer(self):
-        """``docker pull`` over ssh is one blocking command with no stream.
-
-        Kept, and documented on the method: fetch-once on the control node
-        followed by a fan-out is the plan's answer, and it is later work. What
-        is *not* kept is the cancel: see
-        :class:`TestPullCancellationContract`.
-        """
-        seen_local: list[dict] = []
-        DockerService(client=_fake_sdk_client()).pull_image(
-            MISSING_IMAGE, seen_local.append, interval=0
-        )
-        assert len(seen_local) > 1
-        assert seen_local[-1]["layers"] == len(FAKE_LAYERS)
-
-        seen_remote: list[dict] = []
-        RemoteNodeService(NODES["peer"], ssh_client=_simulated_ssh()).pull_image(
-            MISSING_IMAGE, seen_remote.append, interval=0
-        )
-        assert len(seen_remote) == 1
-        assert seen_remote[0]["layers"] == 0
-        assert seen_remote[0]["percent"] == 100.0
-
-    def test_ensure_directories_cannot_attribute_a_failure_on_a_peer(self, tmp_path):
-        """One ``mkdir -p`` for the whole list, so one answer for all of them.
-
-        Kept because the alternative is one round trip per cache directory on
-        a path that runs before every deploy, and the caller treats the result
-        as a warning either way: docker will still start, it will just have
-        invented the bind source as root.
-        """
-        blocker = tmp_path / "a-file"
-        blocker.write_text("not a directory")
-        local = DockerService(client=_fake_sdk_client())
-
-        failed = local.ensure_directories([str(tmp_path / "fine"), str(blocker / "no")])
-
-        assert failed == [str(blocker / "no")]
-        assert (tmp_path / "fine").is_dir()
-
-        remote = RemoteNodeService(NODES["peer"], ssh_client=_MkdirRefused())
-        wanted = ["/opt/one", "/opt/two"]
-        assert remote.ensure_directories(wanted) == wanted
-
-    def test_a_label_value_with_a_comma_does_not_survive_docker_ps(self):
-        """Docker's own listing format, not ours.
-
-        ``docker ps`` renders every label into one comma-separated string, so
-        a value containing a comma cannot be parsed back out of it. Kept
-        because the fix is not a parser — it is ``docker inspect`` per
-        container, which is the Engine-API unification
-        ``docs/transport-reexamined.md`` §5.1 recommends and this change
-        deliberately does not attempt. Nothing spark-pulse writes contains a
-        comma today; this is here so that when something does, a test says so.
-        """
-        metadata = _metadata("contract-comma", recipe="qwen3,awq")
-
-        local = DockerService(client=_fake_sdk_client())
-        local.run_container(
-            image=IMAGE, name="contract-comma", env_vars={}, metadata=metadata
-        )
-        assert local.list_managed_containers()[0].metadata.recipe == "qwen3,awq"
-
-        remote = RemoteNodeService(NODES["peer"], ssh_client=_simulated_ssh())
-        remote.run_container(
-            image=IMAGE,
-            name="contract-comma",
-            env_vars={},
-            metadata=_metadata("contract-comma", recipe="qwen3,awq"),
-        )
-        assert remote.list_managed_containers()[0].metadata.recipe == "qwen3"
-
-    def test_a_node_that_cannot_be_reached_raises_where_a_daemon_returns_false(self):
-        """``image_exists`` is False for "not there" and raises for "cannot ask".
-
-        There is no local analogue of an unreachable node, so this is not two
-        answers to one question: a daemon that refuses is ``False`` on both
-        paths, and only the peer has a third case at all. Kept because the
-        alternative — swallowing the transport failure into ``False`` — is the
-        inference ``list_managed_containers`` was just cured of.
-        """
-        ssh = _simulated_ssh()
-        remote = RemoteNodeService(NODES["peer"], ssh_client=ssh)
-        assert remote.image_exists(IMAGE) is True
-
-        ssh.daemon_down_hosts.add(PEER_ADDRESS)
-        assert remote.image_exists(IMAGE) is False
-
-        ssh.daemon_down_hosts.clear()
-        ssh.fail_hosts.add(PEER_ADDRESS)
-        with pytest.raises(SSHError):
-            remote.image_exists(IMAGE)
-
-    def test_an_attached_run_is_not_a_shape_either_service_supports(self):
+    def test_an_attached_run_is_not_a_shape_any_service_supports(self):
         """``detach=False`` is on the signature and is not honoured anywhere.
 
         Recorded rather than fixed. The SDK's ``containers.run(detach=False)``
-        returns the container's *logs*, not a container, so the local path's
-        ``container.id`` would fail; the CLI path reads the first line of a
-        foreground ``docker run``'s output as an id, which it is not. Nothing
-        in spark-pulse passes it — every caller starts an idle container and
-        execs into it — so both paths assume detached. Making them agree means
-        either implementing an attached run twice or dropping the argument, and
-        the argument is part of ``DockerService``'s published signature.
+        returns the container's *logs*, not a container, so the code that
+        reads ``container.id`` afterwards would fail. Nothing in spark-pulse
+        passes it — every caller starts an idle container and execs into it —
+        so every path assumes detached. Making them agree means either
+        implementing an attached run or dropping the argument, and the
+        argument is part of ``DockerService``'s published signature.
         """
         import inspect
 
         for factory in IMPLEMENTATIONS.values():
             signature = inspect.signature(factory(NODES["peer"]).run_container)
             assert signature.parameters["detach"].default is True
-
-    def test_the_simulated_transport_is_faithful_where_it_used_to_be_kind(self):
-        """The four simulator properties that were hiding real bugs.
-
-        A simulation that is kinder than the thing it stands in for cannot
-        catch a bug in it, and this one was kind in exactly the places the seam
-        was broken: ``docker stop`` deleted the container, so the missing
-        ``docker rm`` was invisible; ``scp`` accepted a directory, so the
-        missing ``-r`` was invisible; ``&&`` was truncated, so a two-command
-        teardown could not be told from a one-command one.
-        """
-        ssh = _simulated_ssh()
-        ssh.exec(PEER_ADDRESS, "docker run -d --name sim img")
-
-        # 1. Stop keeps the container; only rm takes it away.
-        ssh.exec(PEER_ADDRESS, "docker stop -t 1 sim")
-        assert ssh.containers_on(PEER_ADDRESS)["sim"]["State"] == "exited"
-        assert ssh.exec(PEER_ADDRESS, "docker inspect sim").ok
-
-        # 2. Clauses run in order, and a failure short-circuits the rest.
-        assert ssh.exec(PEER_ADDRESS, "docker rm -f sim && docker inspect sim").ok is (
-            False
-        )
-        assert "sim" not in ssh.containers_on(PEER_ADDRESS)
-
-        # 3. An ``&&`` inside a quoted ``bash -lc`` is one argument, not two
-        #    commands — which is how ``_apply_mods`` runs every mod.
-        ssh.exec(PEER_ADDRESS, "docker run -d --name sim2 img")
-        inner = ssh.exec(
-            PEER_ADDRESS, "docker exec sim2 bash -lc 'cd /mods/m && bash run.sh'"
-        )
-        assert inner.ok
-        assert "bash run.sh" in inner.stdout
 
     def test_the_simulated_service_reports_every_copy_as_done(self, tmp_path):
         """``MockDockerService.copy_to_container`` is unconditionally True.
@@ -1779,3 +1745,127 @@ class TestDeclaredDifferences:
         service = MockDockerService(MockDockerClient())
 
         assert service.copy_to_container("nothing", str(tmp_path), "/tmp/x") is True
+
+
+class TestDivergencesThatNoLongerExist:
+    """Five differences this file used to document, and no longer can.
+
+    Each was a difference between the Docker SDK and a second implementation
+    that drove the docker *CLI* over SSH. There is no second implementation of
+    Docker any more: one ``DockerService`` runs on each node and the agent
+    carries its return value back as payload, so the peer's answer is produced
+    by the same code as the control node's.
+
+    They are asserted rather than deleted because "we removed the second
+    implementation" is a claim, and a claim that nothing checks is a claim
+    that quietly stops being true. Each test below fails the moment a peer
+    starts answering differently again.
+    """
+
+    def test_pull_progress_is_per_layer_on_a_peer_too(self):
+        """It used to be one terminal event: ``docker pull`` had no stream.
+
+        A 40 GB pull on a worker showed nothing at all until it finished, and
+        the plan's answer was to fetch once on the control node and fan out.
+        The agent streams the daemon's own layer events back on the command's
+        stream instead, so a peer is now as legible as this machine.
+        """
+        seen_local: list[dict] = []
+        DockerService(client=_fake_sdk_client()).pull_image(
+            MISSING_IMAGE, seen_local.append, interval=0
+        )
+
+        seen_peer: list[dict] = []
+        _agent_service(NODES["peer"]).pull_image(
+            MISSING_IMAGE, seen_peer.append, interval=0
+        )
+
+        assert len(seen_peer) > 1
+        assert seen_peer[-1]["layers"] == len(FAKE_LAYERS) == seen_local[-1]["layers"]
+
+    def test_ensure_directories_attributes_a_failure_on_a_peer(self, tmp_path):
+        """It used to be one ``mkdir -p`` for the list, so one answer for all.
+
+        A caller could learn that *something* failed and never which, on a
+        path that runs before every deploy. The node runs the same
+        ``ensure_directories`` this machine does, so it reports the same list.
+        """
+        blocker = tmp_path / "a-file"
+        blocker.write_text("not a directory")
+        wanted = [str(tmp_path / "fine"), str(blocker / "no")]
+
+        local = DockerService(client=_fake_sdk_client()).ensure_directories(wanted)
+        peer = _agent_service(NODES["peer"]).ensure_directories(wanted)
+
+        assert local == peer == [str(blocker / "no")]
+
+    def test_a_label_value_with_a_comma_survives_on_a_peer(self):
+        """It used to be lost: ``docker ps`` renders labels comma-separated.
+
+        A recipe named ``qwen3,awq`` came back as ``qwen3`` from a worker and
+        intact from this machine. Nothing spark-pulse writes contained a comma
+        at the time, which is why it had never been noticed. Nothing parses
+        ``docker ps`` output now.
+        """
+        metadata = _metadata("contract-comma", recipe="qwen3,awq")
+
+        local = DockerService(client=_fake_sdk_client())
+        local.run_container(
+            image=IMAGE, name="contract-comma", env_vars={}, metadata=metadata
+        )
+
+        peer = _agent_service(NODES["peer"])
+        peer.run_container(
+            image=IMAGE,
+            name="contract-comma",
+            env_vars={},
+            metadata=_metadata("contract-comma", recipe="qwen3,awq"),
+        )
+
+        assert local.list_managed_containers()[0].metadata.recipe == "qwen3,awq"
+        assert peer.list_managed_containers()[0].metadata.recipe == "qwen3,awq"
+
+    def test_exec_on_a_container_that_is_not_there_fails_the_same_way(self):
+        """It used to raise here and return a failed result there.
+
+        Both callers — ``_apply_mods`` and ``_launch_rank`` — failed the
+        deploy on either, so nothing was broken by it; it was two answers to
+        one question, which is the kind of difference that becomes a bug the
+        first time somebody writes a third caller. The node raises, and the
+        raise arrives as a definite failure.
+        """
+        with pytest.raises(Exception):
+            DockerService(client=_fake_sdk_client()).exec_in_container(
+                "contract-nothing", ["true"]
+            )
+
+        with pytest.raises(NodeOperationError):
+            _agent_service(NODES["peer"]).exec_in_container(
+                "contract-nothing", ["true"]
+            )
+
+    def test_a_node_that_cannot_be_reached_is_a_different_type_entirely(self):
+        """It used to be an ``SSHError`` a caller had to know to catch.
+
+        The distinction is the same one — a daemon that refuses is ``False``,
+        a node we cannot ask is neither True nor False — but it is now carried
+        by a type that cannot be confused with a failure, and one no caller
+        has to remember to name: ``NodeUnreachable`` is not a subclass of the
+        error a failed operation raises, and vice versa.
+        """
+        reachable = _agent_service(NODES["peer"])
+        assert reachable.image_exists(IMAGE) is True
+
+        def _refuse(*_args, **_kwargs):
+            raise RuntimeError("Cannot connect to the Docker daemon at unix://...")
+
+        _backing_service(reachable).client.images.get = _refuse
+        assert reachable.image_exists(IMAGE) is False
+
+        gone = AgentNodeService(
+            _FLEET.server.hub, "no-such-node", _FLEET.loop, timeout=2
+        )
+        with pytest.raises(NodeUnreachable):
+            gone.image_exists(IMAGE)
+        assert not issubclass(NodeUnreachable, NodeOperationError)
+        assert not issubclass(NodeOperationError, NodeUnreachable)

--- a/tests/test_multinode.py
+++ b/tests/test_multinode.py
@@ -15,13 +15,19 @@ actually witness:
   nobody could reach is recorded as an outstanding orphan rather than assumed
   gone.
 
-The transport underneath is ``mock.node_service``: the *real*
-:class:`RemoteNodeService` over a simulated SSH channel, so the docker command
-building, the label filtering and the local-versus-peer branch under test are
-the production ones. Only the bytes on the wire are invented — including the
-unreachable case, where the simulated channel raises the same
-:class:`~spark_pulse.tools.ssh.SSHError` ``OpenSSHClient`` raises on ssh's own
-exit 255.
+The transport underneath is ``mock.node_service``: one in-memory container
+service per node behind a wrapper that can fail the two ways a real node
+fails. Every node has its own Docker, which is the property that matters — an
+answer for the wrong node is then visibly the wrong containers rather than a
+plausible-looking right answer, and that is precisely what the shared-daemon
+arrangement this replaced could not show.
+
+The two failure modes are kept apart here because production keeps them
+apart: a node whose agent is not connected raises
+:class:`~spark_pulse.agent.errors.NodeUnreachable` and its ranks are
+*unknown*; a node whose Docker daemon refuses raises, and that failure is
+definite. Releasing a rank's GPU on the first of those is how two gangs end up
+on one device, so simulation has to be able to produce both.
 
 The size-one class at the end is the safety property the whole convergence
 rests on: at one node nothing about this changed.
@@ -44,15 +50,16 @@ from spark_pulse.mock import docker as mock_docker
 from spark_pulse.mock import node_service as mock_node_service
 from spark_pulse.tools.discovery import MESH_NCCL_ENV
 from spark_pulse.tools.labels import RANK_LABEL, WORLD_SIZE_LABEL
-from spark_pulse.tools.ssh import SSHError, SSHErrorType
+from spark_pulse.agent.errors import NodeUnreachable
 
 # See test_tools_native_runtime.py: under SIMULATION_MODE the package attribute
 # is the mock re-export, so hold the real module to patch its globals.
 nr = importlib.import_module("spark_pulse.tools.native_runtime")
 
 #: The control node, as the simulated registry seeds it. Simulation resolves
-#: this address to this machine, so rank zero runs on the local container
-#: service and every other rank goes over SSH — the real shape.
+#: this address to this machine, so rank zero runs on the control node's own
+#: container service and every other rank on that node's own — the real shape,
+#: where the difference between them is a node id and nothing else.
 CONTROL = "192.168.1.100"
 
 #: Peers, in the order ranks are assigned. The first is seeded; the rest this
@@ -118,10 +125,14 @@ def registry(tmp_path):
 def fleet(tmp_path, registry):
     """Four enrolled Sparks, a temp record file, and a clean transport.
 
-    The peers are reached through the process-wide simulated SSH channel,
-    which is what :func:`native_runtime.rank_services` resolves to on its
-    own — so the tests below drive the production resolver rather than
-    handing ``start`` a services callable of their own.
+    The peers are reached through the process-wide simulated transport, which
+    is what :func:`native_runtime.rank_services` resolves to on its own — so
+    the tests below drive the production resolver rather than handing
+    ``start`` a services callable of their own.
+
+    What is yielded is the ``mock.node_service`` module itself: the fleet is
+    process-wide state, not an object a test holds, because the resolver under
+    test finds it the same way production finds the hub.
     """
     mock_node_service.reset()
     mock_docker.reset_mock()
@@ -157,7 +168,7 @@ def fleet(tmp_path, registry):
             ),
         ),
     ):
-        yield mock_node_service.default_ssh_client()
+        yield mock_node_service
     mock_node_service.reset()
     mock_docker.reset_mock()
 
@@ -174,9 +185,31 @@ def plan_for(size: int, **overrides: Any):
     )
 
 
-def containers_on(ssh, address: str) -> list[str]:
-    """Container names live on one peer, per the simulated docker store."""
-    return sorted(ssh.containers_on(address))
+def peer_docker(fleet, address: str):
+    """One simulated peer's own Docker, for setting a node up or reading it."""
+    return fleet.docker_for(tools.node_service.peer_node(address))
+
+
+def _is_launch(entry: dict) -> bool:
+    """Whether this call is a rank's *serve* exec, not some other exec.
+
+    The serve command redirects to ``/proc/1/fd/1`` so the engine's output
+    lands on the container's own stdout; nothing else spark-pulse execs does.
+    """
+    if entry["op"] != "exec_in_container":
+        return False
+    command = entry["args"][1] if len(entry["args"]) > 1 else ""
+    text = " ".join(command) if isinstance(command, (list, tuple)) else str(command)
+    return "/proc/1/fd/1" in text
+
+
+def containers_on(fleet, address: str) -> list[str]:
+    """Container names live on one node, per that node's own docker store."""
+    if tools.node_service.is_local_address(address):
+        return sorted(
+            c.name for c in mock_docker._get_service().list_managed_containers()
+        )
+    return fleet.containers_on(address)
 
 
 def local_containers() -> list[str]:
@@ -283,28 +316,15 @@ class TestLifecycle:
 
         nr.start(plan, wait=True)
 
-        runs = [
-            entry["host"]
-            for entry in fleet.commands
-            if entry["command"].startswith("docker run")
-        ]
-        launches = [
-            entry["host"]
-            for entry in fleet.commands
-            if entry["command"].startswith("docker exec")
-            and "/proc/1/fd/1" in entry["command"]
-        ]
+        runs = [e["host"] for e in fleet.calls if e["op"] == "run_container"]
+        launches = [e["host"] for e in fleet.calls if _is_launch(e)]
         assert runs == FLEET[1:size]
         assert launches == list(reversed(FLEET[1:size]))
 
         kinds = [
-            "run" if entry["command"].startswith("docker run") else "launch"
-            for entry in fleet.commands
-            if entry["command"].startswith("docker run")
-            or (
-                entry["command"].startswith("docker exec")
-                and "/proc/1/fd/1" in entry["command"]
-            )
+            "run" if entry["op"] == "run_container" else "launch"
+            for entry in fleet.calls
+            if entry["op"] == "run_container" or _is_launch(entry)
         ]
         assert kinds == ["run"] * (size - 1) + ["launch"] * (size - 1)
 
@@ -327,7 +347,7 @@ class TestLifecycle:
 
     def test_stop_tears_every_rank_down_head_first(self, fleet, size):
         nr.start(plan_for(size), wait=True)
-        before = len(fleet.commands)
+        before = len(fleet.calls)
 
         record = nr.stop_deployment(f"dep{size}")
 
@@ -338,8 +358,8 @@ class TestLifecycle:
             assert containers_on(fleet, address) == []
         stops = [
             entry["host"]
-            for entry in fleet.commands[before:]
-            if entry["command"].startswith("docker stop")
+            for entry in fleet.calls[before:]
+            if entry["op"] == "stop_container"
         ]
         # Rank zero is local and stops first, off the wire; the peers follow
         # in rank order, so the rendezvous collapses before the workers wait.
@@ -486,7 +506,7 @@ class TestUnreachablePeer:
     """All-or-nothing, and released on evidence rather than on inference."""
 
     def test_a_peer_that_is_already_gone_starts_nothing_anywhere(self, fleet):
-        fleet.fail_hosts.add(PEERS[0])
+        fleet.unreachable.add(PEERS[0])
         plan = plan_for(3)
 
         record = nr.start(plan, wait=True)
@@ -506,15 +526,18 @@ class TestUnreachablePeer:
         """
         plan = plan_for(3)
 
-        original_exec = fleet.exec
+        # Lose the middle peer the moment the last one has its container: the
+        # hook hangs off that node's *own* Docker, which is where a real node
+        # going away would be noticed too.
+        last = peer_docker(fleet, PEERS[1])
+        original_run = last.run_container
 
-        def _lose_the_middle_peer(host, command, *args, **kwargs):
-            result = original_exec(host, command, *args, **kwargs)
-            if host == PEERS[1] and command.startswith("docker run"):
-                fleet.fail_hosts.add(PEERS[0])
+        def _lose_the_middle_peer(*args, **kwargs):
+            result = original_run(*args, **kwargs)
+            fleet.unreachable.add(PEERS[0])
             return result
 
-        with patch.object(fleet, "exec", _lose_the_middle_peer):
+        with patch.object(last, "run_container", _lose_the_middle_peer):
             record = nr.start(plan, wait=True)
 
         assert record["status"] == "error"
@@ -534,7 +557,7 @@ class TestUnreachablePeer:
     def test_a_deployment_with_an_orphan_is_not_deleted(self, fleet):
         plan = plan_for(3)
         nr.start(plan, wait=True)
-        fleet.fail_hosts.add(PEERS[0])
+        fleet.unreachable.add(PEERS[0])
 
         assert nr.delete_deployment("dep3") is False
         record = nr.get_deployment("dep3")
@@ -548,14 +571,13 @@ class TestUnreachablePeer:
         container". Returning a definite negative is how a rank that is still
         holding a GPU gets confirmed gone on inference.
         """
-        from spark_pulse.tools.ssh import SSHError
 
         service = tools.node_service.NodeServices().for_address(PEERS[0])
-        fleet.fail_hosts.add(PEERS[0])
+        fleet.unreachable.add(PEERS[0])
 
-        with pytest.raises(SSHError):
+        with pytest.raises(NodeUnreachable):
             service.get_container_status("anything")
-        with pytest.raises(SSHError):
+        with pytest.raises(NodeUnreachable):
             service.list_managed_containers()
 
 
@@ -726,25 +748,18 @@ class TestCacheDirectories:
 
         nr.start(plan, wait=True)
 
-        made = fleet.directories.get(PEERS[0]) or []
-        assert made, "the peer was never asked to create its bind sources"
+        asked = [
+            entry
+            for entry in fleet.calls
+            if entry["host"] == PEERS[0] and entry["op"] == "ensure_directories"
+        ]
+        assert asked, "the peer was never asked to create its bind sources"
+        made = list(asked[0]["args"][0])
         assert set(made) == set(plan.rank_plans[1].container.mounts)
 
-        indices = [
-            index
-            for index, entry in enumerate(fleet.commands)
-            if entry["host"] == PEERS[0]
-        ]
-        first_mkdir = next(
-            index
-            for index in indices
-            if fleet.commands[index]["command"].startswith("mkdir -p")
-        )
-        first_run = next(
-            index
-            for index in indices
-            if fleet.commands[index]["command"].startswith("docker run")
-        )
+        operations = fleet.operations_on(PEERS[0])
+        first_mkdir = operations.index("ensure_directories")
+        first_run = operations.index("run_container")
         assert first_mkdir < first_run
 
     def test_the_control_node_creates_its_own_too(self, fleet):
@@ -827,22 +842,26 @@ class TestRankStateIsThreeStates:
     """A daemon that did not answer is not a container that is not there."""
 
     def test_a_dead_daemon_reports_unknown_rather_than_missing(self, fleet):
-        """The distinction the local path has always had, at the peer.
+        """The distinction the local path has always had, now at every node.
 
         ``DockerService.get_container_status`` separates ``NotFound`` from
-        ``APIError``, so the control node's own rank is told the truth. The
-        peer gets one exit code for both, and inventing "not found" out of it
-        is a claim we have no evidence for.
+        ``APIError``, so the control node's own rank was always told the
+        truth. The peer used to get one exit code for both, and inventing
+        "not found" out of it is a claim we have no evidence for. It is the
+        same ``DockerService`` on both now, so it cannot answer differently.
+
+        Which node this is about is carried by the rank record rather than by
+        the error string; the string is the daemon's own words, which is what
+        an operator wants to read.
         """
         service = tools.node_service.NodeServices().for_address(PEERS[0])
-        fleet.daemon_down_hosts.add(PEERS[0])
+        fleet.daemon_down.add(PEERS[0])
 
         state = service.get_container_status("spark-pulse-anything-r1-g1")
 
         assert state["status"] == "unknown"
         assert state["running"] is False
-        assert PEERS[0] in state["error"]
-        assert "unknown" in state["error"]
+        assert "Cannot connect to the Docker daemon" in state["error"]
         # And it must not claim the container is absent, which is the sentence
         # the old code wrote for exactly this case.
         assert "not found" not in state["error"]
@@ -856,42 +875,44 @@ class TestRankStateIsThreeStates:
         assert state["status"] == "missing"
         assert state["running"] is False
 
-    def test_the_signal_is_the_daemon_probe_and_not_the_stderr_text(self, fleet):
-        """What the branch actually reads.
+    def test_the_signal_is_structural_and_costs_no_second_command(self, fleet):
+        """What the branch reads, and what it no longer has to guess.
 
-        Both cases arrive as exit 1 with different English. The decision is
-        taken on a second command — ``docker version``, which reports the
-        *server* version and so exits zero only when a daemon answered — and
-        this asserts that command is the one that gets asked.
+        These two cases used to arrive identically — exit 1 with different
+        English — so telling them apart meant a *second* command asking the
+        daemon for its server version, and a substring match on the first. The
+        answer now carries which it is: a missing container is a value, a
+        refusing daemon is a raised failure. One operation either way.
         """
         service = tools.node_service.NodeServices().for_address(PEERS[0])
-        fleet.commands.clear()
+        fleet.calls.clear()
 
-        service.get_container_status("spark-pulse-never-existed-r1-g1")
+        gone = service.get_container_status("spark-pulse-never-existed-r1-g1")
+        assert gone["status"] == "missing"
+        assert fleet.operations_on(PEERS[0]) == ["get_container_status"]
 
-        asked = [c["command"] for c in fleet.commands if c["host"] == PEERS[0]]
-        assert asked[0].startswith("docker inspect")
-        assert asked[1] == tools.node_service.DAEMON_PROBE_COMMAND
+        fleet.calls.clear()
+        fleet.daemon_down.add(PEERS[0])
+        refused = service.get_container_status("spark-pulse-never-existed-r1-g1")
+        assert refused["status"] == "unknown"
+        assert fleet.operations_on(PEERS[0]) == ["get_container_status"]
 
     def test_a_healthy_rank_costs_no_extra_round_trip(self, fleet):
         """The daemon probe runs on the failure path and nowhere else."""
         nr.start(plan_for(2), wait=True)
-        fleet.commands.clear()
+        fleet.calls.clear()
 
         nr.status("dep2")
 
-        asked = [c["command"] for c in fleet.commands if c["host"] == PEERS[0]]
-        # One inspect, carrying both the state and the container id — the same
-        # two facts the SDK path returns from one call.
-        assert asked == [
-            "docker inspect --format '{{json .State}}\t{{.Id}}' "
-            "spark-pulse-dep2-r1-g1"
-        ]
+        # One question, carrying the state and the container id together.
+        assert fleet.operations_on(PEERS[0]) == ["get_container_status"]
+        asked = [c["args"] for c in fleet.calls if c["host"] == PEERS[0]]
+        assert asked == [("spark-pulse-dep2-r1-g1",)]
 
     def test_a_rank_whose_daemon_died_reads_unknown_not_stopped(self, fleet):
         """End to end, through the endpoint's own code path."""
         nr.start(plan_for(3), wait=True)
-        fleet.daemon_down_hosts.add(PEERS[0])
+        fleet.daemon_down.add(PEERS[0])
 
         live = nr.status("dep3")
 
@@ -914,7 +935,7 @@ class TestRankStateIsThreeStates:
         held = {record["port"], record["rendezvous_port"]}
 
         # Rank 1's node goes away mid-teardown, so its rank is outstanding.
-        fleet.fail_hosts.add(PEERS[0])
+        fleet.unreachable.add(PEERS[0])
         nr.stop_deployment("dep3")
         assert [o["node"] for o in nr.get_deployment("dep3")["orphans"]] == [PEERS[0]]
         assert held <= nr._ports_in_use()
@@ -922,9 +943,9 @@ class TestRankStateIsThreeStates:
         # The node comes back and its container really is gone — but its
         # Docker daemon is not answering, so we cannot know that, and the
         # whole point is that we do not guess.
-        fleet.fail_hosts.discard(PEERS[0])
-        fleet.containers_on(PEERS[0]).clear()
-        fleet.daemon_down_hosts.add(PEERS[0])
+        fleet.unreachable.discard(PEERS[0])
+        peer_docker(fleet, PEERS[0]).client.containers._containers.clear()
+        fleet.daemon_down.add(PEERS[0])
 
         assert nr.sweep_orphans("dep3") == 0
         assert [o["node"] for o in nr.get_deployment("dep3")["orphans"]] == [PEERS[0]]
@@ -933,7 +954,7 @@ class TestRankStateIsThreeStates:
         # Once a daemon answers, the same absence becomes evidence and the
         # ports are released — on evidence, which is the only way they ever
         # should be.
-        fleet.daemon_down_hosts.discard(PEERS[0])
+        fleet.daemon_down.discard(PEERS[0])
 
         assert nr.sweep_orphans("dep3") == 1
         assert nr.get_deployment("dep3")["orphans"] == []
@@ -942,7 +963,7 @@ class TestRankStateIsThreeStates:
     def test_a_teardown_against_a_dead_daemon_leaves_an_orphan(self, fleet):
         """Stopping a rank we cannot confirm gone must not read as success."""
         nr.start(plan_for(3), wait=True)
-        fleet.daemon_down_hosts.add(PEERS[0])
+        fleet.daemon_down.add(PEERS[0])
 
         # The confirmation window is shortened only so the test does not sit
         # through it: the point is that it expires without evidence, not how
@@ -962,25 +983,22 @@ class TestOneSilentRankDoesNotStallTheRest:
         """Three silent peers cost one stall, not three.
 
         The simulated transport answers instantly, so the stall is injected
-        here: every peer sleeps and then raises the same ``SSHError`` the real
-        client raises on ssh's exit 255. Serially that is three sleeps; the
-        assertion is that it is nearer one.
+        here: every peer's Docker sleeps and then the node is declared
+        unreachable, which is what a real deadline expiring produces. Serially
+        that is three sleeps; the assertion is that it is nearer one.
         """
         nr.start(plan_for(4), wait=True)
         stall = 0.4
-        original_exec = fleet.exec
 
-        def _silent_peer(host, command, *args, **kwargs):
-            if host in PEERS:
-                time.sleep(stall)
-                raise SSHError(
-                    error_type=SSHErrorType.TIMEOUT,
-                    host=host,
-                    message=f"Command timed out after {stall}s",
-                )
-            return original_exec(host, command, *args, **kwargs)
+        def _silent(*_args, **_kwargs):
+            time.sleep(stall)
+            raise NodeUnreachable(PEERS[0])
 
-        with patch.object(fleet, "exec", _silent_peer):
+        patches = [
+            patch.object(peer_docker(fleet, host), "get_container_status", _silent)
+            for host in PEERS
+        ]
+        with patches[0], patches[1], patches[2]:
             began = time.monotonic()
             live = nr.status("dep4")
             elapsed = time.monotonic() - began
@@ -996,7 +1014,7 @@ class TestOneSilentRankDoesNotStallTheRest:
     ):
         """A dead node marks its own rank; it does not fail the request."""
         nr.start(plan_for(4), wait=True)
-        fleet.fail_hosts.add(PEERS[1])
+        fleet.unreachable.add(PEERS[1])
 
         live = nr.status("dep4")
 

--- a/tests/test_tools_images.py
+++ b/tests/test_tools_images.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import ast
 import importlib
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -29,53 +29,70 @@ from spark_pulse.mock.docker import (  # noqa: E402
     MockDockerService,
 )
 from spark_pulse.mock import registry as mock_registry  # noqa: E402
-from spark_pulse.mock.node_service import (  # noqa: E402
-    NodeServices,
-    SimulatedDockerSSHClient,
-)
-from spark_pulse.tools.ssh import SSHClient, SSHResult  # noqa: E402
+from spark_pulse.mock import node_service as mock_node_service  # noqa: E402
+from spark_pulse.mock.node_service import NodeServices  # noqa: E402
 
 VLLM_REPO = "ghcr.io/kharkevich-engineering-lab/spark-pulse-engine/vllm"
 VLLM_REF = f"{VLLM_REPO}:0.1.0"
 
 
-class _RecordingSSHClient(SSHClient):
-    """SSH double answering like ``docker image inspect`` on a remote node."""
-
-    def __init__(self, ids: dict[str, str] | None = None):
-        self.execs: list[tuple[str, str]] = []
-        self._ids = ids or {}
-
-    def exec(self, host, command, timeout=30, batch_mode=True):
-        self.execs.append((host, command))
-        image_id = self._ids.get(host, "")
-        if not image_id:
-            return SSHResult(returncode=1, stdout="", stderr="No such image")
-        return SSHResult(returncode=0, stdout=f"{image_id}\n", stderr="")
-
-
 @dataclass
 class _Cluster:
-    """The simulated other machines, and this machine's own registry."""
+    """The simulated other machines, and this machine's own registry.
 
-    ssh: SimulatedDockerSSHClient
+    Each node has its own container service, so "n1 pulled and n2 did not" is
+    a fact about two different stores rather than a filter over one command
+    log. That distinction is why the old shared-daemon simulation could not
+    have caught a distribution bug: every node's answer came from the same
+    place.
+    """
+
     services: Any
     registry: Any
+    pulls: dict[str, list[str]] = field(default_factory=dict)
+
+    def docker(self, host: str) -> Any:
+        """The simulated Docker belonging to one node, recording its pulls."""
+        docker = mock_node_service.docker_for(mock_node_service.peer_node(host))
+        if host not in self.pulls:
+            self.pulls[host] = []
+            original = docker.pull_image
+
+            def _record(ref, *args, **kwargs):
+                self.pulls[host].append(ref)
+                return original(ref, *args, **kwargs)
+
+            docker.pull_image = _record
+        return docker
 
     def fail(self, host: str) -> None:
-        """Make every command on ``host`` fail, as an unreachable node would."""
-        self.ssh.fail_hosts.add(host)
+        """Make that node unreachable, as a node with no agent would be."""
 
-    def commands(self, needle: str) -> list[str]:
-        """Every command sent to a node containing ``needle``."""
-        return [c["command"] for c in self.ssh.commands if needle in c["command"]]
+        def _unreachable(*_args, **_kwargs):
+            raise RuntimeError(f"node {host} is unreachable (not_connected)")
+
+        docker = self.docker(host)
+        docker.image_info = _unreachable
+        docker.pull_image = _unreachable
+
+    def pulled(self, host: str) -> list[str]:
+        """Every image reference this node was asked to pull."""
+        self.docker(host)
+        return list(self.pulls.get(host, []))
 
 
 @pytest.fixture
 def nodes():
-    """Node services over a simulated SSH transport, plus the local registry."""
-    ssh = SimulatedDockerSSHClient()
-    return _Cluster(ssh, NodeServices(ssh_client=ssh), mock_registry.default_registry())
+    """One simulated container service per node, plus the local registry."""
+    mock_node_service.reset()
+    cluster = _Cluster(None, mock_registry.default_registry())
+    cluster.services = NodeServices(
+        resolver=lambda node, **_kwargs: cluster.docker(node.address or node.id)
+    )
+    try:
+        yield cluster
+    finally:
+        mock_node_service.reset()
 
 
 @pytest.fixture
@@ -405,18 +422,16 @@ class TestSync:
 
         assert result["ok"] is True
         assert [r["skipped"] for r in result["results"]] == [False, False]
-        pulls = nodes.commands("docker pull")
-        assert len(pulls) == 2
-        assert all(result["pull_ref"] in command for command in pulls)
+        assert nodes.pulled("n1") == nodes.pulled("n2") == [result["pull_ref"]]
 
     def test_a_node_that_already_has_it_is_skipped(self, catalogue, nodes):
         images.sync_to_nodes(VLLM_REF, ["n1", "n2"], services=nodes.services)
-        before = len(nodes.commands("docker pull"))
+        before = len(nodes.pulled("n1")) + len(nodes.pulled("n2"))
 
         again = images.sync_to_nodes(VLLM_REF, ["n1", "n2"], services=nodes.services)
 
         assert [r["skipped"] for r in again["results"]] == [True, True]
-        assert len(nodes.commands("docker pull")) == before
+        assert len(nodes.pulled("n1")) + len(nodes.pulled("n2")) == before
 
     def test_nodes_receive_no_credentials(self, catalogue, nodes, monkeypatch):
         """The credential authenticates the control node's fetch, nothing else."""
@@ -428,9 +443,11 @@ class TestSync:
         result = images.sync_to_nodes(VLLM_REF, ["n1"], services=nodes.services)
 
         assert result["nodes_need_credentials"] is False
-        for entry in nodes.ssh.commands:
-            assert "s3cr3t" not in entry["command"]
-            assert "ci-bot" not in entry["command"]
+        # What a node is asked to pull is the whole of what it is told, and it
+        # is anonymous: no credential is a component of it.
+        for ref in nodes.pulled("n1"):
+            assert "s3cr3t" not in ref
+            assert "ci-bot" not in ref
         # It is used, though — on this machine, for the copy from upstream.
         copies = [c for c in nodes.registry.commands if c[:2] == ["skopeo", "copy"]]
         assert any("ci-bot:s3cr3t" in " ".join(argv) for argv in copies)
@@ -475,14 +492,28 @@ class TestSync:
         with pytest.raises(ValueError):
             images.sync_to_nodes(VLLM_REF, [])
 
-    def test_presence_reports_matching_ids(self, catalogue):
+    def test_presence_reports_matching_ids(self, catalogue, nodes):
+        """Same id is a match; a different id is present and not a match."""
         local_id = catalogue.image_info(VLLM_REF)["id"]
-        ssh = _RecordingSSHClient({"n1": local_id, "n2": "sha256:other"})
+        nodes.docker("n1").image_info = lambda _ref: {"id": local_id}
+        nodes.docker("n2").image_info = lambda _ref: {"id": "sha256:other"}
 
-        result = images.presence(VLLM_REF, ["n1", "n2"], client=ssh)
+        result = images.presence(VLLM_REF, ["n1", "n2"], services=nodes.services)
 
         assert result["local"] is True
         by_node = {r["node"]: r for r in result["nodes"]}
         assert by_node["n1"]["matches"] is True
         assert by_node["n2"]["present"] is True
         assert by_node["n2"]["matches"] is False
+
+    def test_presence_reports_a_node_it_could_not_ask_as_an_error(
+        self, catalogue, nodes
+    ):
+        """Not as absent. "We could not ask" is not "it is not there"."""
+        nodes.fail("n2")
+
+        result = images.presence(VLLM_REF, ["n1", "n2"], services=nodes.services)
+
+        by_node = {r["node"]: r for r in result["nodes"]}
+        assert by_node["n2"]["present"] is False
+        assert "unreachable" in by_node["n2"]["error"]

--- a/tests/test_tools_launch_script.py
+++ b/tests/test_tools_launch_script.py
@@ -6,7 +6,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from unittest.mock import MagicMock
 
 from spark_pulse.tools.launch_script import (
     LaunchScriptManager,
@@ -268,10 +267,11 @@ class TestLaunchScriptDistributor:
             address = node.address or node.id
 
             class _Service:
-                def exec_in_container(
-                    self, container, command, detach=False, timeout=None
+                def copy_to_container(
+                    self, container, local_path, remote_path, timeout=120
                 ):
-                    calls.append((address, container, list(command)))
+                    calls.append((address, container, local_path, remote_path))
+                    return True
 
             return _Service()
 
@@ -282,8 +282,7 @@ class TestLaunchScriptDistributor:
 
     def test_a_worker_script_is_copied_inside_the_worker(self):
         services = self._Services()
-        ssh = MagicMock()
-        distributor = LaunchScriptDistributor(ssh_client=ssh, services=services)
+        distributor = LaunchScriptDistributor(services=services)
 
         distributor.deploy_to_node(
             node=self._Node("10.0.0.2", "worker"),
@@ -295,12 +294,19 @@ class TestLaunchScriptDistributor:
             (
                 "10.0.0.2",
                 "worker-container",
-                ["cp", "/tmp/exec-script.sh", "/workspace/exec-script.sh"],
+                "/tmp/patched.sh",
+                "/workspace/exec-script.sh",
             )
         ]
-        assert ssh.copy.call_args.kwargs["host"] == "10.0.0.2"
 
-    def test_a_local_head_needs_no_ssh(self):
+    def test_the_head_takes_the_very_same_path(self):
+        """One code path, and the head is not the exception it used to be.
+
+        The branch this replaces copied from ``/tmp/exec-script.sh`` *inside*
+        the head's container — a path nothing had put a script at — so the
+        head's script only ever arrived if a previous deploy had left one
+        there.
+        """
         services = self._Services()
         distributor = LaunchScriptDistributor(services=services)
 
@@ -311,7 +317,14 @@ class TestLaunchScriptDistributor:
         )
 
         assert services.nodes[0].is_self is True
-        assert services.calls[0][1] == "head-container"
+        assert services.calls == [
+            (
+                "127.0.0.1",
+                "head-container",
+                "/tmp/patched.sh",
+                "/workspace/exec-script.sh",
+            )
+        ]
 
 
 class TestValidateModContent:

--- a/tests/test_tools_node_service.py
+++ b/tests/test_tools_node_service.py
@@ -1,28 +1,37 @@
-"""Tests for the node-bound container service.
+"""Tests for the node-bound container service's *boundary*.
 
-The service used to take a host as the first argument of every method, where
-an empty string meant "this node". Thirteen call sites passed that empty
-string, so operations aimed at a worker ran against the control plane's own
-Docker daemon. The node is now fixed at construction, and these tests pin the
-two properties that make the mistake unrepresentable:
+The behaviour of a service — all fifteen methods, on both a self node and a
+peer, against every implementation — is under contract in
+``tests/test_container_service_contract.py``. What is left here is the part
+that file cannot exercise: how a :class:`Node` is decided, how one is turned
+into a service, and what happens when it cannot be.
 
-* a service built for a peer never touches the local daemon, and
-* a service built for the control node never shells out to ssh.
+The property the module exists to keep is unchanged, and the shape that
+guarantees it is stronger than it was. The service used to take a host as the
+first argument of every method with an empty string meaning "this node";
+thirteen call sites passed that empty string, so operations aimed at a worker
+ran against the control plane's own Docker daemon. Fixing the node at
+construction removed the argument. Removing the docker-over-SSH service —
+which had a local branch inside it — removed the last place where "this node"
+could be substituted for another one, because there is no longer any code that
+chooses between them.
+
+So the resolver now has exactly two outcomes: the service bound to a node's
+agent, or a named refusal. Never a quietly wrong daemon.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
 
 import pytest
 
-from spark_pulse.mock.node_service import SimulatedDockerSSHClient
-from spark_pulse.tools.docker import ContainerInfo, ContainerMetadata
+from spark_pulse.agent.runtime import ControlPlaneRuntime, use
+from spark_pulse.agent.sync_service import AgentNodeService
 from spark_pulse.tools.node_service import (
-    NODE_SERVICE_METHODS,
+    NoAgent,
     Node,
     NodeServices,
-    RemoteNodeService,
     control_node,
     is_local_address,
     node_for,
@@ -45,41 +54,13 @@ def _fresh_local_addresses():
     reset_local_addresses()
 
 
-def _metadata(name: str) -> ContainerMetadata:
-    return ContainerMetadata(deployment=name, image=IMAGE, mode="cluster")
-
-
-def _forbidden_local() -> MagicMock:
-    """A local Docker service that fails the test if anything reaches it."""
-    local = MagicMock(name="local DockerService")
-    for method in NODE_SERVICE_METHODS:
-        getattr(local, method).side_effect = AssertionError(
-            f"a peer-bound service called the local daemon's {method}"
-        )
-    return local
-
-
-def _forbidden_ssh() -> MagicMock:
-    """An SSH client that fails the test if anything shells out."""
-    ssh = MagicMock(name="SSHClient")
-    ssh.exec.side_effect = AssertionError("a self-bound service shelled out to ssh")
-    ssh.copy.side_effect = AssertionError("a self-bound service scp'd")
-    return ssh
-
-
-def _peer_service(address: str = PEER, ssh=None) -> RemoteNodeService:
-    """A service bound to a peer, with a local daemon that must go untouched."""
-    return RemoteNodeService(
-        peer_node(address),
-        ssh_client=ssh or SimulatedDockerSSHClient(images={IMAGE: 10}),
-        docker_service=_forbidden_local(),
-    )
+# ── The node record ─────────────────────────────────────────────────────────
 
 
 class TestNodeRecord:
-    """The minimal node record, and who counts as "us"."""
+    """A node is decided once, here, so no caller has to ask "is that us?"."""
 
-    @pytest.mark.parametrize("address", ["", "localhost", "127.0.0.1", "::1"])
+    @pytest.mark.parametrize("address", ["", "127.0.0.1", "localhost", "::1"])
     def test_loopback_is_this_machine(self, address):
         assert is_local_address(address) is True
 
@@ -89,214 +70,86 @@ class TestNodeRecord:
     def test_node_for_resolves_loopback_to_the_control_node(self):
         node = node_for("127.0.0.1")
         assert node.is_self is True
-        assert node.id == "control"
+        assert node.address == "127.0.0.1"
 
     def test_node_for_resolves_a_peer_to_a_peer(self):
         node = node_for(PEER, ssh_user="spark")
         assert node.is_self is False
-        assert node.address == PEER
+        assert node.id == PEER
         assert node.ssh_user == "spark"
 
     def test_an_empty_address_can_never_be_a_peer(self):
-        """The old local sentinel must not become an ssh attempt to ""."""
+        """The old local sentinel. A stray "" must not become a machine."""
         with pytest.raises(ValueError):
             peer_node("")
 
     def test_a_node_carries_its_interfaces(self):
-        node = Node(id="w1", address=PEER, interfaces=("eth0", "ib0"))
-        assert node.interfaces == ("eth0", "ib0")
-        assert node.label == PEER
+        node = peer_node(PEER, interfaces=("rocep1s0f1", "roceP2p1s0f1"))
+        assert node.interfaces == ("rocep1s0f1", "roceP2p1s0f1")
+
+    def test_the_label_prefers_an_address_over_an_opaque_id(self):
+        """It goes in error messages, and a uuid tells an operator nothing."""
+        assert peer_node(PEER, node_id="0f3c…").label == PEER
+        assert Node(id="0f3c…").label == "0f3c…"
 
 
-class TestPeerNeverTouchesTheLocalDaemon:
-    """Everything a peer-bound service does leaves this machine."""
-
-    def test_run_container_goes_over_ssh(self):
-        ssh = SimulatedDockerSSHClient(images={IMAGE: 10})
-        service = _peer_service(ssh=ssh)
-
-        info = service.run_container(
-            image=IMAGE,
-            name="cluster-worker-0",
-            env_vars={"NCCL_SOCKET_IFNAME": "eth0"},
-            metadata=_metadata("cluster"),
-        )
-
-        assert isinstance(info, ContainerInfo)
-        assert [c["host"] for c in ssh.commands] == [PEER]
-        assert "docker run" in ssh.commands[0]["command"]
-        assert "--label" in ssh.commands[0]["command"]
-
-    @pytest.mark.parametrize(
-        "call",
-        [
-            lambda s: s.stop_container("cluster-worker-0"),
-            lambda s: s.get_container_status("cluster-worker-0"),
-            lambda s: s.exec_in_container("cluster-worker-0", ["ray", "status"]),
-            lambda s: s.list_managed_containers(),
-            lambda s: s.get_logs("cluster-worker-0"),
-            lambda s: s.image_exists(IMAGE),
-            lambda s: s.image_info(IMAGE),
-            lambda s: s.list_images(),
-        ],
-        ids=[
-            "stop",
-            "status",
-            "exec",
-            "list",
-            "logs",
-            "image_exists",
-            "image_info",
-            "list_images",
-        ],
-    )
-    def test_every_read_and_write_reaches_the_peer(self, call):
-        """The whole surface, not just the one method somebody remembered."""
-        ssh = SimulatedDockerSSHClient(images={IMAGE: 10})
-        service = _peer_service(ssh=ssh)
-
-        call(service)
-
-        assert ssh.hosts_seen() == [PEER]
-
-    def test_copy_to_container_stages_on_the_peer(self, tmp_path):
-        payload = tmp_path / "run.sh"
-        payload.write_text("echo hi\n")
-        ssh = SimulatedDockerSSHClient(images={IMAGE: 10})
-        service = _peer_service(ssh=ssh)
-        service.run_container(
-            image=IMAGE,
-            name="worker",
-            env_vars={},
-            metadata=_metadata("cluster"),
-        )
-
-        assert service.copy_to_container("worker", str(payload), "/workspace/run.sh")
-
-        assert [c["host"] for c in ssh.copies] == [PEER]
-        assert any("docker cp" in c["command"] for c in ssh.commands)
-
-    def test_reaching_for_the_local_daemon_is_an_error(self):
-        """A peer has no local Docker daemon, and asking says so."""
-        service = _peer_service()
-        with pytest.raises(RuntimeError, match="peer"):
-            _ = service._local
-
-
-class TestExecOnAPeerLeavesTheMachine:
-    """The regression test for the defect itself.
-
-    On the old code every one of these ran against the control node, because
-    the host argument defaulted to the empty string and the callers took the
-    default. Here the service is bound to a worker, so an exec that does not
-    reach that worker fails.
-    """
-
-    def test_ray_start_on_a_worker_is_seen_by_that_worker(self):
-        ssh = SimulatedDockerSSHClient()
-        service = _peer_service(ssh=ssh)
-        service.run_container(
-            image=IMAGE, name="c-worker-0", env_vars={}, metadata=_metadata("c")
-        )
-
-        service.exec_in_container(
-            "c-worker-0", ["ray", "start", "--address", "10.0.0.1:29501"]
-        )
-
-        execs = [c for c in ssh.commands if c["command"].startswith("docker exec")]
-        assert len(execs) == 1
-        assert execs[0]["host"] == PEER
-        assert "ray start" in execs[0]["command"]
-
-    def test_two_peers_do_not_share_a_container_store(self):
-        """The property the empty host destroyed: nodes are separate."""
-        ssh = SimulatedDockerSSHClient()
-        first = _peer_service(PEER, ssh=ssh)
-        second = _peer_service(OTHER_PEER, ssh=ssh)
-
-        first.run_container(
-            image=IMAGE, name="only-on-first", env_vars={}, metadata=_metadata("c")
-        )
-
-        assert [c.name for c in first.list_managed_containers()] == ["only-on-first"]
-        assert second.list_managed_containers() == []
-
-
-class TestControlNodeNeverShellsOut:
-    """A service bound to this machine uses the SDK and nothing else."""
-
-    def _service(self, local) -> RemoteNodeService:
-        return RemoteNodeService(
-            control_node(address="127.0.0.1"),
-            ssh_client=_forbidden_ssh(),
-            docker_service=local,
-        )
-
-    def test_is_local_is_true(self):
-        assert self._service(MagicMock()).is_local is True
-
-    @pytest.mark.parametrize(
-        "call,method",
-        [
-            (lambda s: s.stop_container("c"), "stop_container"),
-            (lambda s: s.get_container_status("c"), "get_container_status"),
-            (lambda s: s.exec_in_container("c", ["ray"]), "exec_in_container"),
-            (lambda s: s.list_managed_containers(), "list_managed_containers"),
-            (lambda s: s.get_logs("c"), "get_logs"),
-            (lambda s: s.image_exists(IMAGE), "image_exists"),
-            (lambda s: s.image_info(IMAGE), "image_info"),
-            (lambda s: s.list_images(), "list_images"),
-            (lambda s: s.remove_image(IMAGE), "remove_image"),
-            (
-                lambda s: s.get_container_by_deployment("d"),
-                "get_container_by_deployment",
-            ),
-            (lambda s: s.get_container_by_recipe("r"), "get_container_by_recipe"),
-        ],
-        ids=lambda value: value if isinstance(value, str) else "",
-    )
-    def test_every_call_goes_to_the_sdk(self, call, method):
-        local = MagicMock(name="DockerService")
-        service = self._service(local)
-
-        call(service)
-
-        assert getattr(local, method).called
-
-    def test_pull_keeps_the_sdk_progress_contract(self):
-        """Cancel and the stall watchdog survive the local branch."""
-        local = MagicMock(name="DockerService")
-        service = self._service(local)
-        cancel = object()
-
-        service.pull_image("ref", None, interval=3, cancel=cancel, stall_timeout=7)
-
-        _, kwargs = local.pull_image.call_args
-        assert kwargs == {"interval": 3, "cancel": cancel, "stall_timeout": 7}
-
-    def test_reaching_for_ssh_is_an_error(self):
-        service = self._service(MagicMock())
-        with pytest.raises(RuntimeError, match="not reached over SSH"):
-            _ = service._ssh
+# ── The resolver ────────────────────────────────────────────────────────────
 
 
 class TestResolver:
-    """``service_for`` binds a node to an implementation, once."""
+    """``service_for`` binds a node to its agent, once, or refuses by name."""
 
-    def test_a_peer_gets_the_remote_service(self):
-        service = service_for(peer_node(PEER))
-        assert isinstance(service, RemoteNodeService)
-        assert service.node.address == PEER
+    def test_a_node_resolves_to_a_service_over_its_agent(
+        self, agent_server, agent_node
+    ):
+        runtime = ControlPlaneRuntime(agent_server, asyncio.get_event_loop())
+        with use(runtime):
+            service = service_for(Node(id=agent_node.node_id, address=PEER))
 
-    def test_the_control_node_gets_the_local_docker_service(self):
-        from spark_pulse.tools.docker import DockerService
+        assert isinstance(service, AgentNodeService)
+        assert service.node_id == agent_node.node_id
 
-        service = service_for(control_node())
-        assert isinstance(service, DockerService)
+    def test_the_control_node_resolves_the_same_way_a_peer_does(
+        self, agent_server, agent_node
+    ):
+        """Not a special case, and not a different class.
 
-    def test_the_control_node_shares_one_service(self):
-        """One DockerService process-wide, thread-local clients underneath."""
-        assert service_for(control_node()) is service_for(control_node())
+        This process runs an agent for itself and reaches it over loopback.
+        There is no local branch here — which matters because the local branch
+        of the service this replaced was never once executed by a test.
+        """
+
+        class Local:
+            node_id = agent_node.node_id
+
+        runtime = ControlPlaneRuntime(agent_server, asyncio.get_event_loop())
+        runtime.local = Local()
+        with use(runtime):
+            mine = service_for(control_node())
+            theirs = service_for(Node(id=agent_node.node_id, address=PEER))
+
+        assert type(mine) is type(theirs) is AgentNodeService
+
+    def test_a_node_with_no_agent_is_refused_by_name(self, agent_server):
+        """Never a fallback. A fallback here reads the wrong machine."""
+        runtime = ControlPlaneRuntime(agent_server, asyncio.get_event_loop())
+        with use(runtime), pytest.raises(NoAgent) as caught:
+            service_for(peer_node(PEER))
+
+        assert PEER in str(caught.value)
+
+    def test_resolving_before_the_transport_is_up_says_so(self):
+        """A startup-ordering bug, named as one rather than as a missing node."""
+        with use(None), pytest.raises(NoAgent) as caught:
+            service_for(peer_node(PEER))
+
+        assert "not running" in str(caught.value)
+
+    def test_a_pinned_service_skips_resolution_entirely(self):
+        """For a caller that already holds one. Never used as a fallback."""
+        sentinel = object()
+        with use(None):
+            assert service_for(peer_node(PEER), docker_service=sentinel) is sentinel
 
     def test_simulation_resolves_to_the_mock(self):
         from spark_pulse.mock.docker import MockDockerService
@@ -304,8 +157,34 @@ class TestResolver:
 
         assert isinstance(mock_service_for(control_node()), MockDockerService)
 
+    def test_simulation_gives_every_peer_its_own_docker(self):
+        """One daemon for all nodes is how a wrong answer looks plausible."""
+        from spark_pulse.mock import node_service as mock_node_service
+
+        mock_node_service.reset()
+        try:
+            first = mock_node_service.docker_for(peer_node(PEER))
+            again = mock_node_service.docker_for(peer_node(PEER))
+            other = mock_node_service.docker_for(peer_node(OTHER_PEER))
+
+            assert first is again
+            assert first is not other
+            assert mock_node_service.docker_for(control_node()) is not first
+        finally:
+            mock_node_service.reset()
+
+
+class TestResolverCache:
+    """Callers act on several nodes, so they hold a resolver, not a service."""
+
     def test_the_cache_hands_back_one_service_per_node(self):
-        services = NodeServices()
+        built: dict[str, object] = {}
+
+        def resolver(node, **_kwargs):
+            built.setdefault(node.id, object())
+            return built[node.id]
+
+        services = NodeServices(resolver=resolver)
 
         first = services(peer_node(PEER))
         again = services(peer_node(PEER))
@@ -314,13 +193,32 @@ class TestResolver:
         assert first is again
         assert first is not other
 
-    def test_for_address_routes_loopback_home_and_peers_out(self):
-        from spark_pulse.tools.docker import DockerService
+    def test_for_address_decides_self_versus_peer_once(self):
+        seen: list[Node] = []
 
-        services = NodeServices()
+        def resolver(node, **_kwargs):
+            seen.append(node)
+            return object()
 
-        assert isinstance(services.for_address("127.0.0.1"), DockerService)
-        assert isinstance(services.for_address(PEER), RemoteNodeService)
+        services = NodeServices(resolver=resolver)
+        services.for_address("127.0.0.1")
+        services.for_address(PEER)
+
+        assert [node.is_self for node in seen] == [True, False]
+
+    def test_control_asks_for_the_machine_this_process_runs_on(self):
+        seen: list[Node] = []
+
+        def resolver(node, **_kwargs):
+            seen.append(node)
+            return object()
+
+        NodeServices(resolver=resolver).control()
+
+        assert seen[0].is_self is True
+
+
+# ── The untyped config blob ─────────────────────────────────────────────────
 
 
 class TestDockerConfigMapping:
@@ -354,59 +252,3 @@ class TestDockerConfigMapping:
 
     def test_an_empty_config_still_yields_the_defaults(self):
         assert run_kwargs_from_docker_config(None)["privileged"] is True
-
-
-def _self_service() -> RemoteNodeService:
-    """A service bound to this machine, which must never shell out."""
-    return RemoteNodeService(
-        control_node(address="127.0.0.1"),
-        ssh_client=_forbidden_ssh(),
-        docker_service=MagicMock(),
-    )
-
-
-class TestEnsureDirectories:
-    """Bind sources are created before the container, on whichever node it is.
-
-    Docker invents a missing bind source **owned by root**, and every path we
-    mount is one of the login user's caches — so a directory that does not
-    exist yet is how ``~/.cache/huggingface`` becomes unwritable and the model
-    copy fails afterwards. ``launch-cluster.sh`` does the same ``mkdir -p``,
-    locally at line 1094 and over SSH at line 1104.
-    """
-
-    def test_a_peer_is_asked_over_ssh(self):
-        ssh = SimulatedDockerSSHClient(images={IMAGE: 10})
-        service = _peer_service(ssh=ssh)
-
-        assert service.ensure_directories(["/home/spark/.cache/vllm", "/x y"]) == []
-
-        assert [c["host"] for c in ssh.commands] == [PEER]
-        command = ssh.commands[0]["command"]
-        assert command.startswith("mkdir -p ")
-        # Quoted, because a path with a space is one path, not two.
-        assert "'/x y'" in command
-
-    def test_the_control_node_makes_them_here(self, tmp_path):
-        target = tmp_path / "cache" / "vllm"
-
-        assert _self_service().ensure_directories([str(target)]) == []
-
-        assert target.is_dir()
-
-    def test_an_empty_list_asks_nothing_of_anyone(self):
-        ssh = SimulatedDockerSSHClient(images={IMAGE: 10})
-        service = _peer_service(ssh=ssh)
-
-        assert service.ensure_directories([]) == []
-        assert service.ensure_directories(["", "  "]) == []
-
-        assert ssh.commands == []
-
-    def test_a_path_that_cannot_be_made_is_returned_not_raised(self, tmp_path):
-        """A failed mkdir is a warning: docker will still start the container."""
-        blocker = tmp_path / "file"
-        blocker.write_text("not a directory")
-        under = str(blocker / "under")
-
-        assert _self_service().ensure_directories([under]) == [under]


### PR DESCRIPTION
Step 2 of the three follow-ups, stacked on #34.

`service_for()` now resolves a node to a service **over that node's agent**, and `RemoteNodeService` — the docker-CLI-over-SSH implementation, ~900 lines — is gone. So is the local/peer branch inside it: this process runs an agent for itself and reaches it over loopback, so the control node is not a special case and there is **no local branch left to go untested**. That branch going untested is what made the thirteen call sites in `docs/transport-reexamined.md` §5.1 invisible in the first place.

The resolver has two outcomes now: the service, or `NoAgent`. Never a quiet fallback to the control plane's own daemon — which is exactly what those thirteen call sites were.

## What landed here

**`AgentNodeService`** — the synchronous face of `NodeOperations`. It builds no commands and parses no results; a second hand-written client is the arrangement §5.1 measured at thirty divergences. `NodeUnreachable` and `NodeOperationError` cross it untouched. A small explicit table translates the failures that are part of the container service's *contract* (`PullCancelled`, `PullStalled`) because three call sites catch those by type. Called from a thread with a running loop it raises and names the mistake rather than deadlocking silently.

**Cancelling a pull travels.** `AgentHub.cancel_command` sends a Cancel *without* abandoning the await, so a cancelled pull comes back as a definite `PullCancelled` instead of being downgraded to "unknown" by our own giving up. A cancel that is already true when the call is made is refused up front — no bytes on the wire, and no race deciding what the caller sees.

**One identity per machine.** `mint_token(name, node_id=...)` lets the control plane pin the identity enrolment will mint, so `NodeRecord.id`, the ledger key and the agent's `node_id` are one string. The node still never proposes an identity.

**`app.lifespan` starts the transport** before anything asks about a container. Verified booting: the control node enrols under the registry's id, connects over loopback mTLS, and `service_for(control_node())` hands back an `AgentNodeService`.

**Three more callers stopped shelling out.** `LaunchScriptDistributor` had two paths, and the head branch copied from `/tmp/exec-script.sh` *inside the container*, where nothing had put anything — it could only ever have worked by accident. It is one `copy_to_container` call now. `images.presence` composed its own `docker image inspect` over ssh; it asks each node's service, and a node it could not ask is an error rather than reported absent. `images.sync_to_nodes` no longer takes an SSH client.

## The contract test

The agent joined it as the third implementation, driven from the main thread against a loop in another — production's arrangement — over a real TLS handshake, a real gRPC stream, the real codec and hub, into a fake SDK client. All fifteen methods, both nodes.

**Five of the seven documented divergences no longer exist**, because they were differences between the SDK and a second implementation of Docker: per-layer pull progress on a peer, per-path `ensure_directories` attribution, a label value with a comma surviving, exec-on-a-missing-container failing the same way, and an unreachable node being a *type* rather than an `SSHError` you had to remember to catch. `TestDivergencesThatNoLongerExist` asserts each one — "we removed the second implementation" is a claim, and an unchecked claim quietly stops being true.

## Simulation got smaller and more faithful

`SimulatedDockerSSHClient` and its docker-CLI parser are gone; a peer is a `MockDockerService` behind a wrapper that can fail the two ways a real node fails. Three fidelity gaps it was hiding are fixed:

- a fresh peer holds **no** images, so preflight's "this node has to pull 26 GB" is reachable again;
- a digest-pinned pull records **that** digest rather than the image's own id, so a seeded image is not re-pulled forever;
- a refusing daemon refuses at the **client**, as a real `docker.errors.APIError`, so `DockerService`'s own `unknown` branch runs instead of the substring fallback.

## Where SSH is left

Two places, both bootstrap: `agent/bootstrap*`, and `preflight`, which probes a candidate node *before* it has an agent.

One exception, stated plainly: **`tools/models.py` replication still copies model files over SSH.** It needs a protocol operation for bulk filesystem transfer rather than a rewire, so it is separate work, not something quietly left out.

## Gates

3122 pytest, 53 Playwright passing; black and ruff clean. No frontend file changed. Net **−1,189 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXcT5wARDv1Jcs3wGdTHe1