### PR TITLE
fix: two places the UI reported a state that was not true

### DIFF
--- a/web/src/hooks/useSSEConnection.ts
+++ b/web/src/hooks/useSSEConnection.ts
@@ -49,6 +49,8 @@ export function useSSEConnection(
   const retryCountRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Whether the most recent close was ours rather than the server's. */
+  const intentionalCloseRef = useRef(false);
   const isMountedRef = useRef(true);
   const lastConnectedRef = useRef<string | undefined>(undefined);
 
@@ -93,13 +95,16 @@ export function useSSEConnection(
   const connect = useCallback(() => {
     if (!isMountedRef.current) return;
 
-    // Close existing connection
+    // Close existing connection. Flagged, so the `onerror` this provokes is
+    // not mistaken for the server hanging up on us.
     if (esRef.current) {
+      intentionalCloseRef.current = true;
       esRef.current.close();
     }
 
     const es = new EventSource(url);
     esRef.current = es;
+    intentionalCloseRef.current = false;
 
     updateConnection(url, {
       state: SSEConnectionState.RECONNECTING,
@@ -166,7 +171,22 @@ export function useSSEConnection(
       if (!isMountedRef.current) return;
 
       if (es.readyState === EventSource.CLOSED) {
-        // Explicitly closed
+        if (intentionalCloseRef.current) return;
+        // The browser closed the stream itself and will not retry. That is
+        // what it does for a response it cannot use — a 401 once the session
+        // expires, a proxy error page, the wrong content-type — as opposed to
+        // a dropped connection, which leaves it CONNECTING and retrying.
+        //
+        // Returning here treated the two as the same thing, so the indicator
+        // sat on "Connecting..." for the rest of the page's life and the
+        // operator watched a spinner instead of being told the stream was
+        // dead.
+        updateConnection(url, {
+          state: SSEConnectionState.DISCONNECTED,
+          error: lastConnectedRef.current
+            ? `Connection closed by the server. Last update: ${new Date(lastConnectedRef.current).toLocaleTimeString()}`
+            : "Connection refused by the server.",
+        });
         return;
       }
 
@@ -199,6 +219,7 @@ export function useSSEConnection(
     return () => {
       isMountedRef.current = false;
       if (esRef.current) {
+        intentionalCloseRef.current = true;
         esRef.current.close();
         esRef.current = null;
       }

--- a/web/src/lib/operationStore.ts
+++ b/web/src/lib/operationStore.ts
@@ -78,6 +78,10 @@ export const useOperationStore = create<OperationStore>((set, get) => ({
     set((state) => {
       const op = state.operations.get(operationId);
       if (!op) return state;
+      // A finished operation does not make progress. Without this, a
+      // cancelled deploy kept ticking towards 100% because the request it was
+      // cancelling had not noticed yet.
+      if (TERMINAL_STATES.has(op.state)) return state;
       const next = new Map(state.operations);
       next.set(operationId, {
         ...op,
@@ -92,6 +96,23 @@ export const useOperationStore = create<OperationStore>((set, get) => ({
       const op = state.operations.get(operationId);
       if (!op) return state;
       const newState = success ? OperationState.SUCCESS : OperationState.FAILED;
+      // Through the same gate `updateState` uses. This wrote the new state
+      // directly, so the state machine the store defines was enforced on one
+      // path and ignored on the other — and the path that ignored it is the
+      // one the documented usage takes:
+      //
+      //     const id = startOperation(...)
+      //     try { await work(); completeOperation(id, true) }
+      //     catch (e) { completeOperation(id, false, e.message) }
+      //
+      // Cancel that operation and the request still resolves, so a deployment
+      // the operator cancelled was reported to them as having succeeded.
+      if (!canTransition(op.state, newState)) {
+        console.warn(
+          `[operations] refused ${op.state} -> ${newState} for ${operationId}`,
+        );
+        return state;
+      }
       const next = new Map(state.operations);
       next.set(operationId, {
         ...op,

--- a/web/src/tests/hooks/useSSEConnection.test.tsx
+++ b/web/src/tests/hooks/useSSEConnection.test.tsx
@@ -337,6 +337,56 @@ describe("useSSEConnection, live", () => {
     expect(latest().url).toBe("/sse/logs/two");
   });
 
+  /** A browser closes an SSE stream itself, and does not retry, when the
+   *  response is one it cannot use: a 401 after the session expires, a proxy
+   *  error page, the wrong content-type. A dropped connection is different —
+   *  it stays CONNECTING and the browser retries on its own. Treating the two
+   *  the same left the indicator on "Connecting..." for the life of the page. */
+  it("says the server closed the stream rather than sitting on 'connecting'", () => {
+    const { result } = renderHook(() => useSSEConnection("/sse/deployments", vi.fn()));
+
+    act(() => {
+      const es = latest();
+      es.readyState = FakeEventSource.CLOSED;
+      es.onerror?.();
+    });
+
+    expect(result.current.state).toBe(SSEConnectionState.DISCONNECTED);
+    expect(result.current.error).toMatch(/refused by the server/i);
+  });
+
+  it("names when the stream last worked if it ever did", () => {
+    const { result } = renderHook(() => useSSEConnection("/sse/deployments", vi.fn()));
+
+    act(() => void latest().onopen?.());
+    act(() => {
+      const es = latest();
+      es.readyState = FakeEventSource.CLOSED;
+      es.onerror?.();
+    });
+
+    expect(result.current.state).toBe(SSEConnectionState.DISCONNECTED);
+    expect(result.current.error).toMatch(/closed by the server/i);
+    expect(result.current.error).toMatch(/Last update:/);
+  });
+
+  it("does not report a stream this hook closed itself as server-closed", () => {
+    // Switching streams closes the old one, which fires `onerror` with a
+    // CLOSED readyState. That is our own doing and must not be reported as
+    // the server hanging up.
+    const { rerender } = renderHook(
+      ({ url }: { url: string }) => useSSEConnection(url, vi.fn()),
+      { initialProps: { url: "/sse/logs/one" } },
+    );
+    const first = FakeEventSource.instances[0];
+
+    rerender({ url: "/sse/logs/two" });
+    act(() => void first.onerror?.());
+
+    const status = useSSEStore.getState().getConnection("/sse/logs/two");
+    expect(status?.state).not.toBe(SSEConnectionState.DISCONNECTED);
+  });
+
   /** The heartbeat exists to notice a browser that slept through a drop. It
    *  must not promote a stream that never opened to "seen just now". */
   it("does not claim a fresh update when the heartbeat fires on a dead stream", () => {

--- a/web/src/tests/lib/operationStore.test.ts
+++ b/web/src/tests/lib/operationStore.test.ts
@@ -828,3 +828,88 @@ describe("useSSHErrorStore", () => {
     expect(useSSHErrorStore.getState().getErrors()).toEqual([]);
   });
 });
+
+describe("a terminal operation is actually terminal", () => {
+  beforeEach(() => {
+    useOperationStore.setState({ operations: new Map() });
+  });
+
+  const running = (id: string) => ({
+    operation_id: id,
+    resource: "dep-1",
+    resource_type: "deployment" as const,
+    state: OperationState.RUNNING,
+    started_at: new Date().toISOString(),
+  });
+
+  it("does not report a cancelled operation as succeeded", () => {
+    // The documented usage in `useOperation` is exactly this shape:
+    //   const id = startOperation(...)
+    //   try { await work(); completeOperation(id, true) } catch { ... }
+    // The operator cancels; the request they cancelled still resolves.
+    act(() => {
+      useOperationStore.getState().addOperation(running("op-1"));
+      useOperationStore.getState().cancelOperation("op-1");
+      useOperationStore.getState().completeOperation("op-1", true);
+    });
+
+    expect(useOperationStore.getState().getOperation("op-1")!.state).toBe(
+      OperationState.CANCELLED,
+    );
+  });
+
+  it("does not report a cancelled operation as failed either", () => {
+    act(() => {
+      useOperationStore.getState().addOperation(running("op-2"));
+      useOperationStore.getState().cancelOperation("op-2");
+      useOperationStore.getState().completeOperation("op-2", false, "boom");
+    });
+
+    const op = useOperationStore.getState().getOperation("op-2")!;
+    expect(op.state).toBe(OperationState.CANCELLED);
+    expect(op.error).toBeUndefined();
+  });
+
+  it("does not let a succeeded operation be completed twice", () => {
+    act(() => {
+      useOperationStore.getState().addOperation(running("op-3"));
+      useOperationStore.getState().completeOperation("op-3", true);
+    });
+    const first = useOperationStore.getState().getOperation("op-3")!.completed_at;
+
+    act(() => {
+      useOperationStore.getState().completeOperation("op-3", false, "late failure");
+    });
+
+    const op = useOperationStore.getState().getOperation("op-3")!;
+    expect(op.state).toBe(OperationState.SUCCESS);
+    expect(op.completed_at).toBe(first);
+  });
+
+  it("stops counting progress once the operation is over", () => {
+    act(() => {
+      useOperationStore.getState().addOperation(running("op-4"));
+      useOperationStore.getState().updateProgress("op-4", 40, "pulling");
+      useOperationStore.getState().cancelOperation("op-4");
+      useOperationStore.getState().updateProgress("op-4", 90, "still pulling");
+    });
+
+    const op = useOperationStore.getState().getOperation("op-4")!;
+    expect(op.progress).toBe(40);
+    expect(op.current_step).toBe("pulling");
+  });
+
+  it("still completes an operation that is genuinely running", () => {
+    // The guard must not break the path every deploy takes.
+    act(() => {
+      useOperationStore.getState().addOperation(running("op-5"));
+      useOperationStore.getState().updateProgress("op-5", 50, "starting");
+      useOperationStore.getState().completeOperation("op-5", true);
+    });
+
+    const op = useOperationStore.getState().getOperation("op-5")!;
+    expect(op.state).toBe(OperationState.SUCCESS);
+    expect(op.progress).toBe(50);
+    expect(op.completed_at).toBeDefined();
+  });
+});


### PR DESCRIPTION
Two independent findings in the frontend's state handling, each measured against the running code before it was fixed, and each with a test confirmed red on a reverted tree.

## 1. A cancelled operation was reported as succeeded

The operation store defines a state machine, enforces it in `updateState`, and ignores it in `completeOperation`. `VALID_TRANSITIONS` declares `SUCCESS`, `FAILED`, `CANCELLED` and `ROLLED_BACK` terminal, and `updateState` refuses to leave them — with a comment saying why:

```ts
// Not silent: a rejected transition is a bug in the caller, and the one
// thing worse than the wrong state is a caller that believes it got it.
```

`completeOperation` wrote the new state directly, past that gate — and the path that skipped the machine is the one the documented usage takes. From `useOperation`'s own docstring:

```ts
const id = startOperation(...)
try { await work(); completeOperation(id, true) }
catch (e) { completeOperation(id, false, e.message) }
```

Cancel the operation and the request it was cancelling still resolves, so `completeOperation(id, true)` runs against a `CANCELLED` operation and flips it. **The operator cancels a deployment and the UI tells them it succeeded.** Measured:

```
STATE AFTER LATE COMPLETION: success
PROGRESS AFTER CANCEL: 90
```

That second line is the same hole in `updateProgress` — a cancelled deploy kept counting toward 100%, because the work it was cancelling had not noticed yet.

Both now go through the gate `updateState` already used. `RUNNING → SUCCESS/FAILED` is unchanged, which is every ordinary deploy.

## 2. A stream the server closed looked like one still connecting

`EventSource` closes a stream itself, and does not retry, when the response is one it cannot use — a 401 once the session expires, a proxy error page, the wrong content-type. That is different from a dropped connection, which leaves it CONNECTING while the browser retries on its own. `onerror` treated them as the same:

```ts
if (es.readyState === EventSource.CLOSED) {
  // Explicitly closed
  return;
}
```

The comment is right about one case and wrong about the other. Nothing outside the hook closes the stream, so CLOSED is either our own doing — switching streams, unmounting — or the server refusing to talk to us. Only the first was intended; the second fell through the same `return`:

```
F3 state: reconnecting | error: Connecting... (0/5)
```

An operator whose session expired watched a spinner for the life of the page rather than being told the stream was dead. The two are now told apart by an explicit flag set wherever this hook closes a stream, and the server-closed case reports `DISCONNECTED`, naming when the stream last worked if it ever did.

## A hypothesis I checked and dropped

I also suspected `scheduleReconnect` held a stale `connect` across a URL change and would reconnect to the previous stream. Driving it says otherwise — `url` is in that callback's dependencies, so it is rebuilt with the rest:

```
F1 urls opened: /sse/logs/one -> /sse/logs/two -> /sse/logs/two
```

No change made. Worth recording because the reasoning was plausible and wrong.

## Verification

Eight new tests. Both fixes confirmed red before being applied — 4 of 5 and 2 of 3 respectively. The tests that pass either way are deliberate: they assert the ordinary paths (`RUNNING → SUCCESS`, and closing a stream ourselves) still behave, so a fix that guards too much gets caught.

Gates: vitest **992 passed**, Playwright **53 passed**, tsc and eslint clean.

## Context

Found while reading the frontend logic, which earlier passes had only grep-swept for XSS and storage. Still unread: `doctor.py`, `bootstrap_probe.py`, `models.py` beyond its shell quoting, and the remaining page components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV