### PR TITLE
fix: a deleted deployment stays deleted, and a torn config is not an empty one

### DIFF
--- a/spark_pulse/mock/locking.py
+++ b/spark_pulse/mock/locking.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 
 from spark_pulse.tools.locking import (
     LockInfo,
     LockResult,
     LockType,
 )
+
+
+def default_lock_dir() -> str:
+    """Mirrors the real module's name. Simulation never writes a lock file,
+    but ``test_mock_contract`` requires every public name to have a twin."""
+    return str(Path.home() / ".local" / "share" / "spark-pulse" / "locks")
 
 
 class LockManager:

--- a/spark_pulse/tools/atomic_json.py
+++ b/spark_pulse/tools/atomic_json.py
@@ -33,6 +33,7 @@ from typing import Any
 __all__ = [
     "StateFileError",
     "write_json_atomic",
+    "write_text_atomic",
     "read_state_file",
     "quarantine_corrupt",
 ]
@@ -78,21 +79,21 @@ def _fsync_dir(directory: Path) -> None:
         os.close(dir_fd)
 
 
-def write_json_atomic(
-    path: Path | str,
-    data: Any,
-    *,
-    mode: int = 0o644,
-    indent: int | None = 2,
-    default: Any = None,
-) -> None:
-    """Write ``data`` as JSON to ``path`` atomically and durably.
+def write_text_atomic(path: Path | str, text: str, *, mode: int = 0o644) -> None:
+    """Write ``text`` to ``path`` atomically and durably.
 
-    The sequence is: temp file in the same directory, ``json.dump``, ``flush``,
+    The sequence is: temp file in the same directory, write, ``flush``,
     ``os.fsync`` on the file, ``chmod`` to ``mode``, ``os.replace``, then
     ``os.fsync`` on the directory. A reader either sees the previous complete
     file or the new complete file, never a truncated one, and no temp file is
     left behind on failure.
+
+    The text half exists because not every durable file here is JSON —
+    ``registries.yaml`` is YAML, and it was being written with a plain
+    truncating ``open(path, "w")``. YAML makes that worse rather than better:
+    a JSON file torn mid-write fails to parse and is *detected*, while a YAML
+    file torn mid-write usually still parses and yields a plausible wrong
+    value, and one truncated to nothing parses as empty.
     """
     path = Path(path)
     directory = path.parent
@@ -104,7 +105,7 @@ def write_json_atomic(
     tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "w") as handle:
-            json.dump(data, handle, indent=indent, default=default)
+            handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
         os.chmod(tmp_path, mode)
@@ -113,6 +114,27 @@ def write_json_atomic(
         tmp_path.unlink(missing_ok=True)
         raise
     _fsync_dir(directory)
+
+
+def write_json_atomic(
+    path: Path | str,
+    data: Any,
+    *,
+    mode: int = 0o644,
+    indent: int | None = 2,
+    default: Any = None,
+) -> None:
+    """Write ``data`` as JSON to ``path`` atomically and durably.
+
+    See :func:`write_text_atomic` for the sequence; this is that, with the
+    serialisation done first so a value that cannot be encoded raises before
+    anything on disk is touched.
+    """
+    write_text_atomic(
+        path,
+        json.dumps(data, indent=indent, default=default),
+        mode=mode,
+    )
 
 
 def quarantine_corrupt(path: Path | str) -> Path | None:

--- a/spark_pulse/tools/deployment_records.py
+++ b/spark_pulse/tools/deployment_records.py
@@ -26,6 +26,8 @@ import re
 import signal
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import threading
+from contextlib import AbstractContextManager
 from typing import Any
 
 from spark_pulse.config import RUNTIME_NATIVE, config
@@ -82,6 +84,37 @@ def load() -> list[dict[str, Any]]:
     return data
 
 
+#: Held across every read-modify-write of the record file.
+#:
+#: Each individual write is already atomic, which is a different guarantee and
+#: not the one that was missing: a reader never sees a torn file, but two
+#: threads that each *load, change, save* will still lose one of the changes,
+#: because the second writes back a list it read before the first landed.
+#:
+#: That is not theoretical here. A deploy runs its pull on a background thread
+#: which updates the record as it goes, while the API thread can delete the
+#: same deployment at any moment. The interleaving is:
+#:
+#:     pull thread   records = load()          # the deployment is in this list
+#:     API thread    delete_deployment(...)    # filters it out, saves. Gone.
+#:     pull thread   save(records)             # writes the deleted one back
+#:
+#: and it leaves a record with no container behind it — holding its port,
+#: listed in the UI, and deletable only by someone who notices. Reentrant
+#: because the mutating helpers call one another.
+_MUTATION_LOCK = threading.RLock()
+
+
+def transaction() -> AbstractContextManager[None]:
+    """Serialise a read-modify-write of the record file.
+
+    Every caller that loads records, changes them and saves them back must
+    hold this for the whole sequence — not merely around the save, which is
+    where the atomicity already is.
+    """
+    return _MUTATION_LOCK
+
+
 def save(records: list[dict[str, Any]]) -> None:
     """Persist the records: temp file, fsync, replace, directory fsync."""
     write_json_atomic(RECORDS_FILE, records, indent=2, default=str)
@@ -103,12 +136,13 @@ def get(deployment_id: str) -> dict[str, Any] | None:
 
 def delete(deployment_id: str) -> bool:
     """Drop a record. ``False`` when there was nothing to drop."""
-    records = load()
-    remaining = [r for r in records if r.get("id") != deployment_id]
-    if len(remaining) == len(records):
-        return False
-    save(remaining)
-    return True
+    with transaction():
+        records = load()
+        remaining = [r for r in records if r.get("id") != deployment_id]
+        if len(remaining) == len(records):
+            return False
+        save(remaining)
+        return True
 
 
 def purge_expired(records: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/spark_pulse/tools/locking.py
+++ b/spark_pulse/tools/locking.py
@@ -16,6 +16,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from spark_pulse.tools.atomic_json import write_json_atomic
+
 logger = logging.getLogger(__name__)
 
 
@@ -60,21 +62,44 @@ class LockInfo:
         }
 
 
+def default_lock_dir() -> str:
+    """Where the lock file lives.
+
+    Under the user's own data directory, with everything else this program
+    persists — not ``/tmp/spark-pulse/locks``, which it used to be. A fixed
+    path under a world-writable directory is one any local user can create
+    first and then own: they choose the permissions, and they can replace
+    ``locks.json`` with a symlink to somewhere this process can write.
+    """
+    return str(Path.home() / ".local" / "share" / "spark-pulse" / "locks")
+
+
 class LockManager:
     """In-memory lock manager for cluster/deployment operations.
 
-    Prevents concurrent operations on the same resource.
-    Uses file-based locks for cross-process safety (systemd service).
+    Prevents concurrent operations on the same resource **within one
+    process**. The lock file beside it is a crash-recovery record, not a
+    cross-process mutex: it is read once at construction and written on every
+    change, so a second process picks up what the first left behind but the
+    two do not exclude each other while both are running. The docstring here
+    used to claim cross-process safety, which is not what this does — two
+    processes each hold their own dictionary and never re-read the file.
+
+    Nothing in the control plane constructs one today; the orchestrator that
+    did was removed. It is kept because the deployment paths that would need
+    it are still being built, and because a lock manager that quietly does
+    something other than what it says is worse than no lock manager at all.
     """
 
     DEFAULT_TIMEOUT_SECONDS = 30
 
-    def __init__(self, lock_dir: str = "/tmp/spark-pulse/locks"):
+    def __init__(self, lock_dir: str | None = None):
         """Initialize lock manager.
 
         Args:
             lock_dir: Directory for file-based lock persistence.
         """
+        lock_dir = lock_dir if lock_dir is not None else default_lock_dir()
         self._locks: dict[str, LockInfo] = {}
         self._lock_dir = Path(lock_dir)
         self._lock_dir.mkdir(parents=True, exist_ok=True)
@@ -189,17 +214,30 @@ class LockManager:
     def cleanup_expired(self) -> int:
         """Remove expired locks.
 
+        The scan happens **inside** the mutex, and each candidate is checked
+        again at the moment it is deleted. Both matter, and the second is the
+        one that bites: the scan used to run outside the lock, so a resource
+        whose lock had expired could be legitimately re-acquired by another
+        caller before the delete ran — and the delete then removed that
+        caller's *live* lock by key, leaving it believing it held exclusion it
+        no longer had. Iterating a dict another thread is mutating is the
+        other half, and raises outright.
+
         Returns:
             Number of locks cleaned up.
         """
-        now = datetime.now(timezone.utc)
-        expired_keys = [
-            key for key, info in self._locks.items() if now >= info.expires_at
-        ]
-
         with self._lock:
+            now = datetime.now(timezone.utc)
+            expired_keys = [
+                key for key, info in self._locks.items() if now >= info.expires_at
+            ]
             for key in expired_keys:
-                del self._locks[key]
+                info = self._locks.get(key)
+                # Re-checked, not assumed: between building the list and this
+                # line nothing can have changed *now* — but keeping the two
+                # together is what makes that true rather than incidental.
+                if info is not None and now >= info.expires_at:
+                    del self._locks[key]
             if expired_keys:
                 self._save_file_locks()
 
@@ -234,10 +272,11 @@ class LockManager:
                 }
                 for key, info in self._locks.items()
             }
-            tmp = self._lock_file.with_suffix(".tmp")
-            with open(tmp, "w") as f:
-                json.dump(locks_data, f, indent=2)
-            tmp.rename(self._lock_file)
+            # The same durable write every other persisted file here uses:
+            # fsync the content, rename, fsync the directory. The hand-rolled
+            # version fsynced nothing, so the rename could land before the
+            # bytes did and a power loss left an empty file.
+            write_json_atomic(self._lock_file, locks_data)
         except OSError as e:
             logger.warning(f"Failed to save locks to file: {e}")
 

--- a/spark_pulse/tools/native_runtime.py
+++ b/spark_pulse/tools/native_runtime.py
@@ -527,13 +527,21 @@ def _save_records(records: list[dict[str, Any]]) -> None:
 
 
 def _update_record(deployment_id: str, **fields: Any) -> dict[str, Any] | None:
-    records = _load_records()
-    for record in records:
-        if record.get("id") == deployment_id:
-            record.update(fields)
-            _save_records(records)
-            return record
-    return None
+    """Change one record's fields, or answer None if it is no longer there.
+
+    The whole load-modify-save runs under the record store's mutex. Without
+    it, a background pull thread that had already loaded the list would write
+    back a deployment the API thread deleted in the meantime — and the caller
+    saw a successful delete followed by the record reappearing.
+    """
+    with tools.deployment_records.transaction():
+        records = _load_records()
+        for record in records:
+            if record.get("id") == deployment_id:
+                record.update(fields)
+                _save_records(records)
+                return record
+        return None
 
 
 def get_deployment(deployment_id: str) -> dict[str, Any] | None:
@@ -1639,9 +1647,10 @@ def persist_planned_record(plan_obj: DeployPlan, status: str) -> dict[str, Any]:
     caller seeing nothing until a 26 GB download finishes.
     """
     record = _record_from_plan(plan_obj, status)
-    records = [r for r in _load_records() if r.get("id") != plan_obj.deployment_id]
-    records.append(record)
-    _save_records(records)
+    with tools.deployment_records.transaction():
+        records = [r for r in _load_records() if r.get("id") != plan_obj.deployment_id]
+        records.append(record)
+        _save_records(records)
     return record
 
 
@@ -2026,11 +2035,12 @@ def delete_deployment(
     stopped = stop_deployment(deployment_id, docker=docker, services=services)
     if stopped is not None and stopped.get("orphans"):
         return False
-    records = _load_records()
-    remaining = [r for r in records if r.get("id") != deployment_id]
-    if len(remaining) == len(records):
-        return False
-    _save_records(remaining)
+    with tools.deployment_records.transaction():
+        records = _load_records()
+        remaining = [r for r in records if r.get("id") != deployment_id]
+        if len(remaining) == len(records):
+            return False
+        _save_records(remaining)
     return True
 
 

--- a/spark_pulse/tools/oci_registry.py
+++ b/spark_pulse/tools/oci_registry.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import yaml
 
 from spark_pulse.config import config
+from spark_pulse.tools.atomic_json import write_text_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -105,8 +106,9 @@ def _write_cache(key: str, data: dict) -> None:
     try:
         cache_file = _cache_path(key)
         cache_file.parent.mkdir(parents=True, exist_ok=True)
-        cache_file.write_text(
-            json.dumps({"_cached_at": time.time(), "data": data}, indent=2)
+        write_text_atomic(
+            cache_file,
+            json.dumps({"_cached_at": time.time(), "data": data}, indent=2),
         )
     except Exception as exc:
         logger.debug("Cache write failed for %s: %s", key, exc)
@@ -229,25 +231,60 @@ def _load_registries() -> list[dict]:
 
     if not config_path.exists():
         return []
-    try:
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
-        if not isinstance(data, dict) or "registries" not in data:
-            return []
-        regs = data["registries"]
-        if not isinstance(regs, list):
-            return []
+
+    regs = _read_registries_file(config_path)
+    if regs is not None:
         return regs
+
+    # An unusable file yields no registries, and says so loudly.
+    #
+    # Falling back to the bundled defaults was the other candidate and is the
+    # wrong one: an operator who configured only their own private registry
+    # would then find a corrupted file had silently substituted the public
+    # default, and recipes would start being pulled from somewhere they did
+    # not choose. Doing nothing is the safe failure for a source list. What
+    # was actually wrong here is that the failure was *silent* — and that the
+    # torn write which caused it is no longer possible, because the write is
+    # atomic now.
+    logger.error(
+        "%s exists but holds no usable registry list, so no registries are "
+        "configured. Inspect or remove the file; a backup of a working list "
+        "is the only way back to one.",
+        config_path,
+    )
+    return []
+
+
+def _read_registries_file(path: Path) -> list[dict] | None:
+    """The registry list in ``path``, or None when the file is unusable.
+
+    None means "this file did not tell us anything", and is deliberately
+    distinct from ``[]``, which means "this file says there are none".
+    """
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
     except Exception as exc:
-        logger.warning("Failed to load registries config: %s", exc)
-        return []
+        logger.warning("Failed to load registries config %s: %s", path, exc)
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("registries"), list):
+        return None
+    return data["registries"]
 
 
 def _save_registries(registries: list[dict]) -> None:
-    """Persist registries list to registries.yaml."""
-    REGISTRIES_CONFIG.parent.mkdir(parents=True, exist_ok=True)
-    with open(REGISTRIES_CONFIG, "w") as f:
-        yaml.dump({"registries": registries}, f, default_flow_style=False)
+    """Persist registries list to registries.yaml, atomically.
+
+    A plain ``open(path, "w")`` truncates before it writes, so a crash, a full
+    disk or a power loss between those two moments leaves the operator's
+    registry list empty or half-written — and YAML makes that worse rather
+    than better, because a torn file usually still parses into a plausible
+    wrong value instead of failing loudly.
+    """
+    write_text_atomic(
+        REGISTRIES_CONFIG,
+        yaml.dump({"registries": registries}, default_flow_style=False),
+    )
 
 
 def list_registries() -> list[dict]:
@@ -902,8 +939,7 @@ def install_collection(
             except OSError:
                 pass
 
-        with open(dest, "w") as f:
-            f.write(recipe["content"])
+        write_text_atomic(dest, recipe["content"])
 
         # Create metadata sidecar
         _write_recipe_meta(filename, reg["name"], name, version, recipe["digest"])
@@ -982,8 +1018,7 @@ def install_oci_recipe(
 
     # Install/update the recipe
     RECIPES_DIR.mkdir(parents=True, exist_ok=True)
-    with open(dest, "w") as f:
-        f.write(target["content"])
+    write_text_atomic(dest, target["content"])
 
     # Update metadata
     _write_recipe_meta(
@@ -1190,8 +1225,7 @@ def _write_recipe_meta(
     }
 
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(meta_path, "w") as f:
-        yaml.dump(meta, f, default_flow_style=False)
+    write_text_atomic(meta_path, yaml.dump(meta, default_flow_style=False))
 
 
 def _read_recipe_meta(recipe_filename: str) -> RecipeMeta | None:

--- a/tests/test_tools_locking.py
+++ b/tests/test_tools_locking.py
@@ -85,3 +85,76 @@ class TestLockManager:
         result2 = manager.acquire(LockType.CLUSTER_STOP, "test-cluster")
         assert result1.success is True
         assert result2.success is True
+
+
+class TestCleanupDoesNotStealALiveLock:
+    """``cleanup_expired`` scanned outside the mutex and deleted by key.
+
+    A resource whose lock had expired could be legitimately re-acquired
+    between the scan and the delete — and the delete then removed the new
+    holder's *live* lock, leaving it believing it held exclusion it did not.
+    Iterating a dict another thread is mutating is the other half, and raises
+    outright.
+    """
+
+    def _interleaving_lock(self, manager, action):
+        """A mutex that runs ``action`` once, at the moment it is first taken.
+
+        Deterministic rather than timing-based: the window is a few
+        microseconds wide, so racing threads reproduce it only by luck.
+        """
+        real = manager._lock
+
+        class Interleave:
+            done = False
+
+            def __enter__(self):
+                real.acquire()
+                if not Interleave.done:
+                    Interleave.done = True
+                    real.release()
+                    action()
+                    real.acquire()
+                return real
+
+            def __exit__(self, *_exc):
+                real.release()
+
+        return Interleave(), real
+
+    def test_a_lock_reacquired_mid_cleanup_is_not_deleted(self, tmp_path):
+        from spark_pulse.tools.locking import LockManager, LockType
+
+        manager = LockManager(lock_dir=str(tmp_path))
+        manager.acquire(LockType.DEPLOYMENT_START, "dep-1", owner="first", timeout=0)
+
+        def reacquire():
+            granted = manager.acquire(
+                LockType.DEPLOYMENT_START, "dep-1", owner="second", timeout=600
+            )
+            assert granted.success, "the expired lock should be re-acquirable"
+
+        shim, real = self._interleaving_lock(manager, reacquire)
+        manager._lock = shim
+        manager.cleanup_expired()
+        manager._lock = real
+
+        assert manager.is_locked(
+            LockType.DEPLOYMENT_START, "dep-1"
+        ), "cleanup deleted a live lock it had only seen as expired"
+
+    def test_an_actually_expired_lock_is_still_cleaned(self, tmp_path):
+        """And the fix must not stop cleanup doing its job."""
+        from spark_pulse.tools.locking import LockManager, LockType
+
+        manager = LockManager(lock_dir=str(tmp_path))
+        manager.acquire(LockType.DEPLOYMENT_START, "gone", owner="first", timeout=0)
+
+        assert manager.cleanup_expired() == 1
+        assert not manager.is_locked(LockType.DEPLOYMENT_START, "gone")
+
+    def test_the_lock_file_is_not_under_a_world_writable_directory(self):
+        """A fixed path under /tmp is one any local user can create first."""
+        from spark_pulse.tools.locking import default_lock_dir
+
+        assert not default_lock_dir().startswith("/tmp/")

--- a/tests/test_tools_native_runtime.py
+++ b/tests/test_tools_native_runtime.py
@@ -1524,3 +1524,64 @@ class TestPerRankReads:
         listed = native.list_deployments(docker=docker)
 
         assert [d["status"] for d in listed if d["id"] == "dep1"] == ["running"]
+
+
+class TestADeletedDeploymentStaysDeleted:
+    """A record must not come back after a successful delete.
+
+    Every write to the record file is atomic, which is a different guarantee
+    from the one that was missing. Two threads that each *load, change, save*
+    still lose one of the changes, because the second writes back a list it
+    read before the first landed — and a deploy runs its pull on a background
+    thread that updates the record while the API thread can delete it.
+
+    The zombie that leaves has no container behind it, holds its port, and is
+    listed in the UI until somebody notices and deletes it a second time.
+    """
+
+    def test_an_update_racing_a_delete_does_not_resurrect_the_record(
+        self, native, docker, records
+    ):
+        plan_obj = native.plan("qwen3-8b")
+        dep_id = plan_obj.deployment_id
+        nr.persist_planned_record(plan_obj, "pulling")
+        assert nr.get_deployment(dep_id) is not None
+
+        loaded = threading.Event()
+        delete_began = threading.Event()
+        writer: list[threading.Thread] = []
+        real_save = nr._save_records
+
+        def save_pausing_only_the_writer(records_to_save):
+            """Hold the writer between its load and its save, nobody else.
+
+            That gap is the whole bug: in the real path it is however long it
+            takes to format a status update while an image downloads.
+            """
+            if writer and threading.current_thread() is writer[0]:
+                loaded.set()
+                delete_began.wait(timeout=5)
+                time.sleep(0.2)
+            real_save(records_to_save)
+
+        with patch.object(
+            nr, "_save_records", side_effect=save_pausing_only_the_writer
+        ):
+            thread = threading.Thread(
+                target=lambda: nr._update_record(dep_id, status="pulling"),
+                name="stale-writer",
+                daemon=True,
+            )
+            writer.append(thread)
+            thread.start()
+
+            assert loaded.wait(timeout=5), "the writer never reached its save"
+            delete_began.set()
+            removed = nr.delete_deployment(dep_id, docker=docker)
+            thread.join(timeout=5)
+
+        assert removed is True
+        assert nr.get_deployment(dep_id) is None, (
+            "a record deleted while a background thread held a stale copy came "
+            "back from the dead"
+        )

--- a/tests/test_tools_oci_registry_durability.py
+++ b/tests/test_tools_oci_registry_durability.py
@@ -1,0 +1,153 @@
+"""What survives a crash mid-write, and what an unusable config file means.
+
+``atomic_json``'s module docstring states two rules for every persisted file
+in this repository, and ``registries.yaml`` — the operator's list of OCI
+registries — followed neither. It was written with a plain truncating
+``open(path, "w")``, and a loader turned every failure into ``[]``.
+
+YAML makes the first worse rather than better. A JSON file torn mid-write
+fails to parse and is *detected*; a YAML file torn mid-write usually still
+parses, into a plausible wrong value. The two observable outcomes of a crash
+between the truncate and the flush were therefore a silently corrupted
+registry URL, or silently zero registries.
+
+The fix is the write, not the read: an unusable file still yields no
+registries, because falling back to the bundled defaults would silently
+substitute a public registry for an operator's private one, and pulling
+recipes from somewhere nobody chose is worse than pulling none. What changed
+on the read side is only that it now says so.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from spark_pulse.tools import oci_registry as oci
+from spark_pulse.tools.atomic_json import write_text_atomic
+
+
+@pytest.fixture
+def config_path(tmp_path, monkeypatch):
+    """``registries.yaml`` in tmp_path, never the developer's own."""
+    path = tmp_path / "registries.yaml"
+    monkeypatch.setattr(oci, "REGISTRIES_CONFIG", path)
+    return path
+
+
+def _bundled_count() -> int:
+    data = yaml.safe_load(oci.BUNDLED_REGISTRIES_CONFIG.read_text())
+    return len(data["registries"])
+
+
+# ── The write ───────────────────────────────────────────────────────────────
+
+
+def test_a_saved_list_reads_back(config_path):
+    oci._save_registries([{"name": "prod", "url": "ghcr.io/org/recipes"}])
+
+    assert oci._load_registries() == [{"name": "prod", "url": "ghcr.io/org/recipes"}]
+
+
+def test_the_write_leaves_no_temp_file_behind(config_path):
+    oci._save_registries([{"name": "prod", "url": "ghcr.io/org/recipes"}])
+
+    strays = [p.name for p in config_path.parent.iterdir() if p != config_path]
+    assert strays == []
+
+
+def test_a_failed_write_leaves_the_previous_file_intact(config_path, monkeypatch):
+    """The property the rename buys: a reader sees the old file or the new one.
+
+    A truncating write had no third state to offer — the old content was gone
+    the moment the file was opened.
+    """
+    oci._save_registries([{"name": "prod", "url": "ghcr.io/org/recipes"}])
+
+    def explode(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(yaml, "dump", explode)
+    with pytest.raises(OSError):
+        oci._save_registries([{"name": "other", "url": "ghcr.io/other"}])
+
+    assert oci._load_registries() == [{"name": "prod", "url": "ghcr.io/org/recipes"}]
+
+
+# ── The read ────────────────────────────────────────────────────────────────
+
+
+def test_an_emptied_file_reports_none_loudly(config_path, caplog):
+    """The exact state ``open(path, "w")`` leaves before the dump completes.
+
+    It still yields no registries — falling back to the bundled defaults
+    would silently substitute a public registry for an operator's private
+    one — but it is no longer silent about it.
+    """
+    config_path.write_text("")
+
+    with caplog.at_level("ERROR"):
+        assert oci._load_registries() == []
+
+    assert "no usable registry list" in caplog.text
+
+
+def test_an_unparseable_file_reports_none(config_path):
+    config_path.write_text("{{{ not yaml at all")
+
+    assert oci._load_registries() == []
+
+
+def test_a_file_of_the_wrong_shape_reports_none(config_path):
+    config_path.write_text("registries: not-a-list")
+
+    assert oci._load_registries() == []
+
+
+def test_a_deliberately_empty_list_is_respected(config_path):
+    """An operator who removed every registry meant it.
+
+    This is why the fallback keys on "the file did not parse" rather than on
+    "the list came back empty": the two are different answers and only one of
+    them is a failure.
+    """
+    oci._save_registries([])
+
+    assert oci._load_registries() == []
+
+
+def test_a_missing_file_still_uses_the_bundled_defaults(config_path):
+    assert not config_path.exists()
+
+    assert len(oci._load_registries()) == _bundled_count()
+
+
+# ── The shared helper ───────────────────────────────────────────────────────
+
+
+def test_write_text_atomic_replaces_rather_than_truncates(tmp_path):
+    target = tmp_path / "thing.yaml"
+    target.write_text("old and complete\n")
+
+    write_text_atomic(target, "new and complete\n")
+
+    assert target.read_text() == "new and complete\n"
+    assert [p.name for p in tmp_path.iterdir()] == ["thing.yaml"]
+
+
+def test_write_text_atomic_honours_the_mode_it_is_given(tmp_path):
+    target = tmp_path / "secret.yaml"
+
+    write_text_atomic(target, "hunter2\n", mode=0o600)
+
+    assert target.stat().st_mode & 0o077 == 0
+
+
+def test_write_text_atomic_creates_the_directory(tmp_path):
+    target: Path = tmp_path / "nested" / "deeper" / "thing.yaml"
+
+    write_text_atomic(target, "content\n")
+
+    assert target.read_text() == "content\n"


### PR DESCRIPTION
Third review pass. Three findings, each reproduced before it was fixed and each with a test that fails without the fix.

## A deployment deleted mid-pull came back

Every write to the record file is atomic. That is a different guarantee from the one that was missing: two threads that each *load, change, save* still lose one of the changes, because the second writes back a list it read before the first landed. A deploy runs its pull on a background thread that updates the record as it goes, while the API thread can delete the same deployment at any moment.

```
pull thread   records = _load_records()     # the deployment is in this list
API thread    delete_deployment(...)        # filters it out, saves. Gone.
pull thread   _save_records(records)        # writes the deleted one back
```

What that leaves is a record with no container behind it — holding its port, listed in the UI, and deletable only by someone who notices it is still there.

`deployment_records` now owns a reentrant mutex, and every load-modify-save sequence holds it for the whole sequence rather than only around the save, which is where the atomicity already was. Three sites in `native_runtime` (`_update_record`, `delete_deployment`, `persist_planned_record`) plus `deployment_records.delete`.

**How I found it, which is the interesting part.** `test_a_teardown_during_the_pull_stops_it` — a test that deletes during a pull and then asserts the record is gone — was failing intermittently. I measured it rather than assuming: 2 failures in 25 runs on this branch, 1 in 25 on `main`, which at that sample size is the same number. So it was pre-existing and not something I had introduced. Capturing an actual failure showed the assertion that broke was `assert nr.get_deployment(dep_id) is None`, *after* a delete that returned `True`. It was never flakiness; it was this bug, surfacing about 4% of the time in CI.

After the fix: 0 failures in 30 runs. The new test reproduces the interleaving deterministically — it pauses the writer between its load and its save and lets the delete run in the gap — so it does not depend on the scheduler cooperating.

I also got this wrong once on the way: my first attempt at the regression test passed with *and* without the fix, because patching `_load_records` caught the delete's own loads too. A test that cannot fail proves nothing, so I checked it against a reverted tree, saw it green, and rewrote it to pause only the writer's save. Confirmed red without the fix, green with it.

## registries.yaml was written with a truncating `open()`

A crash, a full disk or a power loss between the truncate and the flush left it empty or half-written, and YAML makes that worse rather than better: a JSON file torn mid-write fails to parse and is *detected*; a YAML file torn mid-write usually still parses, into a plausible wrong value. Measured before the fix:

| torn-write state | result |
|---|---|
| partially written | parses, returns a silently corrupted URL (`ghcr.io/or`) |
| truncated to empty | returns `[]` — every registry gone, no error |
| file absent | correctly falls back to bundled |

`atomic_json`'s own module docstring names both halves of this ("Writes are atomic and durable", "a loader that turns every error into `[]` is the exact input condition behind Nomad issue 18267"), and this file followed neither. The write goes through the shared durable helper now — factored out as `write_text_atomic`, since not every durable file here is JSON — and an unusable file logs at ERROR instead of passing for "none configured".

**It still yields no registries rather than falling back to the bundled defaults.** I implemented the fallback first and then reverted it: an operator who configured only their own private registry would find a corrupted file had silently substituted the public default, and pulling recipes from a registry nobody chose is worse than pulling none. Four existing tests asserted the `[]` behaviour and they were right to.

## `cleanup_expired` could delete a live lock

`tools/locking.py` scanned the dictionary outside the mutex and then deleted by key. A resource whose lock had expired could be legitimately re-acquired between the scan and the delete — and the delete then removed the *new* holder's live lock, leaving it believing it held exclusion it did not. Iterating a dict another thread is mutating is the other half, and raises outright.

Reproduced deterministically by injecting the re-acquire at the moment cleanup takes the mutex (a timing-based attempt did not hit the window):

```
second acquire granted : True | owner: second
second's live lock survived: False     # before
second's live lock survived: True      # after
```

While there: the lock file moves off `/tmp/spark-pulse/locks` — a fixed path under a world-writable directory that any local user can create first and then own — it is written through the same durable path as everything else, and the docstring no longer claims "cross-process safety", which is not what a dictionary read once at construction provides.

This module is still constructed by nothing; the orchestrator that used it was removed. I fixed it rather than deleted it because deletion touches the mock twin and the contract test and is a call for you, not me — but it is a reasonable one to make.

## Gates

pytest **3088 passed** · black, ruff clean. New: `tests/test_tools_oci_registry_durability.py` (11), `TestADeletedDeploymentStaysDeleted`, three cases in `test_tools_locking.py`.

## Still open

`_active_tokens` remains a process-local dict (deferred to you on #39 — it is a dependency and deployment decision). And this pass covered `oci_registry`, `locking`, `deployment_records` and the record-mutation paths of `native_runtime`; `doctor.py`, `bootstrap_probe.py`, `models.py` beyond its quoting, and the frontend's component and store logic are still only grep-swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV
