### PR TITLE
feat: one state store, with the backend behind a URL

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,6 +54,108 @@ jobs:
         env:
           SPARK_PULSE_REQUIRE_RUST: "1"
 
+  # The same suite, a second time, against a real PostgreSQL.
+  #
+  # spark_pulse/db.py goes through SQLAlchemy rather than the sqlite3 driver
+  # for one reason: so that one appliance becoming several is a change to a
+  # URL. Until this job existed the only evidence for that claim was
+  # test_every_table_emits_postgresql_ddl, which compiles the schema for the
+  # PostgreSQL dialect with no server behind it — it proves the column types
+  # are portable and nothing at all about whether the queries run. The day
+  # somebody set SPARK_PULSE_DATABASE_URL would have been the day the rest
+  # was found out.
+  python-unit-tests-postgres:
+    name: Run Python unit tests against PostgreSQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pulse
+          POSTGRES_PASSWORD: pulse
+          POSTGRES_DB: spark_pulse
+        ports:
+          - 5432:5432
+        # Without the health check the first connection races initdb and the
+        # job fails on a connection refused that has nothing to do with the
+        # change under test — the flake that teaches people to re-run CI.
+        options: >-
+          --health-cmd "pg_isready -U pulse -d spark_pulse"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      # tests/conftest.py reads this once: anything that is not a SQLite URL
+      # means "that server, cleaned between tests" instead of a private file
+      # per test. Setting it is the entire difference between this job and the
+      # one above, which is the point being demonstrated.
+      SPARK_PULSE_DATABASE_URL: postgresql+psycopg://pulse:pulse@127.0.0.1:5432/spark_pulse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # [postgres] is psycopg, the driver the URL above names. Installing
+          # it here also keeps the extra honest: an extra nothing installs is
+          # an extra that has stopped resolving without anyone noticing.
+          pip install -e ".[dev,postgres]"
+      # No Rust toolchain here, unlike the job above: what the ~85 agent-binary
+      # tests would add on PostgreSQL is enrolment writes that the stub-based
+      # enrolment tests in test_agent_bootstrap.py already make, and the price
+      # is a second full agent compile on every run. They skip, and the job
+      # above is where they run.
+      - name: Run Python tests
+        run: |
+          pytest --tb=short -v tests/
+      # A suite that quietly ignored the URL would pass this job while proving
+      # nothing, which is the exact failure this job exists to end. The tables
+      # are created once and emptied between tests, never dropped, so after a
+      # real run the server holds every one of them; after a run that fell
+      # back to SQLite it holds none.
+      - name: Confirm the suite really ran on PostgreSQL
+        # The same import environment as the suite: a model module that failed
+        # to import here would shrink the list of tables being looked for, and
+        # a check that silently asks for less is worse than none.
+        env:
+          SIMULATION_MODE: "1"
+        run: |
+          python - <<'PY'
+          import os
+          import tempfile
+
+          from sqlalchemy import create_engine, inspect
+
+          from spark_pulse import db
+
+          url = os.environ["SPARK_PULSE_DATABASE_URL"]
+
+          # engine() imports every model module, which is how the full set of
+          # tables is learned here without repeating the list — a table added
+          # later is covered by this check on the day it is added. Against a
+          # throwaway SQLite file, so that learning it cannot itself be what
+          # creates them on the server.
+          db.configure(f"sqlite:///{tempfile.mkdtemp()}/probe.db")
+          db.engine()
+          expected = {table.name for table in db.Base.metadata.sorted_tables}
+
+          found = set(inspect(create_engine(url)).get_table_names())
+          missing = expected - found
+          if missing:
+              raise SystemExit(
+                  f"the run never created {sorted(missing)} on the PostgreSQL "
+                  f"server, so it did not run against it. Found: "
+                  f"{sorted(found) or 'nothing at all'}."
+              )
+          print(f"{len(expected)} tables were created on PostgreSQL by the run")
+          PY
+
   ui-unit-tests:
     name: Run UI unit tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ agent/agent-aarch64*
 # Built agent binaries and their build cache
 spark_pulse/agent/bin/
 .agent-build-cache/
+spark_pulse/data/*.db*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,13 @@ Import gotcha under pytest (SIMULATION_MODE=1): `from spark_pulse.tools import r
 
 **Frontend structure**: `pages/` map 1:1 to routes in `App.tsx` (`/` recipes, `/jobs`, `/cluster`, `/benchmarking`, `/monitoring`, `/cache`, `/mcp`, `/oci`, `/settings`, `/login` outside `Layout`). Data fetching uses `hooks/useQuery.ts`; imports use the `@/` alias to `web/src`. Unit tests live in `web/src/tests/{components,hooks,lib}` with global mocks in `setupTests.ts`; vitest coverage thresholds are 95% lines, 93% statements, 90% functions, 85% branches, measured over every file under `src/` whether or not a test imports it — they are a ratchet, never to be lowered to make a build green.
 
-**Persistence in real mode** goes under `~/.config/spark-pulse/` (deployments.json, logs/, registries.yaml override). In simulation mode, mock deployments write to `spark_pulse/data/deployments.json` (gitignored).
+**Persistence.** Structured state lives in one SQLAlchemy-backed database (`spark_pulse/db.py`): deployments, nodes, the enrollment ledger, benchmark results, recipe customizations and browser sessions. SQLite in WAL mode by default — `~/.config/spark-pulse/spark-pulse.db`, 0600 because it holds OIDC tokens; `spark_pulse/data/spark-pulse.db` (gitignored) in simulation. `docs/cluster-agent-plan.md` §3.3 chose it, and SQLAlchemy is there so the scale case is a URL: set `database_url` (or `SPARK_PULSE_DATABASE_URL`) to `postgresql+psycopg://…` and `pip install spark-pulse[postgres]`. `tests/test_db_and_sessions.py` compiles every table for the PostgreSQL dialect, so a SQLite-only column type fails in CI rather than in front of an operator.
+
+Each store imports its old JSON file **once**, on first read, recorded in the `meta` table — not inferred from an empty table, because deleting the last row would re-import and resurrect what an operator removed. The legacy files are left where they are.
+
+Still files on purpose: the CA key and node certificates (`~/.config/spark-pulse/agent/`, 0600, read by tooling), user-editable recipe and mod directories, `settings.json`/`secrets.json` (config, layered with env vars), `registries.yaml`, and the caches under `~/.cache/spark-pulse/`.
+
+Tests get a database per test via an autouse fixture in `tests/conftest.py`, which also points every JSON migration source at `tmp_path` — without that a test would import the developer's real deployments.
 
 **CLI** (`cli.py`, Click): `start`, `install/uninstall/status/start-service/stop-service [--user]` (systemd via `service.py`), `mcp`, plus `recipes` and `oci` groups for OCI-registry recipe collections (`tools/oci_registry.py`, defaults in `spark_pulse/registries.yaml`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "authlib>=1.3.0",
     "httpx>=0.28.0",
     "filelock>=3.12.0",
+    # The state store (docs/cluster-agent-plan.md §3.3). SQLAlchemy rather than
+    # the sqlite3 driver so the schema and every query are written once and
+    # emitted for either backend: moving to PostgreSQL is a URL, not a rewrite.
+    "sqlalchemy>=2.0",
     "oras>=0.2.0",
     "docker>=7.0.0",
     "huggingface_hub>=0.26.0",
@@ -49,6 +53,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The scale case: one control plane becomes several and they need shared
+# state. Nothing else changes — set SPARK_PULSE_DATABASE_URL to a
+# postgresql+psycopg:// URL and the schema is created there instead.
+postgres = ["psycopg[binary]>=3.1"]
 dev = [
     "black>=24.8.0",
     "pytest>=8.0",

--- a/spark_pulse/agent/enrollment.py
+++ b/spark_pulse/agent/enrollment.py
@@ -22,11 +22,16 @@ already-accepted uuid, or a hardware fingerprint that no longer matches, marks
 the node ``denied`` and surfaces it for a human decision — which is what
 ``salt-key`` does, and is the opposite of quietly trusting whatever answered.
 
-Storage is the repository's own atomic JSON writer, so the ledger inherits the
-same durability the deployment records have: fsync, atomic rename, and a
-refusal to start on an unreadable file rather than a cheerful empty cluster
-(§3.3). Desired *state* moves to SQLite in a later step; the ledger is a small
-append-mostly membership list and does not need it.
+Storage is the state database (:mod:`spark_pulse.db`), which the ledger shares
+with deployments and sessions: one transaction per mutation, and a one-time
+import of the ``enrollment.json`` this used to be — keyed on the ``meta`` table,
+never on "are the tables empty", because removing the last node empties them
+and an import that re-ran then would readmit it. An unreadable ledger still
+refuses to start rather than reporting a cheerful empty cluster (§3.3).
+
+Writes are per-row: admitting one node writes one row, and the whole-ledger
+write survives only as the housekeeping sweep, which is the pass whose job is
+to reconcile the tables with this ledger's working copy.
 """
 
 from __future__ import annotations
@@ -36,6 +41,7 @@ import logging
 import secrets
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -43,7 +49,11 @@ from typing import Any
 
 from spark_pulse.agent.errors import EnrollmentRejected
 from spark_pulse.agent.identity import mint_node_id
-from spark_pulse.tools.atomic_json import read_state_file, write_json_atomic
+from sqlalchemy import JSON, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, is_done, mark_done, session_scope
+from spark_pulse.tools.atomic_json import read_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +160,57 @@ class TokenGrant:
         return cls(**{k: v for k, v in data.items() if k in known})
 
 
+# ── The tables ───────────────────────────────────────────────────────────────
+
+
+class _LedgerNodeRow(Base):
+    """One node's membership record."""
+
+    __tablename__ = "enrollment_nodes"
+
+    node_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    state: Mapped[str] = mapped_column(String(32), default="", index=True)
+    entry: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+
+class _LedgerTokenRow(Base):
+    """One minted enrollment token, by hash. The secret is never stored."""
+
+    __tablename__ = "enrollment_tokens"
+
+    token_hash: Mapped[str] = mapped_column(String(128), primary_key=True)
+    grant: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+
+def _node_row(entry: LedgerEntry) -> _LedgerNodeRow:
+    return _LedgerNodeRow(
+        node_id=entry.node_id, state=entry.state, entry=entry.to_dict()
+    )
+
+
+def _token_row(grant: TokenGrant) -> _LedgerTokenRow:
+    return _LedgerTokenRow(token_hash=grant.token_hash, grant=grant.to_dict())
+
+
+def _entry_of(row: _LedgerNodeRow) -> LedgerEntry:
+    """The stored membership record, addressed by the row's own id.
+
+    The id comes from the row rather than from the payload because every write
+    addresses a row by ``entry.node_id``: a row whose two disagreed — an
+    imported file, a hand-edited one — would be a row no later write could
+    ever reach again.
+    """
+    entry = LedgerEntry.from_dict(dict(row.entry))
+    entry.node_id = row.node_id
+    return entry
+
+
+def _grant_of(row: _LedgerTokenRow) -> TokenGrant:
+    grant = TokenGrant.from_dict(dict(row.grant))
+    grant.token_hash = row.token_hash
+    return grant
+
+
 @dataclass
 class _State:
     nodes: dict[str, LedgerEntry] = field(default_factory=dict)
@@ -160,8 +221,15 @@ class EnrollmentLedger:
     """Who may connect, and with which key.
 
     Thread-safe: the control plane's event loop and its request threads both
-    reach it. Every mutation writes the whole file atomically, which is ample
-    for a list bounded by the number of machines on a desk.
+    reach it. ``_state`` is the working copy, and it is what keeps
+    :meth:`authorize` — called on every connection — off the database entirely;
+    the lock is what makes each *load, change, store* sequence indivisible, so
+    two threads accepting and denying the same node cannot interleave into one
+    of the two decisions being lost.
+
+    Mutations write the rows they changed and nothing else. A whole-ledger
+    write is kept for :meth:`sweep`, which is housekeeping and is the one pass
+    that is supposed to reconcile the tables with the working copy.
     """
 
     def __init__(self, path: Path | str):
@@ -171,33 +239,138 @@ class EnrollmentLedger:
 
     # ── Persistence ──────────────────────────────────────────────────────
 
-    def _load(self) -> _State:
+    def _import_key(self) -> str:
+        """The ``meta`` key recording that this ledger's file was imported.
+
+        Per path, because a process can hold more than one ledger and an import
+        marked done for one file must not skip another. The path is *hashed*
+        rather than spelled out because the key is a 128-character column:
+        SQLite ignores that length, PostgreSQL enforces it, so a config
+        directory nested deeper than about ninety characters was a control
+        plane that started on one backend and failed its first INSERT on the
+        other. The readable path is kept as the row's value.
+        """
+        return f"enrollment.imported_from_json:{_hash(str(self.path))}"
+
+    def _migrate_from_json(self) -> None:
+        """Import ``enrollment.json`` once, if there is one.
+
+        Recorded in ``meta`` rather than inferred from empty tables: removing
+        the last node empties them, and an import that re-ran then would
+        readmit a node the operator had deliberately removed — which for a
+        membership list is the worst of the three stores to get wrong.
+        """
+        if is_done(self._import_key()):
+            return
         # read_state_file raises rather than returning empty when the file is
         # there but unreadable: an unreadable ledger must stop a start, not
         # report a cluster with nobody in it.
         data = read_state_file(self.path, expect=dict)
-        if not data:
-            return _State()
-        nodes = {
-            node_id: LedgerEntry.from_dict(raw)
-            for node_id, raw in (data.get("nodes") or {}).items()
-        }
-        tokens = {
-            token_hash: TokenGrant.from_dict(raw)
-            for token_hash, raw in (data.get("tokens") or {}).items()
-        }
+        if data is None:
+            return
+        if not mark_done(self._import_key(), str(self.path)):
+            return
+        with session_scope() as db:
+            for node_id, raw in (data.get("nodes") or {}).items():
+                entry = LedgerEntry.from_dict(raw)
+                # The key wins over the payload: every later write addresses a
+                # row by ``entry.node_id``, so a file whose two disagreed would
+                # leave a row that nothing could ever update again.
+                entry.node_id = node_id
+                db.merge(_node_row(entry))
+            for token_hash, raw in (data.get("tokens") or {}).items():
+                grant = TokenGrant.from_dict(raw)
+                grant.token_hash = token_hash
+                db.merge(_token_row(grant))
+
+    def _load(self) -> _State:
+        self._migrate_from_json()
+        with session_scope() as db:
+            nodes = {
+                row.node_id: _entry_of(row)
+                for row in db.execute(select(_LedgerNodeRow)).scalars()
+            }
+            tokens = {
+                row.token_hash: _grant_of(row)
+                for row in db.execute(select(_LedgerTokenRow)).scalars()
+            }
         return _State(nodes=nodes, tokens=tokens)
 
+    def _write(
+        self,
+        *,
+        nodes: Iterable[LedgerEntry] = (),
+        tokens: Iterable[TokenGrant] = (),
+        drop_nodes: Iterable[str] = (),
+        drop_tokens: Iterable[str] = (),
+    ) -> None:
+        """Write exactly the rows named here, in one transaction.
+
+        Every mutation used to go through :meth:`_save`, so admitting one node
+        rewrote the row of every node on the desk. The cost is the smaller
+        half of the problem: the whole-ledger write also writes back rows this
+        instance's working copy is merely *holding*, which is how a field
+        another writer has already changed gets quietly replaced by the value
+        we read before they changed it. A write that names its rows cannot
+        reach a row the call never touched.
+
+        One transaction rather than one per row, because the calls that change
+        two rows change them together: redemption marks a token used *and*
+        admits the node it minted, and a failure between the two leaves a node
+        nobody has a token for. Callers hold ``self._lock`` across the
+        read-modify-write that produced these rows — narrowing a write is not
+        a substitute for serialising the decision behind it.
+        """
+        with session_scope() as db:
+            for node_id in drop_nodes:
+                node_row = db.get(_LedgerNodeRow, node_id)
+                if node_row is not None:
+                    db.delete(node_row)
+            for token_hash in drop_tokens:
+                token_row = db.get(_LedgerTokenRow, token_hash)
+                if token_row is not None:
+                    db.delete(token_row)
+            for entry in nodes:
+                db.merge(_node_row(entry))
+            for grant in tokens:
+                db.merge(_token_row(grant))
+
+    def _stored_node(self, node_id: str) -> LedgerEntry | None:
+        """One node's row as the database has it, not as this copy has it.
+
+        The working copy answers every read on the connection path; this is
+        for the rare write that must not be based on a copy which may have
+        been read before somebody else's change landed.
+        """
+        with session_scope() as db:
+            row = db.get(_LedgerNodeRow, node_id)
+            return _entry_of(row) if row is not None else None
+
     def _save(self) -> None:
-        write_json_atomic(
-            self.path,
-            {
-                "version": 1,
-                "nodes": {k: v.to_dict() for k, v in self._state.nodes.items()},
-                "tokens": {k: v.to_dict() for k, v in self._state.tokens.items()},
-            },
-            mode=0o600,
-        )
+        """Write the whole ledger, in one transaction.
+
+        Both tables together, because a node accepted without the token that
+        admitted it — or the reverse — is a half-written membership list, and
+        that is the state this store exists to make unreachable.
+
+        This is the *reconciling* write, and the reason it survives the move to
+        per-row writes: rows absent from the working copy are deleted, so a row
+        left behind by a write that failed halfway does not live forever, and
+        the ``last_seen`` hints that :meth:`note_seen` deliberately keeps in
+        memory reach the database. :meth:`sweep` — housekeeping, off every
+        connection path — is what calls it.
+        """
+        with session_scope() as db:
+            for row in list(db.execute(select(_LedgerNodeRow)).scalars()):
+                if row.node_id not in self._state.nodes:
+                    db.delete(row)
+            for entry in self._state.nodes.values():
+                db.merge(_node_row(entry))
+            for row in list(db.execute(select(_LedgerTokenRow)).scalars()):
+                if row.token_hash not in self._state.tokens:
+                    db.delete(row)
+            for grant in self._state.tokens.values():
+                db.merge(_token_row(grant))
 
     # ── Tokens ───────────────────────────────────────────────────────────
 
@@ -215,15 +388,16 @@ class EnrollmentLedger:
         secret = secrets.token_urlsafe(32)
         now = time.time()
         with self._lock:
-            self._sweep_locked(now)
-            self._state.tokens[_hash(secret)] = TokenGrant(
+            stale = self._sweep_locked(now)
+            grant = TokenGrant(
                 token_hash=_hash(secret),
                 name=name,
                 created_at=now,
                 expires_at=now + ttl,
                 assign_node_id=node_id,
             )
-            self._save()
+            self._state.tokens[grant.token_hash] = grant
+            self._write(tokens=(grant,), drop_tokens=stale)
         return secret
 
     def redeem_token(self, secret: str, *, now: float | None = None) -> str:
@@ -258,13 +432,16 @@ class EnrollmentLedger:
             node_id = grant.assign_node_id or mint_node_id()
             grant.used_at = now
             grant.node_id = node_id
-            self._state.nodes[node_id] = LedgerEntry(
+            entry = LedgerEntry(
                 node_id=node_id,
                 name=grant.name,
                 state=NodeState.PENDING.value,
                 enrolled_at=now,
             )
-            self._save()
+            self._state.nodes[node_id] = entry
+            # Both rows or neither: a node admitted without the token that
+            # spent itself admitting it is a token that can be redeemed twice.
+            self._write(nodes=(entry,), tokens=(grant,))
         return node_id
 
     def revoke_token(self, secret: str) -> bool:
@@ -285,7 +462,7 @@ class EnrollmentLedger:
                 return False
             if not grant.used_at:
                 grant.used_at = time.time()
-                self._save()
+                self._write(tokens=(grant,))
             return True
 
     def token_for(self, secret: str) -> TokenGrant | None:
@@ -306,11 +483,22 @@ class EnrollmentLedger:
         """Record a certificate issued to a node and accept it."""
         facts = facts or {}
         with self._lock:
-            entry = self._state.nodes.get(node_id) or LedgerEntry(node_id=node_id)
+            # The stored row, not only the working copy: enrolment is rare
+            # enough to afford one read, and it is the call that must not
+            # start from a copy read before another writer's change landed.
+            stored = self._stored_node(node_id)
+            entry = (
+                self._state.nodes.get(node_id) or stored or LedgerEntry(node_id=node_id)
+            )
             entry.state = NodeState.ACCEPTED.value
             entry.public_key_fingerprint = public_key_fingerprint
             entry.cert_not_after = not_after
-            entry.issued += 1
+            # A counter is the one field a narrow write can silently roll
+            # back. ``issued`` exists so that a node re-enrolling in a loop
+            # shows up as a jump; writing our count over a higher stored one
+            # would turn that jump back into a 1, which is the reading that
+            # says nothing is wrong.
+            entry.issued = max(entry.issued, stored.issued if stored else 0) + 1
             entry.denied_reason = ""
             if not entry.enrolled_at:
                 entry.enrolled_at = time.time()
@@ -318,7 +506,7 @@ class EnrollmentLedger:
                 if facts.get(key):
                     setattr(entry, key, facts[key])
             self._state.nodes[node_id] = entry
-            self._save()
+            self._write(nodes=(entry,))
             return entry
 
     def get(self, node_id: str) -> LedgerEntry | None:
@@ -337,7 +525,7 @@ class EnrollmentLedger:
                 return
             entry.state = NodeState.DENIED.value
             entry.denied_reason = reason
-            self._save()
+            self._write(nodes=(entry,))
         logger.warning("node %s denied: %s", node_id, reason)
 
     def remove(self, node_id: str) -> None:
@@ -350,7 +538,10 @@ class EnrollmentLedger:
         """
         with self._lock:
             self._state.nodes.pop(node_id, None)
-            self._save()
+            # By id, not by "everything except this one": a node this ledger
+            # never knew about — enrolled against the same database by someone
+            # else — is not something a removal was asked to delete.
+            self._write(drop_nodes=(node_id,))
 
     def note_seen(self, node_id: str) -> None:
         with self._lock:
@@ -358,10 +549,11 @@ class EnrollmentLedger:
             if entry is None:
                 return
             entry.last_seen = time.time()
-            # Deliberately not saved: a heartbeat every ten seconds must not
-            # be a disk write every ten seconds. Liveness lives in the hub,
+            # Deliberately not written: a heartbeat every ten seconds must not
+            # be a database write every ten seconds. Liveness lives in the hub,
             # in memory, where it belongs; this field is a coarse hint that
-            # gets flushed by the next real mutation.
+            # reaches storage with this node's next real mutation — a renewal,
+            # a denial — or with the next sweep, which writes the ledger whole.
 
     # ── Authorisation ────────────────────────────────────────────────────
 
@@ -394,7 +586,7 @@ class EnrollmentLedger:
                 reason = "a different key was presented for this node id"
                 entry.state = NodeState.DENIED.value
                 entry.denied_reason = reason
-                self._save()
+                self._write(nodes=(entry,))
                 return IdentityVerdict(False, reason)
             fingerprint = facts.get("hardware_fingerprint") or ""
             if (
@@ -405,7 +597,7 @@ class EnrollmentLedger:
                 reason = "hardware fingerprint changed; the node may be reimaged"
                 entry.state = NodeState.DENIED.value
                 entry.denied_reason = reason
-                self._save()
+                self._write(nodes=(entry,))
                 return IdentityVerdict(False, reason)
             return IdentityVerdict(True)
 
@@ -418,14 +610,27 @@ class EnrollmentLedger:
         blacklist from growing without bound. A *used* token is kept for a
         grace period so that a retried install is told "already used" rather
         than the less useful "not recognised".
+
+        The one caller of the whole-ledger write, and the only one that should
+        be: housekeeping is off every connection path, it is where the cost of
+        rewriting a list bounded by the machines on a desk is affordable, and
+        reconciling the tables with the working copy is exactly the job it was
+        given. Everything on the enrollment and connection paths writes the
+        rows it changed.
         """
         with self._lock:
-            removed = self._sweep_locked(now if now is not None else time.time())
+            removed = len(self._sweep_locked(now if now is not None else time.time()))
             if removed:
                 self._save()
             return removed
 
-    def _sweep_locked(self, now: float) -> int:
+    def _sweep_locked(self, now: float) -> list[str]:
+        """Drop stale tokens from the working copy; return what was dropped.
+
+        The hashes rather than a count, because the caller has to write the
+        deletions too — a token dropped from memory and left in the table is a
+        token the next reload readmits.
+        """
         grace = TOKEN_TTL_SECONDS
         stale = [
             token_hash
@@ -435,4 +640,4 @@ class EnrollmentLedger:
         ]
         for token_hash in stale:
             del self._state.tokens[token_hash]
-        return len(stale)
+        return stale

--- a/spark_pulse/agent/enrollment.py
+++ b/spark_pulse/agent/enrollment.py
@@ -380,7 +380,7 @@ class EnrollmentLedger:
             row = db.get(_LedgerNodeRow, node_id)
             return _entry_of(row) if row is not None else None
 
-    def _save(self) -> None:
+    def _save(self) -> None:  # noqa: D401 — see the warning in the docstring
         """Write the whole ledger, in one transaction.
 
         Both tables together, because a node accepted without the token that

--- a/spark_pulse/agent/enrollment.py
+++ b/spark_pulse/agent/enrollment.py
@@ -52,7 +52,9 @@ from spark_pulse.agent.identity import mint_node_id
 from sqlalchemy import JSON, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from spark_pulse.db import Base, is_done, mark_done, session_scope
+from sqlalchemy.exc import IntegrityError
+
+from spark_pulse.db import Base, is_done, mark_done_within, session_scope
 from spark_pulse.tools.atomic_json import read_state_file
 
 logger = logging.getLogger(__name__)
@@ -217,6 +219,28 @@ class _State:
     tokens: dict[str, TokenGrant] = field(default_factory=dict)
 
 
+def _put_node(db, entry: LedgerEntry) -> None:
+    """Write one ledger row inside the caller's transaction, without ``merge``.
+
+    See the house rule in :mod:`spark_pulse.db`: merge picks UPDATE from its
+    own load and then matches nothing on PostgreSQL.
+    """
+    row = db.get(_LedgerNodeRow, entry.node_id)
+    if row is None:
+        db.add(_node_row(entry))
+    else:
+        row.state = entry.state
+        row.entry = entry.to_dict()
+
+
+def _put_token(db, grant: TokenGrant) -> None:
+    row = db.get(_LedgerTokenRow, grant.token_hash)
+    if row is None:
+        db.add(_token_row(grant))
+    else:
+        row.grant = grant.to_dict()
+
+
 class EnrollmentLedger:
     """Who may connect, and with which key.
 
@@ -268,20 +292,30 @@ class EnrollmentLedger:
         data = read_state_file(self.path, expect=dict)
         if data is None:
             return
-        if not mark_done(self._import_key(), str(self.path)):
+        # Marker and rows in one transaction. Marking first leaves a window in
+        # which the marker says the ledger was imported while none of it was —
+        # and for a *membership list* that is the worst of the stores to lose:
+        # every enrolled node becomes unknown and is refused on its next
+        # connection.
+        try:
+            with session_scope() as db:
+                if not mark_done_within(db, self._import_key(), str(self.path)):
+                    return
+                for node_id, raw in (data.get("nodes") or {}).items():
+                    entry = LedgerEntry.from_dict(raw)
+                    # The key wins over the payload: every later write
+                    # addresses a row by ``entry.node_id``, so a file whose two
+                    # disagreed would leave a row nothing could update again.
+                    entry.node_id = node_id
+                    _put_node(db, entry)
+                for token_hash, raw in (data.get("tokens") or {}).items():
+                    grant = TokenGrant.from_dict(raw)
+                    grant.token_hash = token_hash
+                    _put_token(db, grant)
+        except IntegrityError:
+            # Another control plane claimed the import between our read and
+            # our insert; our whole transaction rolled back and theirs stands.
             return
-        with session_scope() as db:
-            for node_id, raw in (data.get("nodes") or {}).items():
-                entry = LedgerEntry.from_dict(raw)
-                # The key wins over the payload: every later write addresses a
-                # row by ``entry.node_id``, so a file whose two disagreed would
-                # leave a row that nothing could ever update again.
-                entry.node_id = node_id
-                db.merge(_node_row(entry))
-            for token_hash, raw in (data.get("tokens") or {}).items():
-                grant = TokenGrant.from_dict(raw)
-                grant.token_hash = token_hash
-                db.merge(_token_row(grant))
 
     def _load(self) -> _State:
         self._migrate_from_json()
@@ -331,9 +365,9 @@ class EnrollmentLedger:
                 if token_row is not None:
                     db.delete(token_row)
             for entry in nodes:
-                db.merge(_node_row(entry))
+                _put_node(db, entry)
             for grant in tokens:
-                db.merge(_token_row(grant))
+                _put_token(db, grant)
 
     def _stored_node(self, node_id: str) -> LedgerEntry | None:
         """One node's row as the database has it, not as this copy has it.
@@ -365,12 +399,12 @@ class EnrollmentLedger:
                 if row.node_id not in self._state.nodes:
                     db.delete(row)
             for entry in self._state.nodes.values():
-                db.merge(_node_row(entry))
+                _put_node(db, entry)
             for row in list(db.execute(select(_LedgerTokenRow)).scalars()):
                 if row.token_hash not in self._state.tokens:
                     db.delete(row)
             for grant in self._state.tokens.values():
-                db.merge(_token_row(grant))
+                _put_token(db, grant)
 
     # ── Tokens ───────────────────────────────────────────────────────────
 

--- a/spark_pulse/app.py
+++ b/spark_pulse/app.py
@@ -37,6 +37,8 @@ from spark_pulse.auth import AuthMiddleware, CsrfMiddleware, router as auth_rout
 from spark_pulse.sse import router as sse_router
 from spark_pulse import tools
 from spark_pulse.tools import is_simulation
+from sqlalchemy.exc import OperationalError
+
 from spark_pulse.tools.atomic_json import StateFileError
 from spark_pulse.tools.oci_registry import (
     start_background_updater,
@@ -131,6 +133,14 @@ async def lifespan(app: FastAPI):
     # still running is what lets a control plane tear down live work.
     try:
         tools.deployment_records.check_state_file()
+    except OperationalError as e:
+        # `check_state_file` now also opens the database, and an unreachable
+        # one raises from SQLAlchemy rather than as a StateFileError. Without
+        # this the operator got a raw traceback instead of the sentence below,
+        # which is the whole point of catching anything here.
+        print(f"FATAL: cannot open the state database: {e}")
+        print("FATAL: refusing to start with an empty view of running deployments.")
+        raise
     except StateFileError as e:
         print(f"FATAL: cannot read deployment state file {e.path}: {e.reason}")
         if e.quarantine_path is not None:

--- a/spark_pulse/auth.py
+++ b/spark_pulse/auth.py
@@ -20,14 +20,13 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
+from starlette.concurrency import run_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from spark_pulse import sessions
 from spark_pulse.config import config
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-
-# In-memory token store (replace with Redis in production)
-_active_tokens: dict[str, dict] = {}
 
 #: How long an unredeemed OIDC ``state`` stays valid. The round trip is one
 #: browser redirect to the provider and back; ten minutes is generous.
@@ -83,9 +82,9 @@ def _consume_state(state: str) -> str | None:
 def _session_expired(user: dict, now: float | None = None) -> bool:
     """Whether a stored session has passed the expiry it was created with.
 
-    ``expires_at`` was recorded at login and then never read, so a session
-    outlived the provider's own token for as long as the process ran and the
-    store grew without bound. Both are fixed by consulting it.
+    Kept as a pure predicate even though the store now enforces expiry on
+    read: a caller holding a session dict can still ask, and the answer must
+    not depend on a round trip.
     """
     expires_at = user.get("expires_at")
     if not expires_at:
@@ -93,10 +92,14 @@ def _session_expired(user: dict, now: float | None = None) -> bool:
     return (time.time() if now is None else now) >= float(expires_at)
 
 
-def _sweep_sessions() -> None:
-    for key, user in list(_active_tokens.items()):
-        if _session_expired(user):
-            _active_tokens.pop(key, None)
+async def _load_session(token: str) -> dict | None:
+    """The session behind a cookie, read off the event loop.
+
+    ``run_in_threadpool`` because the store is synchronous — which is §3.3's
+    "all access off the event loop", and which is what keeps this correct when
+    the URL points at PostgreSQL across a network rather than at a local file.
+    """
+    return await run_in_threadpool(sessions.get, token)
 
 
 async def discover(provider_url: str, *, refresh: bool = False) -> dict:
@@ -313,16 +316,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 status_code=401, content={"detail": "Not authenticated"}
             )
 
-        user = _active_tokens.get(token)
+        # The store drops an expired row as it reads it, so "expired" and
+        # "never existed" arrive here as the same answer — which is all this
+        # needs to know, and is one round trip rather than two.
+        user = await _load_session(token)
         if not user:
-            return JSONResponse(status_code=401, content={"detail": "Invalid token"})
-        if _session_expired(user):
-            # The provider's own token has expired, so ours has too. Dropped
-            # here rather than left to accumulate: the cookie's max-age only
-            # governs the browser, and a client that keeps sending an expired
-            # cookie was otherwise honoured for the life of the process.
-            _active_tokens.pop(token, None)
-            return JSONResponse(status_code=401, content={"detail": "Session expired"})
+            return JSONResponse(
+                status_code=401, content={"detail": "Not authenticated"}
+            )
 
         # Attach user to request state
         request.state.user = user
@@ -444,15 +445,16 @@ async def callback(request: Request, code: str, state: str):
 
             # Store token, dropping anything that has already expired so the
             # store stays bounded by the number of live sessions.
-            _sweep_sessions()
-            token_key = secrets.token_urlsafe(32)
-            _active_tokens[token_key] = {
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-                "expires_at": datetime.now(timezone.utc).timestamp() + expires_in,
-                "user": user_info,
-                "created_at": datetime.now(timezone.utc).isoformat(),
-            }
+            await run_in_threadpool(sessions.sweep)
+            token_key = await run_in_threadpool(
+                lambda: sessions.create(
+                    access_token=access_token,
+                    refresh_token=refresh_token,
+                    expires_at=datetime.now(timezone.utc).timestamp() + expires_in,
+                    user=user_info,
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                )
+            )
 
             # Set session cookie and redirect to home
             response = RedirectResponse(url="/", status_code=302)
@@ -482,7 +484,7 @@ async def logout(request: Request):
     """Invalidate current token and clear cookie."""
     token = request.cookies.get("token")
     if token:
-        _active_tokens.pop(token, None)
+        await run_in_threadpool(sessions.remove, token)
     response = {"message": "Logged out"}
     resp = JSONResponse(content=response)
     resp.delete_cookie(key="token", path="/")
@@ -496,12 +498,9 @@ async def get_me(request: Request):
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    user_data = _active_tokens.get(token)
+    user_data = await _load_session(token)
     if not user_data:
-        raise HTTPException(status_code=401, detail="Invalid token")
-    if _session_expired(user_data):
-        _active_tokens.pop(token, None)
-        raise HTTPException(status_code=401, detail="Session expired")
+        raise HTTPException(status_code=401, detail="Not authenticated")
 
     return {
         "authenticated": True,

--- a/spark_pulse/blobs.py
+++ b/spark_pulse/blobs.py
@@ -1,0 +1,213 @@
+"""File content in the database, materialised to disk on demand.
+
+Recipes and mods are *files*: a recipe is a YAML document an operator edits, a
+mod is a directory copied wholesale into a container by
+``native_runtime._apply_mods``. Everything that consumes them takes a
+``Path`` — ``mod_dir.iterdir()``, ``docker.copy_to_container(str(path), …)`` —
+and that is not an accident worth undoing, because the thing on the far end is
+a container filesystem.
+
+So they cannot simply move into the database the way a deployment record did.
+What they can do is change which copy is *authoritative*. Here the database
+holds the content and the filesystem holds a cache of it, rebuilt when the
+digest says it is stale. One control plane behaves exactly as it does today,
+because its cache is always warm. Several control planes finally agree with
+each other, because an operator who uploads a mod to one of them is not
+uploading it to only one of them any more — which is the whole reason this
+moves at all.
+
+**Not encrypted.** Recipes and mods are configuration an operator wrote and
+can read back through the UI; they are not secrets, and encrypting them would
+cost the ability to inspect the store without the key while protecting
+something that is not sensitive. Secrets go through
+:mod:`spark_pulse.crypto` instead, and the two must not be confused: if a
+recipe ever carries a token, that token belongs in the secret store and the
+recipe should reference it by name.
+
+**Digest-addressed, not timestamp-addressed.** A cache keyed on mtime is a
+cache that is wrong whenever two instances write the same second, or a clock
+moves. The digest is of the content, so "is this stale" has an answer that
+does not depend on anybody's clock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Iterable
+
+from sqlalchemy import Integer, LargeBinary, String, delete, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, session_scope
+
+__all__ = [
+    "Blob",
+    "put",
+    "get",
+    "listing",
+    "remove",
+    "remove_scope",
+    "digest_of",
+    "materialize",
+    "import_tree",
+]
+
+
+def digest_of(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+class Blob(Base):
+    """One file, addressed by the scope it belongs to and its relative path.
+
+    ``LargeBinary`` rather than ``Text``: a mod directory can hold a chat
+    template, a shell script and a wheel, and deciding which of those is text
+    is a decision that only has to be wrong once.
+    """
+
+    __tablename__ = "blobs"
+
+    #: What this file belongs to — ``mod:my-mod``, ``recipe:custom/foo``.
+    #: Scoped rather than one flat namespace so a whole mod is one delete.
+    scope: Mapped[str] = mapped_column(String(255), primary_key=True)
+    #: Path relative to the scope's root. Never absolute, never containing
+    #: ``..`` — checked on the way in, because the far end of this is a
+    #: filesystem and eventually a container.
+    path: Mapped[str] = mapped_column(String(1024), primary_key=True)
+    content: Mapped[bytes] = mapped_column(LargeBinary, default=b"")
+    #: The executable bit matters: a mod's ``run.sh`` is executed.
+    mode: Mapped[int] = mapped_column(Integer, default=0o644)
+    digest: Mapped[str] = mapped_column(String(64), default="", index=True)
+
+
+class UnsafeBlobPath(ValueError):
+    """A relative path that would escape the scope it is written into."""
+
+
+def _checked(path: str) -> str:
+    """``path`` as a safe relative path, or a refusal.
+
+    The same rule the agent applies to an incoming tar, for the same reason:
+    what is on the other end of this is a directory on disk and then a
+    container, and an absolute or climbing path reaches outside both.
+    """
+    candidate = Path(path)
+    if not path or candidate.is_absolute():
+        raise UnsafeBlobPath(f"{path!r} is not a relative path")
+    if any(part in ("..", "") for part in candidate.parts):
+        raise UnsafeBlobPath(f"{path!r} escapes its scope")
+    return candidate.as_posix()
+
+
+def put(scope: str, path: str, content: bytes, *, mode: int = 0o644) -> str:
+    """Store one file and return its digest."""
+    safe = _checked(path)
+    fingerprint = digest_of(content)
+    with session_scope() as db:
+        # An explicit get-then-write rather than ``Session.merge``. merge
+        # decides between UPDATE and INSERT from a load it performs itself,
+        # and on PostgreSQL that produced
+        # ``StaleDataError: UPDATE expected to update 1 row(s); 0 were
+        # matched`` — it had decided to update a row its own load had seen and
+        # the statement then matched nothing. Doing the decision here makes it
+        # the transaction's, which is where it can actually be held.
+        row = db.get(Blob, (scope, safe))
+        if row is None:
+            db.add(
+                Blob(
+                    scope=scope,
+                    path=safe,
+                    content=content,
+                    mode=mode,
+                    digest=fingerprint,
+                )
+            )
+        else:
+            row.content = content
+            row.mode = mode
+            row.digest = fingerprint
+    return fingerprint
+
+
+def get(scope: str, path: str) -> bytes | None:
+    with session_scope() as db:
+        row = db.get(Blob, (scope, _checked(path)))
+        return bytes(row.content) if row is not None else None
+
+
+def listing(scope: str) -> list[tuple[str, str, int]]:
+    """``(path, digest, mode)`` for every file in ``scope``, sorted."""
+    with session_scope() as db:
+        rows = db.execute(select(Blob).where(Blob.scope == scope)).scalars()
+        return sorted((row.path, row.digest, row.mode) for row in rows)
+
+
+def remove(scope: str, path: str) -> bool:
+    with session_scope() as db:
+        row = db.get(Blob, (scope, _checked(path)))
+        if row is None:
+            return False
+        db.delete(row)
+        return True
+
+
+def remove_scope(scope: str) -> int:
+    """Drop every file in a scope — deleting a mod, in one statement."""
+    with session_scope() as db:
+        result = db.execute(delete(Blob).where(Blob.scope == scope))
+        return int(result.rowcount or 0)
+
+
+def materialize(scope: str, destination: Path) -> Path:
+    """Write ``scope`` into ``destination`` and return it.
+
+    Only what changed is written: a file whose on-disk content already hashes
+    to the stored digest is left alone, so a warm cache costs one read per
+    file and no writes. Files present on disk but no longer in the scope are
+    removed, because a mod that dropped a script must not keep running it.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    wanted: dict[str, tuple[str, int]] = {}
+    with session_scope() as db:
+        rows = list(db.execute(select(Blob).where(Blob.scope == scope)).scalars())
+        for row in rows:
+            wanted[row.path] = (row.digest, row.mode)
+            target = destination / row.path
+            if target.is_file() and digest_of(target.read_bytes()) == row.digest:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(bytes(row.content))
+            os.chmod(target, row.mode)
+
+    for existing in sorted(destination.rglob("*"), reverse=True):
+        if existing.is_file():
+            relative = existing.relative_to(destination).as_posix()
+            if relative not in wanted:
+                existing.unlink()
+        elif existing.is_dir() and not any(existing.iterdir()):
+            existing.rmdir()
+    return destination
+
+
+def import_tree(
+    scope: str, source: Path, *, paths: Iterable[Path] | None = None
+) -> int:
+    """Load a directory into ``scope``. The migration path for what is on disk.
+
+    Returns how many files were stored. Symlinks are read through rather than
+    recorded: what a container needs is the bytes, and a link into the
+    operator's home directory would not resolve there anyway.
+    """
+    source = Path(source)
+    if not source.is_dir():
+        return 0
+    stored = 0
+    for item in sorted(paths if paths is not None else source.rglob("*")):
+        if not item.is_file():
+            continue
+        relative = item.relative_to(source).as_posix()
+        put(scope, relative, item.read_bytes(), mode=item.stat().st_mode & 0o777)
+        stored += 1
+    return stored

--- a/spark_pulse/blobs.py
+++ b/spark_pulse/blobs.py
@@ -102,6 +102,11 @@ def _checked(path: str) -> str:
         raise UnsafeBlobPath(f"{path!r} is not a relative path")
     if any(part in ("..", "") for part in candidate.parts):
         raise UnsafeBlobPath(f"{path!r} escapes its scope")
+    # ``Path(".").parts`` is empty, so the check above passes it. It names the
+    # scope root, and materialising it would call ``write_bytes`` on a
+    # directory.
+    if candidate.as_posix() in (".", ""):
+        raise UnsafeBlobPath(f"{path!r} names the scope root, not a file in it")
     return candidate.as_posix()
 
 
@@ -180,10 +185,25 @@ def materialize(scope: str, destination: Path) -> Path:
             wanted[row.path] = (row.digest, row.mode)
             target = destination / row.path
             if target.is_file() and digest_of(target.read_bytes()) == row.digest:
+                # Content is current; the mode may not be. A ``put`` that only
+                # changes permissions leaves the digest alone, and skipping
+                # outright meant a mod's ``run.sh`` promoted to 0755 stayed
+                # non-executable in the cache — the one case the column's own
+                # docstring calls out.
+                if target.stat().st_mode & 0o777 != row.mode:
+                    os.chmod(target, row.mode)
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(bytes(row.content))
             os.chmod(target, row.mode)
+
+    if not wanted:
+        # Nothing is stored under this scope, so there is nothing to reconcile
+        # the directory against. Sweeping here would delete every file in
+        # ``destination`` — and the caller chose that path, so a typo or a
+        # scope that does not exist yet would erase an operator's mod
+        # directory rather than produce an empty cache.
+        return destination
 
     for existing in sorted(destination.rglob("*"), reverse=True):
         if existing.is_file():

--- a/spark_pulse/blobs.py
+++ b/spark_pulse/blobs.py
@@ -75,7 +75,11 @@ class Blob(Base):
     #: Path relative to the scope's root. Never absolute, never containing
     #: ``..`` — checked on the way in, because the far end of this is a
     #: filesystem and eventually a container.
-    path: Mapped[str] = mapped_column(String(1024), primary_key=True)
+    #: ``String(1024)`` would be a cap only PostgreSQL enforces; a deep mod
+    #: tree is a real path. It stays a ``String`` because it is a primary key
+    #: and PostgreSQL will not index an unbounded ``Text`` beyond ~2704 bytes
+    #: — 2048 is well inside that and well past any real relative path.
+    path: Mapped[str] = mapped_column(String(2048), primary_key=True)
     content: Mapped[bytes] = mapped_column(LargeBinary, default=b"")
     #: The executable bit matters: a mod's ``run.sh`` is executed.
     mode: Mapped[int] = mapped_column(Integer, default=0o644)

--- a/spark_pulse/config.py
+++ b/spark_pulse/config.py
@@ -139,6 +139,18 @@ class _Config:
         return int(self._data.get("webui_port", 8100))
 
     @property
+    def database_url(self) -> str:
+        """Where structured state lives. Empty means the SQLite default.
+
+        A SQLAlchemy URL, so the scale case — one control plane becoming
+        several that need shared state — is
+        ``postgresql+psycopg://user@host/spark_pulse`` here and nothing else
+        anywhere. ``SPARK_PULSE_DATABASE_URL`` overrides it, which is how a
+        systemd unit or a test points the process somewhere private.
+        """
+        return str(self._data.get("database_url", ""))
+
+    @property
     def external_url(self) -> str:
         """The address browsers reach this control plane at, if it is fixed.
 

--- a/spark_pulse/config.yaml
+++ b/spark_pulse/config.yaml
@@ -33,6 +33,11 @@ oidc_client_secret: ""
 oidc_provider_url: ""
 spark_vllm_path: /tmp/spark-vllm-docker
 webui_port: 8100
+# Where structured state lives (deployments, nodes, the enrollment ledger,
+# sessions). Empty means SQLite under ~/.config/spark-pulse. A SQLAlchemy URL,
+# so the scale case is a URL change: postgresql+psycopg://user@host/spark_pulse
+# — install the driver with `pip install spark-pulse[postgres]`.
+database_url: ""
 # Browser origins allowed to call this API cross-origin. Empty means "the
 # defaults": this port on localhost, plus the Vite dev server. Never "*" —
 # Starlette reflects the caller's own origin back when the wildcard is combined

--- a/spark_pulse/crypto.py
+++ b/spark_pulse/crypto.py
@@ -1,0 +1,278 @@
+"""Envelope encryption for the secrets that now live in the database.
+
+Config and secrets are moving out of ``~/.config/spark-pulse/*.json`` and into
+the store :mod:`spark_pulse.db` owns, because in a distributed deployment the
+database is the primary and the filesystem is only a local cache. That move
+takes three things with it that were previously protected by a 0600 file on
+one machine: the HuggingFace token, the OIDC client secret, and eventually the
+cluster CA's private key. On PostgreSQL a 0600 file no longer exists, and the
+rows are reachable by anything holding a connection string — a backup, a
+replica, a read-only analytics grant, a ``pg_dump`` in someone's home
+directory. So the values are encrypted before they are written, and the key
+that opens them is *not* in the database.
+
+**The key is an environment variable, per app instance.** ``SPARK_PULSE_MASTER_KEY``
+holds 32 base64 bytes for AES-256-GCM. Keeping it out of the database is the
+entire point: a key stored beside the ciphertext it protects is decoration.
+Every instance of the app that must read a given secret needs the same key,
+which is why it is an operator-supplied constant rather than something this
+program generates on first boot — a self-generated per-node key would make the
+second node unable to read what the first one wrote.
+
+**AEAD, not encryption alone.** GCM authenticates as well as conceals, so a row
+edited in the database — by a botched migration or by someone with write
+access and no read access — fails loudly on the next read instead of decrypting
+to attacker-chosen bytes. The version tag is fed in as associated data, so
+relabelling a ``v1`` token as some future ``v2`` also fails authentication
+rather than being handed to a parser that expects a different shape.
+
+**No key configured means secrets are refused, never stored in the clear.**
+The alternative — fall back to plaintext so the app keeps working — is the
+worse failure in every direction. It is silent: an operator who typoed the
+variable name gets a running system that reports nothing wrong and a database
+full of readable tokens, and the moment they later *set* the key those rows
+are still plaintext, because nothing ever went back for them. It is also
+ambiguous: a plaintext value and a ciphertext value are both just strings in
+the column, so no reader can tell which it is holding, and "is this deployment
+encrypted at rest?" stops having an answer. Refusing turns that into an error
+at the one moment an operator can still act on it — the first attempt to save
+a secret — with a message telling them what to run. :func:`is_configured` is
+how a caller asks in advance so it can refuse politely, in its own vocabulary,
+rather than by propagating an exception.
+
+Generating a key is :func:`generate_key`, so the documentation can hand an
+operator one command::
+
+    python -c "from spark_pulse.crypto import generate_key; print(generate_key())"
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+import secrets
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+__all__ = [
+    "MASTER_KEY_ENV",
+    "KEY_BYTES",
+    "NONCE_BYTES",
+    "VERSION",
+    "CryptoError",
+    "MasterKeyError",
+    "DecryptionError",
+    "generate_key",
+    "is_configured",
+    "is_encrypted",
+    "encrypt",
+    "decrypt",
+]
+
+#: Where the key comes from. Namespaced like every other variable this program
+#: reads, so it is greppable in a unit file and unmistakable in an environment
+#: dump.
+MASTER_KEY_ENV = "SPARK_PULSE_MASTER_KEY"
+
+#: AES-256. Not negotiable per-instance: a key length that varied by
+#: deployment would mean the stored form does not say which cipher opens it.
+KEY_BYTES = 32
+
+#: 96 bits, the size GCM is specified for. Anything else forces the cipher
+#: through an extra hashing step and buys nothing.
+NONCE_BYTES = 12
+
+#: The version tag every stored value carries. Present so that changing the
+#: format later is a branch on a known string rather than a guess about what
+#: the bytes used to mean — the failure this avoids is a future ``v2`` reader
+#: silently mis-parsing a ``v1`` row and returning plausible garbage.
+VERSION = "v1"
+
+_SEPARATOR = "."
+
+
+class CryptoError(Exception):
+    """Base for everything here, so a caller can catch the category."""
+
+
+class MasterKeyError(CryptoError):
+    """The key is absent, undecodable, or the wrong length.
+
+    Distinct from :class:`DecryptionError` because the operator response is
+    different: this one means *fix the environment*, and the other means *you
+    have the wrong key, or the data has been altered*. An operator who rotates
+    a key badly must be able to tell those apart from the message alone.
+    """
+
+
+class DecryptionError(CryptoError):
+    """The ciphertext did not authenticate under this key.
+
+    Wrong key, truncated value, or tampering — GCM cannot distinguish them and
+    neither can we, so the message says all three rather than guessing at one.
+    """
+
+
+def generate_key() -> str:
+    """A fresh master key, base64, ready to paste into an environment file."""
+    return base64.b64encode(secrets.token_bytes(KEY_BYTES)).decode("ascii")
+
+
+def _raw_key() -> str:
+    """The configured key as the operator typed it, or "" for absent.
+
+    An exported-but-empty variable counts as absent: ``Environment=SPARK_PULSE_MASTER_KEY=``
+    in a unit file, or an unset shell variable expanded into a wrapper script,
+    both produce one, and treating it as a zero-length key would report
+    "wrong length" for what is really "not configured".
+    """
+    return os.environ.get(MASTER_KEY_ENV, "").strip()
+
+
+def is_configured() -> bool:
+    """Whether a key is present at all. Not whether it is valid.
+
+    A caller uses this to decide *before* it offers to store a secret, so the
+    refusal reads as "this instance has no master key" rather than as a
+    traceback from the save. A malformed key still raises on use, because a
+    key that is present and wrong is an operator error to surface, not a
+    reason to behave as if none were set.
+    """
+    return bool(_raw_key())
+
+
+def master_key() -> bytes:
+    """The decoded key, or :class:`MasterKeyError` saying which way it is wrong.
+
+    Deliberately not cached. The saving is one base64 decode per secret read,
+    and a cache would need invalidating the moment anything changed the
+    environment — which is exactly what the tests do, and what a supervisor
+    does when it re-execs the process with a rotated key.
+    """
+    raw = _raw_key()
+    if not raw:
+        raise MasterKeyError(
+            f"{MASTER_KEY_ENV} is not set, so secrets cannot be encrypted or read. "
+            "Generate one with: python -c "
+            '"from spark_pulse.crypto import generate_key; print(generate_key())"'
+        )
+    # Accept the URL-safe alphabet and missing padding as well as the strict
+    # form: operators paste these through shells, YAML and secret managers,
+    # and several of those hand back ``-``/``_`` or strip trailing ``=``.
+    # Rejecting a key that is materially correct helps nobody.
+    normalised = raw.replace("-", "+").replace("_", "/")
+    normalised += "=" * (-len(normalised) % 4)
+    try:
+        key = base64.b64decode(normalised, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise MasterKeyError(
+            f"{MASTER_KEY_ENV} is not valid base64. Expected {KEY_BYTES} "
+            f"base64-encoded bytes; generate one with "
+            'python -c "from spark_pulse.crypto import generate_key; '
+            'print(generate_key())"'
+        ) from exc
+    if len(key) != KEY_BYTES:
+        raise MasterKeyError(
+            f"{MASTER_KEY_ENV} decodes to {len(key)} bytes; AES-256-GCM needs "
+            f"exactly {KEY_BYTES}. A key of the wrong length is usually a "
+            "truncated paste."
+        )
+    return key
+
+
+def _b64encode(data: bytes) -> str:
+    """URL-safe and unpadded, so a token survives being a URL or a shell word.
+
+    The stored form ends up in log lines, error messages and occasionally a
+    query string; ``+``, ``/`` and ``=`` are the three characters that would
+    need quoting in one of those places.
+    """
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _b64decode(text: str) -> bytes:
+    """Strict, because a discarded character is corruption worth naming.
+
+    The lenient decoders silently drop anything outside the alphabet, which
+    turns an edited row into a shorter blob and defers the complaint to the
+    authentication tag — where the message would blame the key rather than
+    the value that was actually damaged.
+    """
+    padded = text + "=" * (-len(text) % 4)
+    return base64.b64decode(padded.encode("ascii"), altchars=b"-_", validate=True)
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt ``plaintext`` into the self-describing stored form.
+
+    The form is ``v1.<nonce>.<ciphertext+tag>``, both parts unpadded URL-safe
+    base64. The version leads so it is readable in a ``SELECT`` without
+    decoding anything, and it is also the AEAD's associated data, which is
+    what stops a stored value from being relabelled as a later format.
+
+    The nonce is fresh randomness on every call and never a counter. A counter
+    restarts at zero when a replica reboots or a database is restored from a
+    backup, and two messages sharing a nonce under one GCM key do not merely
+    leak their relationship — they expose the authentication subkey, after
+    which any ciphertext can be forged.
+    """
+    key = master_key()
+    nonce = os.urandom(NONCE_BYTES)
+    ciphertext = AESGCM(key).encrypt(
+        nonce, plaintext.encode("utf-8"), VERSION.encode("ascii")
+    )
+    return _SEPARATOR.join((VERSION, _b64encode(nonce), _b64encode(ciphertext)))
+
+
+def is_encrypted(value: str) -> bool:
+    """Whether ``value`` looks like something :func:`decrypt` should be given.
+
+    For the one-time import of the old JSON secrets, which has to tell a
+    legacy plaintext value from a row that has already been through here, and
+    must not do it by calling :func:`decrypt` and catching the failure — that
+    would make a genuine wrong-key error indistinguishable from a legacy row
+    and quietly re-encrypt someone's ciphertext as if it were a password.
+    """
+    return value.startswith(VERSION + _SEPARATOR)
+
+
+def decrypt(token: str) -> str:
+    """Recover the plaintext, or say precisely which way it could not be.
+
+    :class:`MasterKeyError` if this instance has no usable key;
+    :class:`DecryptionError` if the value is not a token of a version we know,
+    or does not authenticate under the key we have.
+    """
+    key = master_key()
+    parts = token.split(_SEPARATOR)
+    if len(parts) != 3 or parts[0] != VERSION:
+        raise DecryptionError(
+            f"not an encrypted value this build understands: expected a "
+            f"{VERSION!r} token of three {_SEPARATOR!r}-separated parts"
+        )
+    _, nonce_b64, ciphertext_b64 = parts
+    try:
+        nonce = _b64decode(nonce_b64)
+        ciphertext = _b64decode(ciphertext_b64)
+    except (binascii.Error, ValueError) as exc:
+        raise DecryptionError(
+            "encrypted value is corrupt: its base64 does not decode"
+        ) from exc
+    if len(nonce) != NONCE_BYTES:
+        # A short nonce is a truncated or edited row, not a different format —
+        # v1 has only ever emitted twelve bytes.
+        raise DecryptionError(
+            f"encrypted value is corrupt: nonce is {len(nonce)} bytes, "
+            f"expected {NONCE_BYTES}"
+        )
+    try:
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, VERSION.encode("ascii"))
+    except InvalidTag as exc:
+        raise DecryptionError(
+            f"encrypted value failed authentication: either {MASTER_KEY_ENV} is "
+            "not the key this value was written with, or the stored value has "
+            "been altered"
+        ) from exc
+    return plaintext.decode("utf-8")

--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -47,6 +47,7 @@ one backend, or a SQLite-only pragma outside :func:`_configure_sqlite`.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from contextlib import contextmanager
@@ -64,6 +65,8 @@ from sqlalchemy.orm import (
     sessionmaker,
 )
 from sqlalchemy.pool import StaticPool
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "Base",
@@ -210,17 +213,32 @@ def _create_engine(url: str) -> Engine:
     if _is_sqlite(url):
         path = Path(make_url(url).database or "")
         path.parent.mkdir(parents=True, exist_ok=True)
-        created = create_engine(url, connect_args={"check_same_thread": False})
-        _configure_sqlite(created)
-        # 0600 the moment it exists: this file holds OIDC access and refresh
-        # tokens, and on a shared machine the default 0644 hands them to
-        # every local user.
-        with created.connect():
-            pass
+        # 0600 *before* the first connection, not after. Connecting runs
+        # `PRAGMA journal_mode=WAL`, and SQLite copies the database file's mode
+        # onto the `-wal` and `-shm` sidecars at the moment it creates them —
+        # so a chmod afterwards secured the database and left the sidecars at
+        # the umask default. Those sidecars hold the rows most recently
+        # written, which on a first run is every session token this process has
+        # ever minted. The exposure this comment claims to prevent was real for
+        # exactly the run that matters most.
         try:
+            path.touch(mode=0o600, exist_ok=True)
             path.chmod(0o600)
         except OSError:  # pragma: no cover — a filesystem without modes
             pass
+        created = create_engine(url, connect_args={"check_same_thread": False})
+        _configure_sqlite(created)
+        with created.connect():
+            pass
+        for sidecar in (
+            path.with_name(path.name + "-wal"),
+            path.with_name(path.name + "-shm"),
+        ):
+            try:
+                if sidecar.exists():
+                    sidecar.chmod(0o600)
+            except OSError:  # pragma: no cover
+                pass
         return created
     return create_engine(url, pool_pre_ping=True)
 
@@ -247,8 +265,19 @@ def _load_models() -> None:
     for name in _MODEL_MODULES:
         try:
             importlib.import_module(name)
-        except Exception:  # pragma: no cover - a stripped install
-            pass
+        except ModuleNotFoundError as exc:
+            # A stripped install genuinely may not carry every module. Anything
+            # else — an ImportError from a bad dependency, a SyntaxError — must
+            # not be swallowed: the schema would then be emitted *without* that
+            # table and the failure would surface much later as "no such table"
+            # at whichever call site got there first, which is precisely what
+            # importing them all up front exists to prevent.
+            logger.warning(
+                "no model module %s (%s); its table will be absent", name, exc
+            )
+        except Exception:
+            logger.exception("model module %s failed to import", name)
+            raise
 
 
 def _create_schema(engine: Engine) -> None:
@@ -282,6 +311,15 @@ def _create_schema(engine: Engine) -> None:
     # Something other than a race: create_all again so the real error is the
     # one that reaches the caller, rather than a stale one from the retry.
     Base.metadata.create_all(engine)
+
+
+def _session_factory() -> "sessionmaker[Session]":
+    """The session factory, built if needed, read under the lock that builds it."""
+    engine()
+    with _lock:
+        if _sessionmaker is None:  # pragma: no cover — configure() raced us
+            raise RuntimeError("the database was reconfigured mid-transaction")
+        return _sessionmaker
 
 
 def engine() -> Engine:
@@ -333,9 +371,12 @@ def session_scope() -> Iterator[Session]:
     the whole reason the JSON files were written atomically, expressed once
     instead of at each call site.
     """
-    engine()
-    assert _sessionmaker is not None  # engine() builds it
-    session = _sessionmaker()
+    # The factory is captured under the same lock that builds it. Reading the
+    # global afterwards left a window in which ``configure()`` could null it,
+    # and the guard was an ``assert`` — stripped under ``python -O``, where it
+    # becomes ``TypeError: 'NoneType' object is not callable``.
+    factory = _session_factory()
+    session = factory()
     try:
         yield session
         session.commit()

--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -40,7 +40,14 @@ from typing import Any, Iterator
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine, make_url
-from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy import String
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    sessionmaker,
+)
 from sqlalchemy.pool import StaticPool
 
 __all__ = [
@@ -50,12 +57,43 @@ __all__ = [
     "default_database_url",
     "dispose",
     "engine",
+    "is_done",
+    "mark_done",
     "session_scope",
 ]
 
 
 class Base(DeclarativeBase):
     """The declarative base every table in this program inherits from."""
+
+
+class Meta(Base):
+    """Bookkeeping that has to outlive the rows it describes.
+
+    A one-time import cannot key off "is the table empty" — deleting the last
+    deployment would make it empty again and the import would run a second
+    time, resurrecting everything the operator had removed. It keys off a row
+    here instead, which no amount of deleting deployments touches.
+    """
+
+    __tablename__ = "meta"
+
+    key: Mapped[str] = mapped_column(String(128), primary_key=True)
+    value: Mapped[str] = mapped_column(String(1024), default="")
+
+
+def mark_done(key: str, value: str = "1") -> bool:
+    """Record that ``key`` has happened. False if it already had."""
+    with session_scope() as db:
+        if db.get(Meta, key) is not None:
+            return False
+        db.add(Meta(key=key, value=value))
+        return True
+
+
+def is_done(key: str) -> bool:
+    with session_scope() as db:
+        return db.get(Meta, key) is not None
 
 
 def default_database_url() -> str:

--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -1,0 +1,207 @@
+"""The one database, and the one place that decides which database it is.
+
+``docs/cluster-agent-plan.md`` §3.3 chose this: *"SQLite in WAL mode replaces
+the JSON file as the source of truth for desired state, with a single writer
+thread and all access off the event loop. k3s backs a Kubernetes API server
+with SQLite, so it is ample here."* This module is that, plus the seam that
+makes the second half of the sentence — swapping SQLite for PostgreSQL when
+one appliance becomes several — a change to a URL rather than a rewrite.
+
+**Why SQLAlchemy rather than the ``sqlite3`` driver.** Not for the ORM. For the
+dialect boundary: the schema is declared once and emitted as SQLite DDL or
+PostgreSQL DDL by the same code, and every query is written against the same
+API. A direct driver would mean hand-written SQL that is portable only by
+inspection, and the day the URL changed would be the day it was discovered not
+to be. ``SPARK_PULSE_DATABASE_URL=postgresql+psycopg://...`` is the whole
+migration path, and ``pip install spark-pulse[postgres]`` the whole
+dependency.
+
+**Why synchronous.** Everything in ``tools/`` is synchronous and runs on the
+AnyIO worker threads FastAPI hands to sync endpoints; the async half of the
+program is the agent transport and the auth routes. A synchronous engine
+therefore matches the code that has the most state to store, and the async
+callers reach it through ``run_in_threadpool`` — which is §3.3's "all access
+off the event loop" stated as a rule rather than hoped for.
+
+**Portability is a constraint on the schema, not a promise about it.** Column
+types here are the ones both backends have: ``String``, ``Integer``,
+``Float``, ``Boolean``, ``Text``, and JSON via SQLAlchemy's dialect-neutral
+``JSON``. Nothing here may use ``AUTOINCREMENT``, ``ON CONFLICT`` spelled for
+one backend, or a SQLite-only pragma outside :func:`_configure_sqlite`.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+__all__ = [
+    "Base",
+    "configure",
+    "database_url",
+    "default_database_url",
+    "dispose",
+    "engine",
+    "session_scope",
+]
+
+
+class Base(DeclarativeBase):
+    """The declarative base every table in this program inherits from."""
+
+
+def default_database_url() -> str:
+    """Where the database lives when nothing says otherwise.
+
+    Beside the JSON files it replaces, so an operator looking for state finds
+    it where they already look. Simulation gets its own file inside the
+    package's gitignored ``data/`` directory, for the same reason the
+    deployment records do: an e2e run must not be able to write over the
+    deployments of the machine it runs on.
+    """
+    if os.environ.get("SIMULATION_MODE", "0") == "1":
+        path = Path(__file__).resolve().parent / "data" / "spark-pulse.db"
+    else:
+        path = Path.home() / ".config" / "spark-pulse" / "spark-pulse.db"
+    return f"sqlite:///{path}"
+
+
+def database_url() -> str:
+    """The configured URL, or the default."""
+    from spark_pulse.config import config
+
+    return (
+        os.environ.get("SPARK_PULSE_DATABASE_URL")
+        or config.database_url
+        or (default_database_url())
+    )
+
+
+_lock = threading.Lock()
+_engine: Engine | None = None
+_sessionmaker: sessionmaker[Session] | None = None
+_configured_url: str | None = None
+
+
+def _is_sqlite(url: str) -> bool:
+    return make_url(url).get_backend_name() == "sqlite"
+
+
+def _is_memory(url: str) -> bool:
+    database = make_url(url).database
+    return _is_sqlite(url) and (not database or database == ":memory:")
+
+
+def _configure_sqlite(engine: Engine) -> None:
+    """The pragmas that make SQLite safe for more than one reader.
+
+    WAL is the one that matters: without it a writer blocks every reader for
+    the length of its transaction, and with it readers never block at all.
+    ``busy_timeout`` covers the one case WAL does not — two writers — by
+    waiting rather than failing, which at this scale means waiting for a
+    login to finish.
+    """
+
+    @event.listens_for(engine, "connect")
+    def _pragmas(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.execute("PRAGMA busy_timeout=5000")
+        finally:
+            cursor.close()
+
+
+def _create_engine(url: str) -> Engine:
+    if _is_memory(url):
+        # One shared connection, or every session gets its own empty database.
+        return create_engine(
+            url, poolclass=StaticPool, connect_args={"check_same_thread": False}
+        )
+    if _is_sqlite(url):
+        path = Path(make_url(url).database or "")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        created = create_engine(url, connect_args={"check_same_thread": False})
+        _configure_sqlite(created)
+        # 0600 the moment it exists: this file holds OIDC access and refresh
+        # tokens, and on a shared machine the default 0644 hands them to
+        # every local user.
+        with created.connect():
+            pass
+        try:
+            path.chmod(0o600)
+        except OSError:  # pragma: no cover — a filesystem without modes
+            pass
+        return created
+    return create_engine(url, pool_pre_ping=True)
+
+
+def engine() -> Engine:
+    """The process-wide engine, built on first use and reused after."""
+    global _engine, _sessionmaker, _configured_url
+    url = database_url()
+    with _lock:
+        if _engine is None or _configured_url != url:
+            if _engine is not None:
+                _engine.dispose()
+            _engine = _create_engine(url)
+            _sessionmaker = sessionmaker(bind=_engine, expire_on_commit=False)
+            _configured_url = url
+            Base.metadata.create_all(_engine)
+        return _engine
+
+
+def configure(url: str | None) -> None:
+    """Point the process at ``url``, disposing whatever it held before.
+
+    Tests use this to get a database per test; nothing in the product calls
+    it, because the product reads the URL from configuration.
+    """
+    global _engine, _sessionmaker, _configured_url
+    with _lock:
+        if _engine is not None:
+            _engine.dispose()
+        _engine = None
+        _sessionmaker = None
+        _configured_url = None
+    if url is not None:
+        os.environ["SPARK_PULSE_DATABASE_URL"] = url
+    else:
+        os.environ.pop("SPARK_PULSE_DATABASE_URL", None)
+
+
+def dispose() -> None:
+    """Close every pooled connection. Shutdown, and tests."""
+    configure(os.environ.get("SPARK_PULSE_DATABASE_URL"))
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """A transaction: commits on success, rolls back on anything else.
+
+    Every write goes through here rather than through a bare session, so
+    "half the change landed" is not a state this program can reach — which is
+    the whole reason the JSON files were written atomically, expressed once
+    instead of at each call site.
+    """
+    engine()
+    assert _sessionmaker is not None  # engine() builds it
+    session = _sessionmaker()
+    try:
+        yield session
+        session.commit()
+    except BaseException:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -23,6 +23,21 @@ therefore matches the code that has the most state to store, and the async
 callers reach it through ``run_in_threadpool`` — which is §3.3's "all access
 off the event loop" stated as a rule rather than hoped for.
 
+**Do not use ``Session.merge`` for an upsert.** It decides between UPDATE and
+INSERT from a load it performs itself, and on PostgreSQL that produced
+``StaleDataError: UPDATE statement on table 'blobs' expected to update 1
+row(s); 0 were matched`` — it had chosen to update a row its own load had
+seen, and the statement then matched nothing. SQLite never showed it. Write
+the decision out instead::
+
+    row = db.get(Model, key)
+    if row is None:
+        db.add(Model(...))
+    else:
+        row.field = value
+
+which puts the choice inside the transaction, where it can be held.
+
 **Portability is a constraint on the schema, not a promise about it.** Column
 types here are the ones both backends have: ``String``, ``Integer``,
 ``Float``, ``Boolean``, ``Text``, and JSON via SQLAlchemy's dialect-neutral
@@ -184,6 +199,65 @@ def _create_engine(url: str) -> Engine:
     return create_engine(url, pool_pre_ping=True)
 
 
+#: Every module that declares a table. Imported before ``create_all`` so the
+#: schema is the whole schema: SQLAlchemy only emits DDL for models it has
+#: seen, so a process that happened not to import one would create a database
+#: missing that table and fail on the first query against it — at runtime, on
+#: whichever call site got there first.
+_MODEL_MODULES = (
+    "spark_pulse.sessions",
+    "spark_pulse.blobs",
+    "spark_pulse.tools.deployment_records",
+    "spark_pulse.tools.node_registry",
+    "spark_pulse.tools.benchmarking",
+    "spark_pulse.tools.custom_recipes",
+    "spark_pulse.agent.enrollment",
+)
+
+
+def _load_models() -> None:
+    import importlib
+
+    for name in _MODEL_MODULES:
+        try:
+            importlib.import_module(name)
+        except Exception:  # pragma: no cover - a stripped install
+            pass
+
+
+def _create_schema(engine: Engine) -> None:
+    """Create any missing table, tolerating another instance doing the same.
+
+    ``create_all`` checks what exists and then creates what does not, and
+    those are two steps. Two control planes starting against one PostgreSQL
+    — which is the *ordinary* case once there is more than one instance, not
+    a rare race — both see a table missing and both create it, and the loser
+    gets ``duplicate key value violates unique constraint
+    "pg_type_typname_nsp_index"``. Observed, not imagined: six agents sharing
+    one database reproduced it immediately.
+
+    The loser's answer is not to fail. It is to look again: if the table it
+    was told it could not create now exists, the schema is what it needed to
+    be and somebody else did the work.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+
+    try:
+        Base.metadata.create_all(engine)
+        return
+    except (IntegrityError, ProgrammingError, DBAPIError):
+        pass
+
+    existing = set(sa_inspect(engine).get_table_names())
+    missing = [name for name in Base.metadata.tables if name not in existing]
+    if not missing:
+        return  # another instance created them while we were looking
+    # Something other than a race: create_all again so the real error is the
+    # one that reaches the caller, rather than a stale one from the retry.
+    Base.metadata.create_all(engine)
+
+
 def engine() -> Engine:
     """The process-wide engine, built on first use and reused after."""
     global _engine, _sessionmaker, _configured_url
@@ -195,7 +269,8 @@ def engine() -> Engine:
             _engine = _create_engine(url)
             _sessionmaker = sessionmaker(bind=_engine, expire_on_commit=False)
             _configured_url = url
-            Base.metadata.create_all(_engine)
+            _load_models()
+            _create_schema(_engine)
         return _engine
 
 

--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -55,7 +55,7 @@ from typing import Any, Iterator
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine, make_url
-from sqlalchemy import String
+from sqlalchemy import String, Text
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -74,6 +74,7 @@ __all__ = [
     "engine",
     "is_done",
     "mark_done",
+    "mark_done_within",
     "session_scope",
 ]
 
@@ -94,16 +95,41 @@ class Meta(Base):
     __tablename__ = "meta"
 
     key: Mapped[str] = mapped_column(String(128), primary_key=True)
-    value: Mapped[str] = mapped_column(String(1024), default="")
+    #: ``Text``: the enrolment ledger stores a full filesystem path here, and
+    #: a declared length is one only PostgreSQL enforces — the exact shape of
+    #: the bug that made the ledger's own key a hash instead of a path.
+    value: Mapped[str] = mapped_column(Text, default="")
 
 
 def mark_done(key: str, value: str = "1") -> bool:
-    """Record that ``key`` has happened. False if it already had."""
+    """Record that ``key`` has happened. False if it already had.
+
+    Prefer :func:`mark_done_within` for a one-time import: this commits on its
+    own, so a caller that marks here and writes rows afterwards has two
+    transactions and a window between them.
+    """
     with session_scope() as db:
-        if db.get(Meta, key) is not None:
-            return False
-        db.add(Meta(key=key, value=value))
-        return True
+        return mark_done_within(db, key, value)
+
+
+def mark_done_within(db: Session, key: str, value: str = "1") -> bool:
+    """Record ``key`` inside the caller's transaction. False if already done.
+
+    This exists because the marker and the work it describes have to land
+    together. A one-time import that commits "imported" first and then writes
+    the rows has a window: die in it, and the marker says the file was taken
+    while none of it was — permanently, because the marker is what stops it
+    being tried again. The file is then silently discarded, which is the
+    "empty cluster" every state module here refuses by name.
+
+    ``IntegrityError`` on commit is the other instance racing us; the loser's
+    whole transaction rolls back, marker and rows together, and the winner's
+    import stands.
+    """
+    if db.get(Meta, key) is not None:
+        return False
+    db.add(Meta(key=key, value=value))
+    return True
 
 
 def is_done(key: str) -> bool:

--- a/spark_pulse/sessions.py
+++ b/spark_pulse/sessions.py
@@ -1,0 +1,167 @@
+"""Browser sessions, in the database rather than in a dictionary.
+
+What this replaces was one line — ``_active_tokens: dict[str, dict] = {}`` —
+with a comment saying to replace it with Redis in production. Three things
+followed from it being a dictionary in one process's memory, and the first two
+are the reason this exists:
+
+* **A restart logged everyone out.** Not dangerous, but for a service that
+  restarts on upgrade it meant re-authenticating every time.
+* **It ruled out more than one worker.** ``--workers 4`` gives each process its
+  own dictionary, so a cookie minted by one is unknown to the other three and
+  roughly three requests in four get a 401 at random. The shipped systemd unit
+  pins ``--workers 1``, so this was latent — and latent is exactly how it would
+  be found, by whoever first tried to scale under load.
+* The refresh token was stored and never used, which is a separate gap and
+  still is.
+
+Redis was the obvious answer and is the wrong one here: it is a daemon to
+install, supervise, secure and back up, and it puts a network service in front
+of *logging in* — on a control plane whose job is to work when other things
+are broken. SQLite costs no service at all, and §3.3 had already chosen it for
+the rest of the state.
+
+**The row holds OIDC access and refresh tokens**, so the database file is
+0600 from the moment it exists (see :func:`spark_pulse.db._create_engine`). On
+PostgreSQL that guarantee becomes the database's own, which is a thing to
+decide deliberately rather than inherit.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from sqlalchemy import JSON, Float, String, delete, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, session_scope
+
+__all__ = ["Session", "create", "get", "remove", "sweep", "count", "clear"]
+
+#: How many bytes of entropy a session id carries. The cookie is a bearer of
+#: this and nothing else — the provider's tokens never leave the server — so
+#: it has to be unguessable and need not be anything else.
+_TOKEN_BYTES = 32
+
+
+class Session(Base):
+    """One logged-in browser.
+
+    Column types are the ones SQLite and PostgreSQL both have, because the
+    point of the seam is that the same declaration emits DDL for either.
+    """
+
+    __tablename__ = "sessions"
+
+    #: The opaque id in the cookie. The primary key, so a lookup on every
+    #: authenticated request is an index hit rather than a scan.
+    token: Mapped[str] = mapped_column(String(128), primary_key=True)
+    #: The provider's own tokens, which never reach the browser.
+    access_token: Mapped[str] = mapped_column(String(4096), default="")
+    refresh_token: Mapped[str] = mapped_column(String(4096), default="")
+    #: Unix seconds. Indexed because the sweep orders by it.
+    expires_at: Mapped[float] = mapped_column(Float, default=0.0, index=True)
+    created_at: Mapped[str] = mapped_column(String(64), default="")
+    #: The claims the provider published. JSON rather than columns because the
+    #: shape is the provider's, not ours.
+    user: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """The shape the rest of ``auth`` already expects.
+
+        Deliberately identical to what the dictionary held, so moving the
+        store did not become a rewrite of everything that read it.
+        """
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+            "user": self.user or {},
+            "created_at": self.created_at,
+        }
+
+
+def create(
+    *,
+    access_token: str = "",
+    refresh_token: str = "",
+    expires_at: float = 0.0,
+    user: dict[str, Any] | None = None,
+    created_at: str = "",
+    token: str | None = None,
+) -> str:
+    """Store a session and return the id the cookie will carry.
+
+    ``token`` exists for tests that need a known id; nothing in the product
+    passes it, because a session id a caller can choose is a session id an
+    attacker can choose.
+    """
+    session_id = token or secrets.token_urlsafe(_TOKEN_BYTES)
+    with session_scope() as db:
+        db.merge(
+            Session(
+                token=session_id,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at=float(expires_at or 0.0),
+                created_at=created_at,
+                user=user or {},
+            )
+        )
+    return session_id
+
+
+def get(token: str, *, now: float | None = None) -> dict[str, Any] | None:
+    """The session, or None if there is none or it has expired.
+
+    An expired row is deleted on the way past. That is what keeps the table
+    bounded without a scheduled job: the busiest thing in the system reads it,
+    so the busiest thing in the system cleans it.
+    """
+    if not token:
+        return None
+    moment = time.time() if now is None else now
+    with session_scope() as db:
+        row = db.get(Session, token)
+        if row is None:
+            return None
+        if row.expires_at and moment >= row.expires_at:
+            db.delete(row)
+            return None
+        return row.to_dict()
+
+
+def remove(token: str) -> bool:
+    """Drop a session. ``False`` when there was nothing to drop."""
+    if not token:
+        return False
+    with session_scope() as db:
+        row = db.get(Session, token)
+        if row is None:
+            return False
+        db.delete(row)
+        return True
+
+
+def sweep(*, now: float | None = None) -> int:
+    """Delete every expired session, and say how many. Returns 0 on an empty table."""
+    moment = time.time() if now is None else now
+    with session_scope() as db:
+        result = db.execute(
+            delete(Session).where(Session.expires_at != 0, Session.expires_at <= moment)
+        )
+        return int(result.rowcount or 0)
+
+
+def count() -> int:
+    """How many sessions are stored, expired or not. For tests and diagnostics."""
+    with session_scope() as db:
+        return len(list(db.execute(select(Session.token)).scalars()))
+
+
+def clear() -> None:
+    """Drop every session. Logout-everywhere, and test teardown."""
+    with session_scope() as db:
+        db.execute(delete(Session))

--- a/spark_pulse/sessions.py
+++ b/spark_pulse/sessions.py
@@ -100,16 +100,26 @@ def create(
     """
     session_id = token or secrets.token_urlsafe(_TOKEN_BYTES)
     with session_scope() as db:
-        db.merge(
-            Session(
-                token=session_id,
-                access_token=access_token,
-                refresh_token=refresh_token,
-                expires_at=float(expires_at or 0.0),
-                created_at=created_at,
-                user=user or {},
+        # Not ``merge`` — see the house rule in ``db``: it chooses UPDATE from
+        # its own load and then matches nothing on PostgreSQL.
+        row = db.get(Session, session_id)
+        if row is None:
+            db.add(
+                Session(
+                    token=session_id,
+                    access_token=access_token,
+                    refresh_token=refresh_token,
+                    expires_at=float(expires_at or 0.0),
+                    created_at=created_at,
+                    user=user or {},
+                )
             )
-        )
+        else:
+            row.access_token = access_token
+            row.refresh_token = refresh_token
+            row.expires_at = float(expires_at or 0.0)
+            row.created_at = created_at
+            row.user = user or {}
     return session_id
 
 

--- a/spark_pulse/sessions.py
+++ b/spark_pulse/sessions.py
@@ -33,7 +33,7 @@ import secrets
 import time
 from typing import Any
 
-from sqlalchemy import JSON, Float, String, delete, select
+from sqlalchemy import JSON, Float, String, Text, delete, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from spark_pulse.db import Base, session_scope
@@ -59,8 +59,15 @@ class Session(Base):
     #: authenticated request is an index hit rather than a scan.
     token: Mapped[str] = mapped_column(String(128), primary_key=True)
     #: The provider's own tokens, which never reach the browser.
-    access_token: Mapped[str] = mapped_column(String(4096), default="")
-    refresh_token: Mapped[str] = mapped_column(String(4096), default="")
+    #:
+    #: ``Text``, not ``String(n)``. SQLite ignores a declared length and
+    #: PostgreSQL enforces it, so any cap here is a cap that only exists on the
+    #: backend this whole seam was built to enable. Azure AD and Okta routinely
+    #: issue access tokens past 4 KB once group claims are included: with a
+    #: length, login succeeds on SQLite and returns 500 from ``/auth/callback``
+    #: on PostgreSQL, which is the worst possible place to discover it.
+    access_token: Mapped[str] = mapped_column(Text, default="")
+    refresh_token: Mapped[str] = mapped_column(Text, default="")
     #: Unix seconds. Indexed because the sweep orders by it.
     expires_at: Mapped[float] = mapped_column(Float, default=0.0, index=True)
     created_at: Mapped[str] = mapped_column(String(64), default="")

--- a/spark_pulse/tools/benchmarking.py
+++ b/spark_pulse/tools/benchmarking.py
@@ -10,12 +10,16 @@ import json
 import logging
 import threading
 import uuid
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from filelock import FileLock
+from sqlalchemy import JSON, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, is_done, mark_done, session_scope
 
 logger = logging.getLogger(__name__)
 
@@ -51,33 +55,214 @@ def _reset_cache() -> None:
         _bench_cache_dirty = True
 
 
-def _load() -> list[dict]:
+class _BenchmarkRow(Base):
+    """One benchmark result."""
+
+    __tablename__ = "benchmarks"
+
+    benchmark_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    record: Mapped[dict] = mapped_column(JSON, default=dict)
+
+
+#: Recorded once ``benchmarks.json`` has been imported. See the deployment
+#: store for why this is a row rather than "are the tables empty".
+_IMPORT_KEY = "benchmarks.imported_from_json"
+
+
+def _migrate_from_json() -> None:
+    if is_done(_IMPORT_KEY):
+        return
     if not _BENCHMARKS_PATH.exists():
-        return []
+        return
     try:
-        with open(_BENCHMARKS_PATH) as f:
-            return json.load(f)
+        with open(_BENCHMARKS_PATH) as handle:
+            data = json.load(handle)
     except (json.JSONDecodeError, OSError):
-        return []
+        return
+    if not isinstance(data, list) or not mark_done(_IMPORT_KEY):
+        return
+    with session_scope() as db:
+        for record in data:
+            if isinstance(record, dict) and record.get("benchmark_id"):
+                db.merge(
+                    _BenchmarkRow(
+                        benchmark_id=str(record["benchmark_id"]), record=record
+                    )
+                )
+
+
+def _apply(row: _BenchmarkRow, record: dict) -> bool:
+    """Copy ``record`` onto an existing row; ``False`` if nothing differed.
+
+    Assigning an equal-but-distinct dict to a JSON column still marks the
+    attribute dirty, so without this comparison a whole-set save that changed
+    one benchmark emits an UPDATE for every other one — on PostgreSQL a dead
+    tuple and a WAL record per untouched benchmark, on every backend a write
+    that grows with the size of the history rather than the size of the change.
+    """
+    if row.record == record:
+        return False
+    row.record = record
+    return True
+
+
+def _transaction() -> AbstractContextManager[Any]:
+    """Serialise a read-modify-write of the benchmark set.
+
+    Every caller that reads records, changes them and writes them back holds
+    this for the whole sequence — not merely around the write, which is where
+    the transaction already is. A single write being one transaction is a
+    different guarantee and not the one that was missing: two callers that
+    each *load, change, save* still lose one of the changes, because the
+    second writes back a list it read before the first landed. The whole-set
+    path makes that worse than a lost field — it deletes every row absent from
+    the list it loaded, so a benchmark created while it was running is not
+    stale, it is gone. The per-row writers take the same lock for exactly that
+    reason.
+
+    ``_BENCHMARKS_LOCK`` rather than a mutex because it is the one of the two
+    that also holds when a second process — a CLI invocation beside the
+    server — writes the same database. ``filelock`` counts acquisitions per
+    thread, so it is reentrant for the helpers that call one another and still
+    exclusive between threads.
+    """
+    return _BENCHMARKS_LOCK
+
+
+# ── The whole set ────────────────────────────────────────────────────────────
+
+
+def _load() -> list[dict]:
+    """Every stored record.
+
+    Ordered by id, so the sequence is the same on both backends. Without an
+    ``ORDER BY`` a row order is whatever the storage engine last did to the
+    heap, which is not a property to let ``list_benchmarks``' tie-breaking
+    depend on.
+    """
+    _migrate_from_json()
+    with session_scope() as db:
+        rows = db.execute(select(_BenchmarkRow).order_by(_BenchmarkRow.benchmark_id))
+        return [dict(row.record) for row in rows.scalars()]
 
 
 def _save(data: list[dict]) -> None:
-    _BENCHMARKS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = _BENCHMARKS_PATH.with_suffix(".tmp")
-    with open(tmp, "w") as f:
-        json.dump(data, f, indent=2)
-    tmp.rename(_BENCHMARKS_PATH)
+    """Replace the whole set, in one transaction.
+
+    Kept because callers still hold the whole list, and because "the set is
+    now exactly this" — records absent from ``data`` are removed — is a
+    guarantee :func:`_upsert_row` deliberately does not make. What it no
+    longer does is *write* the whole set: only rows that actually differ are
+    updated, so saving a list in which one benchmark changed costs one row
+    rather than the table.
+    """
+    wanted = {
+        str(r["benchmark_id"]): r
+        for r in data
+        if isinstance(r, dict) and r.get("benchmark_id")
+    }
+    with _transaction():
+        # Before the write, not after: an import that ran later would merge
+        # the old JSON file back in and resurrect every record this save had
+        # just removed.
+        _migrate_from_json()
+        with session_scope() as db:
+            stored = {
+                row.benchmark_id: row
+                for row in db.execute(select(_BenchmarkRow)).scalars()
+            }
+            for benchmark_id, row in stored.items():
+                if benchmark_id not in wanted:
+                    db.delete(row)
+            for benchmark_id, record in wanted.items():
+                row = stored.get(benchmark_id)
+                if row is None:
+                    db.add(_BenchmarkRow(benchmark_id=benchmark_id, record=record))
+                else:
+                    _apply(row, record)
 
 
 @contextmanager
 def _atomic_benchmarks():
-    """Context manager for atomic read-modify-write of the benchmarks file."""
+    """Context manager for atomic read-modify-write of the whole benchmark set."""
     global _bench_cache_dirty
-    with _BENCHMARKS_LOCK:
+    with _transaction():
         data = _load()
         yield data
         _save(data)
         _bench_cache_dirty = True
+
+
+# ── One row at a time ────────────────────────────────────────────────────────
+#
+# Everything above treats the benchmark history as one value. That is the right
+# shape for a caller that genuinely rewrote it, and the wrong one for the case
+# that dominates here: one benchmark being created, and that same benchmark
+# finishing. Rewriting ninety days of history to record either is what these
+# replace.
+
+
+def _get_row(benchmark_id: str) -> dict | None:
+    """One record by id, read by primary key rather than by loading the table."""
+    _migrate_from_json()
+    with session_scope() as db:
+        row = db.get(_BenchmarkRow, benchmark_id)
+        return dict(row.record) if row is not None else None
+
+
+def _upsert_row(record: dict) -> None:
+    """Store one record, leaving every other row exactly as it was.
+
+    Unlike :func:`_save` this never deletes: a benchmark this call was not
+    given is one it has no opinion about, not one to remove. That difference
+    is the point — it is what makes the write safe to issue from a caller that
+    never loaded the rest of the history.
+    """
+    benchmark_id = str(record.get("benchmark_id") or "")
+    if not benchmark_id:
+        # ``_save`` skips these silently because in a whole set they are
+        # noise. A per-row write of one is a caller bug that would otherwise
+        # look like a successful write and lose the record.
+        raise ValueError("a benchmark record needs a benchmark_id to be stored")
+    with _transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(_BenchmarkRow, benchmark_id)
+            if row is None:
+                db.add(_BenchmarkRow(benchmark_id=benchmark_id, record=record))
+            else:
+                _apply(row, record)
+
+
+def _delete_row(benchmark_id: str) -> bool:
+    """Drop one record. ``False`` when there was nothing to drop.
+
+    Naming the row is what lets retention express "delete this expired one"
+    instead of "the set is now these other forty", which would also delete
+    whatever was created while it was deciding.
+    """
+    with _transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(_BenchmarkRow, benchmark_id)
+            if row is None:
+                return False
+            db.delete(row)
+            return True
+
+
+def _cache_put(record: dict) -> None:
+    """Keep the point-read cache in step with a single-row write.
+
+    Marking the whole cache dirty would also be correct, and is what the
+    whole-set path does — but then the next ``get_benchmark`` reloads every
+    benchmark in order to learn about one, which is the cost the per-row write
+    exists to avoid. A cache that has never been loaded is left dirty: there is
+    nothing yet to keep in step.
+    """
+    with _bench_cache_lock:
+        if not _bench_cache_dirty:
+            _bench_cache[str(record["benchmark_id"])] = record
 
 
 def _purge_expired(data: list[dict]) -> list[dict]:
@@ -122,14 +307,16 @@ def create_benchmark(
         "results": None,
     }
 
-    with _atomic_benchmarks() as benchmarks:
-        benchmarks.append(record)
-        logger.info(
-            "Created benchmark %s for deployment %s (recipe: %s)",
-            benchmark_id,
-            deployment_id,
-            recipe_name,
-        )
+    # One insert. Appending to the loaded list and saving it back would have
+    # rewritten every benchmark ever run to record this one starting.
+    _upsert_row(record)
+    _cache_put(record)
+    logger.info(
+        "Created benchmark %s for deployment %s (recipe: %s)",
+        benchmark_id,
+        deployment_id,
+        recipe_name,
+    )
 
     return record
 
@@ -138,10 +325,12 @@ def execute_benchmark(benchmark_id: str) -> None:
     """Load a 'running' benchmark record, run llama-benchy, and update its status."""
     logger.info("Executing benchmark %s", benchmark_id)
 
-    with _atomic_benchmarks() as benchmarks:
-        record = next(
-            (b for b in benchmarks if b["benchmark_id"] == benchmark_id), None
-        )
+    # The mutex spans the run, exactly as it did when this was a whole-set
+    # read-modify-write. The record read here is written back when the run
+    # ends, so releasing in between would let a concurrent whole-set save
+    # delete the benchmark and this call quietly resurrect it.
+    with _transaction():
+        record = _get_row(benchmark_id)
         if record is None:
             logger.warning("Benchmark %s not found for execution", benchmark_id)
             return
@@ -178,22 +367,43 @@ def execute_benchmark(benchmark_id: str) -> None:
             record["results"] = {"error": str(e)}
             logger.error("Benchmark %s failed: %s", benchmark_id, e)
 
+        # One row: the benchmark that just finished. The record this writes is
+        # the one read above, so it can only clobber fields of the benchmark
+        # this call owns.
+        _upsert_row(record)
+        _cache_put(record)
+
 
 def list_benchmarks() -> list[dict]:
     """Return all benchmarks sorted by started_at descending."""
+    global _bench_cache_dirty
+
     with _bench_cache_lock:
-        _ensure_cache_loaded()
-        # Re-purge expired on each list call (also marks cache dirty if records removed)
-        raw = _load()
-        raw = _purge_expired(raw)
-        # Sync cache with purged data
+        records = _load()
+        kept = _purge_expired(records)
         _bench_cache.clear()
-        _bench_cache.update({b["benchmark_id"]: b for b in raw})
-        return sorted(
+        _bench_cache.update({b["benchmark_id"]: b for b in kept})
+        _bench_cache_dirty = False
+        listed = sorted(
             _bench_cache.values(),
             key=lambda b: b.get("started_at", ""),
             reverse=True,
         )
+
+    # Outside the cache lock, because deleting takes the mutex and the write
+    # paths take the mutex *before* the cache lock; holding them in both orders
+    # is a deadlock. Expired records used to be filtered out of the answer and
+    # left in the store, so a log line claimed a purge that never happened and
+    # the table grew for ever. Deleting them by name rather than saving the
+    # surviving set keeps the purge from also removing whatever was created
+    # while this list was being assembled.
+    if len(kept) != len(records):
+        surviving = {b["benchmark_id"] for b in kept}
+        for record in records:
+            if record["benchmark_id"] not in surviving:
+                _delete_row(record["benchmark_id"])
+
+    return listed
 
 
 def get_benchmark(benchmark_id: str) -> dict | None:

--- a/spark_pulse/tools/benchmarking.py
+++ b/spark_pulse/tools/benchmarking.py
@@ -19,7 +19,9 @@ from filelock import FileLock
 from sqlalchemy import JSON, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from spark_pulse.db import Base, is_done, mark_done, session_scope
+from sqlalchemy.exc import IntegrityError
+
+from spark_pulse.db import Base, is_done, mark_done_within, session_scope
 
 logger = logging.getLogger(__name__)
 
@@ -79,16 +81,30 @@ def _migrate_from_json() -> None:
             data = json.load(handle)
     except (json.JSONDecodeError, OSError):
         return
-    if not isinstance(data, list) or not mark_done(_IMPORT_KEY):
+    if not isinstance(data, list):
         return
-    with session_scope() as db:
-        for record in data:
-            if isinstance(record, dict) and record.get("benchmark_id"):
-                db.merge(
-                    _BenchmarkRow(
-                        benchmark_id=str(record["benchmark_id"]), record=record
-                    )
-                )
+    # Marker and rows in one transaction, and ``get``-then-write rather than
+    # ``merge`` (see the house rule in :mod:`spark_pulse.db`). Marking in its
+    # own transaction leaves a window in which the marker says the file was
+    # taken while none of it was — and the marker is what stops it being
+    # retried, so the file would be discarded for good.
+    try:
+        with session_scope() as db:
+            if not mark_done_within(db, _IMPORT_KEY):
+                return
+            for record in data:
+                if not (isinstance(record, dict) and record.get("benchmark_id")):
+                    continue
+                key = str(record["benchmark_id"])
+                row = db.get(_BenchmarkRow, key)
+                if row is None:
+                    db.add(_BenchmarkRow(benchmark_id=key, record=record))
+                else:
+                    _apply(row, record)
+    except IntegrityError:
+        # Another instance claimed the import between our read and our insert.
+        # Our whole transaction rolled back; theirs stands.
+        return
 
 
 def _apply(row: _BenchmarkRow, record: dict) -> bool:

--- a/spark_pulse/tools/benchmarking.py
+++ b/spark_pulse/tools/benchmarking.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
 from sqlalchemy import JSON, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -122,7 +123,7 @@ def _apply(row: _BenchmarkRow, record: dict) -> bool:
     return True
 
 
-def _transaction() -> AbstractContextManager[Any]:
+def _transaction(*, timeout: float | None = None) -> AbstractContextManager[Any]:
     """Serialise a read-modify-write of the benchmark set.
 
     Every caller that reads records, changes them and writes them back holds
@@ -141,8 +142,14 @@ def _transaction() -> AbstractContextManager[Any]:
     server — writes the same database. ``filelock`` counts acquisitions per
     thread, so it is reentrant for the helpers that call one another and still
     exclusive between threads.
+
+    ``timeout`` overrides the lock's own for one acquisition; ``0`` means
+    "take it or raise", which is how a read path declines to wait behind a
+    running benchmark.
     """
-    return _BENCHMARKS_LOCK
+    if timeout is None:
+        return _BENCHMARKS_LOCK
+    return _BENCHMARKS_LOCK.acquire(timeout=timeout)
 
 
 # ── The whole set ────────────────────────────────────────────────────────────
@@ -250,14 +257,18 @@ def _upsert_row(record: dict) -> None:
                 _apply(row, record)
 
 
-def _delete_row(benchmark_id: str) -> bool:
+def _delete_row(benchmark_id: str, *, timeout: float | None = None) -> bool:
     """Drop one record. ``False`` when there was nothing to drop.
 
     Naming the row is what lets retention express "delete this expired one"
     instead of "the set is now these other forty", which would also delete
     whatever was created while it was deciding.
+
+    ``timeout=0`` asks for the lock without waiting, and raises
+    ``filelock.Timeout`` rather than blocking — which is what a *read* path
+    wants, since the write mutex is held for the length of a benchmark run.
     """
-    with _transaction():
+    with _transaction(timeout=timeout):
         _migrate_from_json()
         with session_scope() as db:
             row = db.get(_BenchmarkRow, benchmark_id)
@@ -406,18 +417,28 @@ def list_benchmarks() -> list[dict]:
             reverse=True,
         )
 
-    # Outside the cache lock, because deleting takes the mutex and the write
-    # paths take the mutex *before* the cache lock; holding them in both orders
-    # is a deadlock. Expired records used to be filtered out of the answer and
-    # left in the store, so a log line claimed a purge that never happened and
-    # the table grew for ever. Deleting them by name rather than saving the
-    # surviving set keeps the purge from also removing whatever was created
-    # while this list was being assembled.
+    # The purge is *offered*, never waited for. `_delete_row` takes the file
+    # mutex, and `execute_benchmark` holds that mutex for the whole length of a
+    # benchmark run — minutes. Blocking here meant that listing benchmarks
+    # while one was running waited 30 seconds and then raised
+    # `filelock.Timeout`, i.e. a 500 on a read-only endpoint for the duration
+    # of every run. Reading is not the moment to insist on housekeeping: the
+    # expired records are already absent from the answer, and the next attempt
+    # will take them.
     if len(kept) != len(records):
         surviving = {b["benchmark_id"] for b in kept}
         for record in records:
-            if record["benchmark_id"] not in surviving:
-                _delete_row(record["benchmark_id"])
+            if record["benchmark_id"] in surviving:
+                continue
+            try:
+                _delete_row(record["benchmark_id"], timeout=0)
+            except FileLockTimeout:
+                logger.debug(
+                    "benchmark %s is past retention but the store is busy; "
+                    "leaving it for the next sweep",
+                    record["benchmark_id"],
+                )
+                break
 
     return listed
 

--- a/spark_pulse/tools/custom_recipes.py
+++ b/spark_pulse/tools/custom_recipes.py
@@ -31,7 +31,9 @@ from pathlib import Path
 from sqlalchemy import JSON, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from spark_pulse.db import Base, is_done, mark_done, session_scope
+from sqlalchemy.exc import IntegrityError
+
+from spark_pulse.db import Base, is_done, mark_done_within, session_scope
 
 _CUSTOM_PATH = Path.home() / ".config" / "spark-pulse" / "custom-recipes.json"
 
@@ -69,14 +71,28 @@ def _migrate_from_json() -> None:
             data = json.load(handle)
     except (json.JSONDecodeError, OSError):
         return
-    if not isinstance(data, dict) or not mark_done(_IMPORT_KEY):
+    if not isinstance(data, dict):
         return
-    with session_scope() as db:
-        for recipe_id, overrides in data.items():
-            if isinstance(overrides, dict):
-                db.merge(
-                    _CustomizationRow(recipe_id=str(recipe_id), overrides=overrides)
-                )
+    # Marker and rows in one transaction, and ``get``-then-write rather than
+    # ``merge`` (see the house rule in :mod:`spark_pulse.db`). Marking in its
+    # own transaction leaves a window in which the marker says the file was
+    # taken while none of it was — and the marker is what stops it being
+    # retried, so the file would be discarded for good.
+    try:
+        with session_scope() as db:
+            if not mark_done_within(db, _IMPORT_KEY):
+                return
+            for recipe_id, overrides in data.items():
+                if not isinstance(overrides, dict):
+                    continue
+                key = str(recipe_id)
+                row = db.get(_CustomizationRow, key)
+                if row is None:
+                    db.add(_CustomizationRow(recipe_id=key, overrides=overrides))
+                else:
+                    row.overrides = overrides
+    except IntegrityError:
+        return
 
 
 def _apply(row: _CustomizationRow, overrides: dict) -> bool:

--- a/spark_pulse/tools/custom_recipes.py
+++ b/spark_pulse/tools/custom_recipes.py
@@ -1,10 +1,11 @@
 """User recipe customizations storage.
 
-Stores partial overrides for recipes in a separate JSON file
-(~/.config/spark-pulse/custom-recipes.json) so original YAML files
-are never modified — git updates to spark-vllm-docker always work.
+Stores partial overrides for recipes as one row per recipe id, separately from
+the recipe YAML, so original files are never modified — git updates to
+spark-vllm-docker always work. ``~/.config/spark-pulse/custom-recipes.json`` is
+where they used to live and is now only the one-time import source.
 
-Data structure (flat map):
+Data structure (one row's ``overrides``, keyed by recipe id):
   {
     "<recipe_id>": {
       "command": "...",         // override command template
@@ -23,7 +24,14 @@ the original YAML fields (low → high priority).
 from __future__ import annotations
 
 import json
+import threading
+from contextlib import AbstractContextManager
 from pathlib import Path
+
+from sqlalchemy import JSON, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, is_done, mark_done, session_scope
 
 _CUSTOM_PATH = Path.home() / ".config" / "spark-pulse" / "custom-recipes.json"
 
@@ -39,73 +47,200 @@ CUSTOMIZABLE_FIELDS = {
 }
 
 
-def load_customizations() -> dict[str, dict]:
-    """Load all recipe customizations from disk."""
+class _CustomizationRow(Base):
+    """One recipe's partial override."""
+
+    __tablename__ = "recipe_customizations"
+
+    recipe_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    overrides: Mapped[dict] = mapped_column(JSON, default=dict)
+
+
+_IMPORT_KEY = "custom_recipes.imported_from_json"
+
+
+def _migrate_from_json() -> None:
+    if is_done(_IMPORT_KEY):
+        return
     if not _CUSTOM_PATH.exists():
-        return {}
+        return
     try:
-        with open(_CUSTOM_PATH) as f:
-            data = json.load(f)
-        if isinstance(data, dict):
-            return data
+        with open(_CUSTOM_PATH) as handle:
+            data = json.load(handle)
     except (json.JSONDecodeError, OSError):
-        pass
-    return {}
+        return
+    if not isinstance(data, dict) or not mark_done(_IMPORT_KEY):
+        return
+    with session_scope() as db:
+        for recipe_id, overrides in data.items():
+            if isinstance(overrides, dict):
+                db.merge(
+                    _CustomizationRow(recipe_id=str(recipe_id), overrides=overrides)
+                )
+
+
+def _apply(row: _CustomizationRow, overrides: dict) -> bool:
+    """Copy ``overrides`` onto an existing row; ``False`` if nothing differed.
+
+    Assigning an equal-but-distinct dict to a JSON column still marks the
+    attribute dirty, so without this comparison a whole-set save that changed
+    one recipe emits an UPDATE for every other one — a write that grows with
+    the number of customized recipes rather than with the size of the change.
+    """
+    if row.overrides == overrides:
+        return False
+    row.overrides = overrides
+    return True
+
+
+#: Held across every read-modify-write of the customizations.
+#:
+#: :func:`save_customization` merges what the caller sent into what is stored,
+#: so two of them are the classic lost update: both read the same overrides,
+#: both write their own merge, and whichever field the first one set is gone.
+#: It also serialises those against :func:`save_customizations`, whose whole-set
+#: write deletes every recipe absent from the set it was handed — including one
+#: customized since that set was assembled. Reentrant because the writers below
+#: call one another.
+_MUTATION_LOCK = threading.RLock()
+
+
+def transaction() -> AbstractContextManager[None]:
+    """Serialise a read-modify-write of the customizations.
+
+    Every caller that reads customizations, changes them and writes them back
+    must hold this for the whole sequence — not merely around the write, which
+    is where the transaction already is.
+    """
+    return _MUTATION_LOCK
+
+
+# ── The whole set ────────────────────────────────────────────────────────────
+
+
+def load_customizations() -> dict[str, dict]:
+    """Every recipe customization.
+
+    Ordered by recipe id so the mapping is built the same way on both
+    backends: without an ``ORDER BY`` the row order is whatever the storage
+    engine last did to the heap.
+    """
+    _migrate_from_json()
+    with session_scope() as db:
+        rows = db.execute(
+            select(_CustomizationRow).order_by(_CustomizationRow.recipe_id)
+        )
+        return {row.recipe_id: dict(row.overrides) for row in rows.scalars()}
 
 
 def save_customizations(customizations: dict[str, dict]) -> None:
-    """Persist recipe customizations to disk."""
-    _CUSTOM_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = _CUSTOM_PATH.with_suffix(".tmp")
-    with open(tmp, "w") as f:
-        json.dump(customizations, f, indent=2)
-    tmp.rename(_CUSTOM_PATH)
+    """Replace the whole set, in one transaction.
+
+    Kept because "the set is now exactly this" — recipes absent from
+    ``customizations`` are removed — is a guarantee the per-recipe writers
+    below deliberately do not make. What it no longer does is *write* the whole
+    set: only rows that actually differ are updated.
+    """
+    with transaction():
+        # Before the write, not after: an import that ran later would merge the
+        # old JSON file back in and resurrect every customization this save had
+        # just removed.
+        _migrate_from_json()
+        with session_scope() as db:
+            stored = {
+                row.recipe_id: row
+                for row in db.execute(select(_CustomizationRow)).scalars()
+            }
+            for recipe_id, row in stored.items():
+                if recipe_id not in customizations:
+                    db.delete(row)
+            for recipe_id, overrides in customizations.items():
+                row = stored.get(str(recipe_id))
+                if row is None:
+                    db.add(
+                        _CustomizationRow(recipe_id=str(recipe_id), overrides=overrides)
+                    )
+                else:
+                    _apply(row, overrides)
+
+
+# ── One recipe at a time ─────────────────────────────────────────────────────
+#
+# A customization is per recipe in every direction: the UI edits one recipe,
+# the router addresses one recipe, and a recipe listing asks about one recipe
+# at a time. Loading and rewriting the whole set to serve any of that was the
+# storage migration's first step, not its shape.
 
 
 def get_customization(recipe_id: str) -> dict | None:
     """Get partial customization for a specific recipe.
 
     Returns the partial override dict, or None if no customization exists.
+
+    A keyed read rather than a load of the whole set: this is called once per
+    recipe while a listing is assembled, so reading every customization here
+    made a listing cost the whole table once per recipe on it.
     """
-    customizations = load_customizations()
-    return customizations.get(recipe_id)
+    _migrate_from_json()
+    with session_scope() as db:
+        row = db.get(_CustomizationRow, recipe_id)
+        return dict(row.overrides) if row is not None else None
 
 
 def save_customization(recipe_id: str, customization: dict) -> dict:
     """Save (merge) customizations for a recipe.
 
     Only keys in CUSTOMIZABLE_FIELDS are stored. Returns the complete
-    customization dict for this recipe (all fields).
+    customization dict for this recipe (all fields), or an empty one when the
+    merge left nothing and the row was dropped.
+
+    The merge is against what is *stored now* — inside the mutex, in one
+    transaction, on the single row being changed — rather than against a copy
+    of the whole set read earlier. A caller therefore cannot use this to write
+    a stale field back over somebody else's change, only the fields it named,
+    and cannot delete a recipe it never mentioned.
+
+    The row is selected ``FOR UPDATE``, which SQLAlchemy renders for PostgreSQL
+    and omits for SQLite. The mutex serialises one process; the reason
+    PostgreSQL is a supported backend at all is the day there is more than one,
+    and a lock held in Python says nothing to the other process.
     """
-    customizations = load_customizations()
-    # Merge into existing
-    existing = customizations.get(recipe_id, {})
-    # Store only customizable fields, merged with existing
     filtered = {
         k: v
         for k, v in customization.items()
         if k in CUSTOMIZABLE_FIELDS and v is not None
     }
-    merged = {**existing, **filtered}
-    if merged:
-        customizations[recipe_id] = merged
-    else:
-        customizations.pop(recipe_id, None)
-    save_customizations(customizations)
-    return merged
+    with transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(_CustomizationRow, recipe_id, with_for_update=True)
+            merged = {**(dict(row.overrides) if row is not None else {}), **filtered}
+            if not merged:
+                if row is not None:
+                    db.delete(row)
+            elif row is None:
+                db.add(_CustomizationRow(recipe_id=str(recipe_id), overrides=merged))
+            else:
+                _apply(row, merged)
+            return merged
 
 
 def delete_customization(recipe_id: str) -> bool:
     """Remove customization for a specific recipe.
 
     Returns True if a customization existed and was deleted.
+
+    By name, not by saving the set minus it: the whole-set path would also
+    delete any recipe customized between the load and the save.
     """
-    customizations = load_customizations()
-    if recipe_id in customizations:
-        del customizations[recipe_id]
-        save_customizations(customizations)
-        return True
-    return False
+    with transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(_CustomizationRow, recipe_id)
+            if row is None:
+                return False
+            db.delete(row)
+            return True
 
 
 def has_customization(recipe_id: str) -> bool:

--- a/spark_pulse/tools/deployment_records.py
+++ b/spark_pulse/tools/deployment_records.py
@@ -21,6 +21,7 @@ can create one.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import signal
@@ -30,12 +31,17 @@ import threading
 from contextlib import AbstractContextManager
 from typing import Any
 
+from sqlalchemy import JSON, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
 from spark_pulse.config import RUNTIME_NATIVE, config
+from spark_pulse.db import Base, engine, is_done, mark_done, session_scope
 from spark_pulse.tools.atomic_json import (
     StateFileError as StateFileError,
     read_state_file,
-    write_json_atomic,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Where the records live. Simulation writes to the gitignored package copy so
 #: an e2e run cannot overwrite the deployments of the machine it runs on.
@@ -59,6 +65,75 @@ def _redact(cmd: str) -> str:
     return _SENSITIVE_ENV_RE.sub(r"\1[REDACTED]", cmd)
 
 
+# ── The table ────────────────────────────────────────────────────────────────
+
+
+class DeploymentRow(Base):
+    """One deployment, as a row.
+
+    The identifying and queryable fields are columns; the rest of the record
+    is a JSON document. That split is deliberate rather than lazy: the record
+    shape belongs to :mod:`spark_pulse.tools.native_runtime` and is still
+    moving — ranks, orphans, warnings, engine details — while ``id``,
+    ``status`` and ``runtime`` are what everything else filters on and what a
+    future index would be built over. Normalising a shape that is still
+    changing would make every change to it a migration.
+    """
+
+    __tablename__ = "deployments"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    status: Mapped[str] = mapped_column(String(32), default="", index=True)
+    runtime: Mapped[str] = mapped_column(String(32), default="", index=True)
+    created_at: Mapped[str] = mapped_column(String(64), default="")
+    record: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+
+def _row_of(record: dict[str, Any]) -> DeploymentRow:
+    return DeploymentRow(
+        id=str(record.get("id") or ""),
+        status=str(record.get("status") or ""),
+        runtime=str(record.get("runtime") or ""),
+        created_at=str(record.get("created_at") or ""),
+        record=record,
+    )
+
+
+#: Recorded once the legacy file has been imported. Keyed in ``meta`` rather
+#: than inferred from an empty table: deleting the last deployment empties the
+#: table, and an import that re-ran then would resurrect everything.
+_IMPORT_KEY = "deployments.imported_from_json"
+
+
+def _migrate_from_json() -> None:
+    """Import ``deployments.json`` once, if there is one and the table is empty.
+
+    An upgrade must not look like an empty cluster. The file is left where it
+    is rather than deleted — a downgrade should find it, and an operator
+    should be able to see what was imported.
+    """
+    if is_done(_IMPORT_KEY):
+        return
+    data = read_state_file(RECORDS_FILE, expect=list)
+    if data is None:
+        # No file to import, and nothing to remember: a fresh install must not
+        # record an import it never did, or a file restored later is ignored.
+        return
+    if not mark_done(_IMPORT_KEY, RECORDS_FILE.name):
+        return  # another thread got there first
+    with session_scope() as db:
+        for record in data:
+            if isinstance(record, dict) and record.get("id"):
+                db.merge(_row_of(record))
+    if not data:
+        return
+    logger.info(
+        "imported %d deployment record(s) from %s into the state database",
+        len(data),
+        RECORDS_FILE,
+    )
+
+
 # ── The file ─────────────────────────────────────────────────────────────────
 
 
@@ -70,9 +145,10 @@ def load() -> list[dict[str, Any]]:
     unreadable state file is not an empty cluster, and swallowing the error
     here is what lets a control plane tear down running work.
     """
-    data = read_state_file(RECORDS_FILE, expect=list)
-    if data is None:
-        return []
+    _migrate_from_json()
+    with session_scope() as db:
+        rows = list(db.execute(select(DeploymentRow)).scalars())
+    data = [dict(row.record) for row in rows]
     changed = False
     for record in data:
         command = record.get("launch_command") if isinstance(record, dict) else None
@@ -116,8 +192,23 @@ def transaction() -> AbstractContextManager[None]:
 
 
 def save(records: list[dict[str, Any]]) -> None:
-    """Persist the records: temp file, fsync, replace, directory fsync."""
-    write_json_atomic(RECORDS_FILE, records, indent=2, default=str)
+    """Persist the whole record set, replacing what is stored.
+
+    Whole-set rather than per-row because that is the shape every caller
+    already has — ``native_runtime`` loads the list, changes it and saves it
+    back — and changing that shape and the storage in one step would make
+    neither reviewable. The replacement happens in one transaction, so a
+    reader sees the previous set or the new one.
+    """
+    wanted = {
+        str(r.get("id")): r for r in records if isinstance(r, dict) and r.get("id")
+    }
+    with session_scope() as db:
+        for row in list(db.execute(select(DeploymentRow)).scalars()):
+            if row.id not in wanted:
+                db.delete(row)
+        for record in wanted.values():
+            db.merge(_row_of(record))
 
 
 def check_state_file() -> None:
@@ -126,22 +217,31 @@ def check_state_file() -> None:
     Startup calls this so the control plane refuses to come up with an empty
     view of the world while containers are still running.
     """
+    # The JSON file is only consulted while it still exists, to import it.
+    # Once state lives in the database, an unreadable *database* is what
+    # engine() raises on, and it raises for the same reason: an unreadable
+    # state store is not an empty cluster.
     read_state_file(RECORDS_FILE, expect=list)
+    engine()
 
 
 def get(deployment_id: str) -> dict[str, Any] | None:
     """One record by id, exactly as stored."""
-    return next((r for r in load() if r.get("id") == deployment_id), None)
+    _migrate_from_json()
+    with session_scope() as db:
+        row = db.get(DeploymentRow, deployment_id)
+        return dict(row.record) if row is not None else None
 
 
 def delete(deployment_id: str) -> bool:
     """Drop a record. ``False`` when there was nothing to drop."""
     with transaction():
-        records = load()
-        remaining = [r for r in records if r.get("id") != deployment_id]
-        if len(remaining) == len(records):
-            return False
-        save(remaining)
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(DeploymentRow, deployment_id)
+            if row is None:
+                return False
+            db.delete(row)
         return True
 
 

--- a/spark_pulse/tools/deployment_records.py
+++ b/spark_pulse/tools/deployment_records.py
@@ -37,7 +37,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, mapped_column
 
 from spark_pulse.config import RUNTIME_NATIVE, config
-from spark_pulse.db import Base, engine, is_done, mark_done, session_scope
+from spark_pulse.db import Base, engine, is_done, mark_done_within, session_scope
 from spark_pulse.tools.atomic_json import (
     StateFileError as StateFileError,
     read_state_file,
@@ -138,6 +138,20 @@ _IMPORT_KEY = "deployments.imported_from_json"
 _IMPORT_LOCK = threading.Lock()
 
 
+def _write_row(db, record: dict[str, Any]) -> None:
+    """Store one record inside the caller's transaction.
+
+    Get-then-write, not ``merge``: see the house rule in :mod:`spark_pulse.db`
+    — merge chooses UPDATE from a load it performs itself and then matches
+    nothing on PostgreSQL.
+    """
+    row = db.get(DeploymentRow, str(record.get("id") or ""))
+    if row is None:
+        db.add(_row_of(record))
+    else:
+        _apply(row, record)
+
+
 def _migrate_from_json() -> None:
     """Import ``deployments.json`` once, if there is one and the table is empty.
 
@@ -156,27 +170,27 @@ def _migrate_from_json() -> None:
             # not record an import it never did, or a file restored later is
             # ignored.
             return
+        # Marker and rows in one transaction. Claiming first and writing
+        # afterwards leaves a window in which the marker says the file was
+        # taken while none of it was — and the marker is what stops it being
+        # retried, so the records would be gone for good.
         try:
-            claimed = mark_done(_IMPORT_KEY, RECORDS_FILE.name)
+            with session_scope() as db:
+                if not mark_done_within(db, _IMPORT_KEY, RECORDS_FILE.name):
+                    return
+                for record in data:
+                    if isinstance(record, dict) and record.get("id"):
+                        _write_row(db, record)
         except IntegrityError:
             # A second control plane against the same PostgreSQL claimed it
-            # between the read and the insert. The lock above cannot reach
-            # that one, and the outcome is the one that matters: somebody
-            # imported the file, and it was not this process.
+            # between the read and the insert. Our whole transaction rolled
+            # back — marker and rows together — and theirs stands.
             return
-        if not claimed:
-            return
-        with session_scope() as db:
-            for record in data:
-                if isinstance(record, dict) and record.get("id"):
-                    db.merge(_row_of(record))
-        if not data:
-            return
-        logger.info(
-            "imported %d deployment record(s) from %s into the state database",
-            len(data),
-            RECORDS_FILE,
-        )
+    logger.info(
+        "imported %d deployment record(s) from %s into the state database",
+        len(data),
+        RECORDS_FILE,
+    )
 
 
 # ── The file ─────────────────────────────────────────────────────────────────

--- a/spark_pulse/tools/deployment_records.py
+++ b/spark_pulse/tools/deployment_records.py
@@ -28,10 +28,12 @@ import signal
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import threading
+from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from typing import Any
 
 from sqlalchemy import JSON, String, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, mapped_column
 
 from spark_pulse.config import RUNTIME_NATIVE, config
@@ -89,20 +91,51 @@ class DeploymentRow(Base):
     record: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
 
 
+def _fields_of(record: dict[str, Any]) -> dict[str, Any]:
+    """The columns a record projects onto, denormalised out of the document."""
+    return {
+        "id": str(record.get("id") or ""),
+        "status": str(record.get("status") or ""),
+        "runtime": str(record.get("runtime") or ""),
+        "created_at": str(record.get("created_at") or ""),
+        "record": record,
+    }
+
+
 def _row_of(record: dict[str, Any]) -> DeploymentRow:
-    return DeploymentRow(
-        id=str(record.get("id") or ""),
-        status=str(record.get("status") or ""),
-        runtime=str(record.get("runtime") or ""),
-        created_at=str(record.get("created_at") or ""),
-        record=record,
-    )
+    return DeploymentRow(**_fields_of(record))
+
+
+def _apply(row: DeploymentRow, record: dict[str, Any]) -> bool:
+    """Copy ``record`` onto an existing row; ``False`` if nothing differed.
+
+    Assigning an equal-but-distinct dict to a JSON column still marks the
+    attribute dirty, so without this comparison a whole-set save that changed
+    one deployment emits an UPDATE for every other one — on PostgreSQL a dead
+    tuple and a WAL record per untouched deployment, on every backend a write
+    amplification that grows with the size of the cluster rather than with the
+    size of the change.
+    """
+    changed = False
+    for column, value in _fields_of(record).items():
+        if getattr(row, column) != value:
+            setattr(row, column, value)
+            changed = True
+    return changed
 
 
 #: Recorded once the legacy file has been imported. Keyed in ``meta`` rather
 #: than inferred from an empty table: deleting the last deployment empties the
 #: table, and an import that re-ran then would resurrect everything.
 _IMPORT_KEY = "deployments.imported_from_json"
+
+#: Held for the whole check-claim-import, which every read and every write
+#: begins with. ``mark_done`` is a read followed by an insert, so two threads
+#: arriving together both see the key missing and both try to write it: one
+#: gets the row, the other gets a primary-key violation out of what was
+#: supposed to be a question. The startup reconcile and the first API request
+#: are exactly that pair.
+_IMPORT_LOCK = threading.Lock()
 
 
 def _migrate_from_json() -> None:
@@ -114,24 +147,36 @@ def _migrate_from_json() -> None:
     """
     if is_done(_IMPORT_KEY):
         return
-    data = read_state_file(RECORDS_FILE, expect=list)
-    if data is None:
-        # No file to import, and nothing to remember: a fresh install must not
-        # record an import it never did, or a file restored later is ignored.
-        return
-    if not mark_done(_IMPORT_KEY, RECORDS_FILE.name):
-        return  # another thread got there first
-    with session_scope() as db:
-        for record in data:
-            if isinstance(record, dict) and record.get("id"):
-                db.merge(_row_of(record))
-    if not data:
-        return
-    logger.info(
-        "imported %d deployment record(s) from %s into the state database",
-        len(data),
-        RECORDS_FILE,
-    )
+    with _IMPORT_LOCK:
+        if is_done(_IMPORT_KEY):
+            return  # another thread imported it while this one waited
+        data = read_state_file(RECORDS_FILE, expect=list)
+        if data is None:
+            # No file to import, and nothing to remember: a fresh install must
+            # not record an import it never did, or a file restored later is
+            # ignored.
+            return
+        try:
+            claimed = mark_done(_IMPORT_KEY, RECORDS_FILE.name)
+        except IntegrityError:
+            # A second control plane against the same PostgreSQL claimed it
+            # between the read and the insert. The lock above cannot reach
+            # that one, and the outcome is the one that matters: somebody
+            # imported the file, and it was not this process.
+            return
+        if not claimed:
+            return
+        with session_scope() as db:
+            for record in data:
+                if isinstance(record, dict) and record.get("id"):
+                    db.merge(_row_of(record))
+        if not data:
+            return
+        logger.info(
+            "imported %d deployment record(s) from %s into the state database",
+            len(data),
+            RECORDS_FILE,
+        )
 
 
 # ── The file ─────────────────────────────────────────────────────────────────
@@ -149,14 +194,17 @@ def load() -> list[dict[str, Any]]:
     with session_scope() as db:
         rows = list(db.execute(select(DeploymentRow)).scalars())
     data = [dict(row.record) for row in rows]
-    changed = False
     for record in data:
         command = record.get("launch_command") if isinstance(record, dict) else None
         if command and _SENSITIVE_ENV_RE.search(command):
             record["launch_command"] = _redact(command)
-            changed = True
-    if changed:
-        save(data)
+            # Per row, not ``save(data)``. A redaction is a repair to the
+            # records that need it, and a whole-set save here would delete
+            # every deployment another thread created since this load began —
+            # on the read path, which callers reasonably assume writes nothing
+            # they did not ask for.
+            if record.get("id"):
+                update(str(record["id"]), launch_command=record["launch_command"])
     return data
 
 
@@ -194,21 +242,95 @@ def transaction() -> AbstractContextManager[None]:
 def save(records: list[dict[str, Any]]) -> None:
     """Persist the whole record set, replacing what is stored.
 
-    Whole-set rather than per-row because that is the shape every caller
-    already has — ``native_runtime`` loads the list, changes it and saves it
-    back — and changing that shape and the storage in one step would make
-    neither reviewable. The replacement happens in one transaction, so a
-    reader sees the previous set or the new one.
+    Kept because callers still hold the whole list — ``native_runtime`` loads
+    it, changes it and saves it back — and because "the set is now exactly
+    this" is a guarantee :func:`upsert` deliberately does not make: records
+    absent from ``records`` are removed. The replacement happens in one
+    transaction, so a reader sees the previous set or the new one.
+
+    What it no longer does is *write* the whole set. Only rows that actually
+    differ are updated, so the common shape — load the list, change one
+    deployment, save it back — costs one row rather than the table.
+
+    Under the mutex, because a save is one half of the read-modify-write the
+    mutex exists to serialise, and a caller that holds it already re-enters
+    harmlessly.
     """
     wanted = {
         str(r.get("id")): r for r in records if isinstance(r, dict) and r.get("id")
     }
-    with session_scope() as db:
-        for row in list(db.execute(select(DeploymentRow)).scalars()):
-            if row.id not in wanted:
-                db.delete(row)
-        for record in wanted.values():
-            db.merge(_row_of(record))
+    with transaction():
+        with session_scope() as db:
+            stored = {
+                row.id: row for row in db.execute(select(DeploymentRow)).scalars()
+            }
+            for row_id, row in stored.items():
+                if row_id not in wanted:
+                    db.delete(row)
+            for record_id, record in wanted.items():
+                row = stored.get(record_id)
+                if row is None:
+                    db.add(_row_of(record))
+                else:
+                    _apply(row, record)
+
+
+# ── One row at a time ────────────────────────────────────────────────────────
+#
+# Everything above treats the record set as one value. That is the right shape
+# for a caller that genuinely rewrote the set, and the wrong one for the case
+# that actually dominates: a deploy changing the status of the single
+# deployment it is running. These are that case, and they are the operations
+# to reach for when the caller knows which record it touched.
+
+
+def upsert(record: dict[str, Any]) -> None:
+    """Store one record, leaving every other row exactly as it was.
+
+    Unlike :func:`save`, this never deletes: a record that is not in the
+    argument is one this call has no opinion about, not one to remove. That
+    difference is the point — it is what makes a per-row write safe to issue
+    from a caller holding a partial view of the set.
+    """
+    deployment_id = str(record.get("id") or "")
+    if not deployment_id:
+        # ``save`` skips these silently because they are noise in a whole set.
+        # A per-row write of one is a caller bug that would otherwise look
+        # like a successful write and lose the record.
+        raise ValueError("a deployment record needs an id to be stored")
+    with transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(DeploymentRow, deployment_id)
+            if row is None:
+                db.add(_row_of(record))
+            else:
+                _apply(row, record)
+
+
+def update(deployment_id: str, **fields: Any) -> dict[str, Any] | None:
+    """Merge ``fields`` into one stored record. ``None`` if it is not there.
+
+    This is a read-modify-write, which is precisely what the mutex exists for,
+    so it happens inside the mutex and against what is *stored now* rather
+    than against a copy the caller loaded earlier — a caller cannot use this
+    to write a stale field back over somebody else's change, only the fields
+    it named.
+
+    The row is also selected ``FOR UPDATE``, which SQLAlchemy renders for
+    PostgreSQL and omits for SQLite. The mutex serialises one process; the
+    reason PostgreSQL is a supported backend at all is the day there is more
+    than one, and a lock held in Python says nothing to the other process.
+    """
+    with transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            row = db.get(DeploymentRow, deployment_id, with_for_update=True)
+            if row is None:
+                return None
+            record = {**row.record, **fields}
+            _apply(row, record)
+            return record
 
 
 def check_state_file() -> None:
@@ -235,14 +357,26 @@ def get(deployment_id: str) -> dict[str, Any] | None:
 
 def delete(deployment_id: str) -> bool:
     """Drop a record. ``False`` when there was nothing to drop."""
+    return delete_many([deployment_id]) == 1
+
+
+def delete_many(deployment_ids: Iterable[str]) -> int:
+    """Drop several records in one transaction; answers how many existed.
+
+    Retention purging is the caller: naming the rows to remove keeps it from
+    having to express "delete these three" as "the set is now these forty",
+    which would also delete anything created while it was deciding.
+    """
     with transaction():
         _migrate_from_json()
+        removed = 0
         with session_scope() as db:
-            row = db.get(DeploymentRow, deployment_id)
-            if row is None:
-                return False
-            db.delete(row)
-        return True
+            for deployment_id in deployment_ids:
+                row = db.get(DeploymentRow, deployment_id)
+                if row is not None:
+                    db.delete(row)
+                    removed += 1
+        return removed
 
 
 def purge_expired(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -252,7 +386,7 @@ def purge_expired(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return records
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention)
     kept: list[dict[str, Any]] = []
-    changed = False
+    expired: list[str] = []
     for record in records:
         if record.get("status") in ("stopped", "error"):
             stopped_at = record.get("stopped_at")
@@ -262,13 +396,18 @@ def purge_expired(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     if ts.tzinfo is None:
                         ts = ts.replace(tzinfo=timezone.utc)
                     if ts < cutoff:
-                        changed = True
+                        if record.get("id"):
+                            expired.append(str(record["id"]))
                         continue
                 except ValueError:
                     pass
         kept.append(record)
-    if changed:
-        save(kept)
+    if expired:
+        # The rows this decided are expired, not "the set is now ``kept``":
+        # purging runs on the list path, so the set it would write back was
+        # read before the purge started and would take a deployment created
+        # since with it.
+        delete_many(expired)
     return kept
 
 
@@ -308,33 +447,39 @@ def list_legacy() -> list[dict[str, Any]]:
     with no PID never got as far as a process and is marked errored. This is
     the only reconciliation these records will ever get.
     """
-    records = load()
-    legacy = [r for r in records if is_legacy(r)]
-    changed = False
-    for record in legacy:
-        status = record.get("status")
-        if status not in ("running", "pending"):
-            continue
-        pid = record.get("pid")
-        if not pid:
-            if status == "pending":
-                record["status"] = "error"
-                record["error_message"] = (
-                    "Interrupted: the deployment runtime that started this was removed"
-                )
-                record["stopped_at"] = _now()
-                changed = True
-            continue
-        if not _pid_is_alive(int(pid)):
-            record["status"] = "stopped"
-            record.setdefault("stopped_at", _now())
-            changed = True
-        elif status == "pending":
-            record["status"] = "running"
-            changed = True
-    if changed:
-        save(records)
-    return [r for r in purge_expired(records) if is_legacy(r)]
+    with transaction():
+        records = load()
+        reconciled: list[dict[str, Any]] = []
+        for record in records:
+            if not is_legacy(record):
+                continue
+            status = record.get("status")
+            if status not in ("running", "pending"):
+                continue
+            pid = record.get("pid")
+            if not pid:
+                if status == "pending":
+                    record["status"] = "error"
+                    record["error_message"] = (
+                        "Interrupted: the deployment runtime that started this "
+                        "was removed"
+                    )
+                    record["stopped_at"] = _now()
+                    reconciled.append(record)
+                continue
+            if not _pid_is_alive(int(pid)):
+                record["status"] = "stopped"
+                record.setdefault("stopped_at", _now())
+                reconciled.append(record)
+            elif status == "pending":
+                record["status"] = "running"
+                reconciled.append(record)
+        for record in reconciled:
+            # Only the records this sweep decided something about. A native
+            # deployment created while the PIDs were being probed is none of
+            # this function's business, and a whole-set save would delete it.
+            upsert(record)
+        return [r for r in purge_expired(records) if is_legacy(r)]
 
 
 def stop_legacy(deployment_id: str) -> dict[str, Any] | None:
@@ -344,21 +489,21 @@ def stop_legacy(deployment_id: str) -> dict[str, Any] | None:
     ``start_new_session=True``, so the whole tree goes. A PID that is already
     gone is success: the point is that the record and the machine agree.
     """
-    records = load()
-    for record in records:
-        if record.get("id") != deployment_id:
-            continue
+    with transaction():
+        record = get(deployment_id)
+        if record is None:
+            return None
         pid = record.get("pid")
         if pid:
             try:
                 os.killpg(os.getpgid(int(pid)), signal.SIGTERM)
             except (ProcessLookupError, PermissionError, OSError):
                 pass
-        record["status"] = "stopped"
-        record["stopped_at"] = _now()
-        save(records)
-        return record
-    return None
+        # The signal and the record change are one step, so a concurrent
+        # delete cannot land between them and leave a signalled process with
+        # no record; and it is a two-field update of one row, not a rewrite of
+        # every deployment on the machine.
+        return update(deployment_id, status="stopped", stopped_at=_now())
 
 
 #: How much of a log file the tail may read. An engine log runs to gigabytes;

--- a/spark_pulse/tools/native_runtime.py
+++ b/spark_pulse/tools/native_runtime.py
@@ -520,8 +520,9 @@ def _load_records() -> list[dict[str, Any]]:
 def _save_records(records: list[dict[str, Any]]) -> None:
     """Persist the deployment records.
 
-    Delegates to ``deployment_records.save``, which writes through
-    ``atomic_json.write_json_atomic`` — temp file, fsync, replace, dir fsync.
+    Delegates to ``deployment_records.save``, which replaces the whole set in
+    one database transaction — so a reader sees the previous set or the new
+    one, never half of either.
     """
     tools.deployment_records.save(records)
 

--- a/spark_pulse/tools/node_registry.py
+++ b/spark_pulse/tools/node_registry.py
@@ -47,6 +47,8 @@ from typing import Any, Iterable
 from sqlalchemy import JSON, Boolean, String, select
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
+from sqlalchemy.exc import IntegrityError
+
 from spark_pulse.db import Base, is_done, mark_done_within, session_scope
 from spark_pulse.tools.atomic_json import read_state_file
 
@@ -374,16 +376,24 @@ def _migrate_from_json() -> None:
     # afterwards leaves a window in which the marker says the file was taken
     # while none of it was — and the marker is what stops it being tried
     # again, so the registry would be empty for good.
-    with session_scope() as db:
-        if not mark_done_within(db, _IMPORT_KEY, registry_path().name):
-            return
-        # Through ``NodeRecord.from_dict`` rather than straight off the dict:
-        # a hand-edited nodes.json is a supported thing to have, and an entry
-        # without an id is given one there.
-        for item in raw:
-            if not isinstance(item, dict):
-                continue
-            _upsert(db, NodeRecord.from_dict(item))
+    try:
+        with session_scope() as db:
+            if not mark_done_within(db, _IMPORT_KEY, registry_path().name):
+                return
+            # Through ``NodeRecord.from_dict`` rather than straight off the dict:
+            # a hand-edited nodes.json is a supported thing to have, and an entry
+            # without an id is given one there.
+            for item in raw:
+                if not isinstance(item, dict):
+                    continue
+                _upsert(db, NodeRecord.from_dict(item))
+    except IntegrityError:
+        # Another reader claimed the import between our check and our insert.
+        # This runs from plain reads (`list_nodes`, `self_node`) and outside
+        # the mutation mutex, so two concurrent first reads on an upgrade —
+        # the lifespan's `register_self` beside reconciliation — really do
+        # race. Our whole transaction rolled back; theirs stands.
+        return
     logger.info(
         "imported %d node(s) from %s into the state database", len(raw), registry_path()
     )

--- a/spark_pulse/tools/node_registry.py
+++ b/spark_pulse/tools/node_registry.py
@@ -33,7 +33,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-from spark_pulse.tools.atomic_json import read_state_file, write_json_atomic
+from sqlalchemy import JSON, Boolean, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spark_pulse.db import Base, is_done, mark_done, session_scope
+from spark_pulse.tools.atomic_json import read_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +211,64 @@ class Finding:
 # ── Persistence ──────────────────────────────────────────────────────────────
 
 
+# ── The table ────────────────────────────────────────────────────────────────
+
+#: Recorded once ``nodes.json`` has been imported. In ``meta`` rather than
+#: inferred from an empty table: removing the last node empties the table, and
+#: an import that re-ran then would resurrect a node the operator forgot.
+_IMPORT_KEY = "nodes.imported_from_json"
+
+
+class _NodeRow(Base):
+    """One machine, as a row.
+
+    ``id`` and ``address`` are columns because identity and reachability are
+    what everything looks a node up by; the rest travels as a document, for
+    the same reason the deployment record does — the shape is still growing.
+    """
+
+    __tablename__ = "nodes"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    address: Mapped[str] = mapped_column(String(255), default="", index=True)
+    is_control_plane: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    record: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+
+def _migrate_from_json() -> None:
+    """Import ``nodes.json`` once, if there is one. See §3.3."""
+    if is_done(_IMPORT_KEY):
+        return
+    data = read_state_file(registry_path(), expect=dict)
+    if data is None:
+        return
+    if not mark_done(_IMPORT_KEY, registry_path().name):
+        return
+    raw = data.get("nodes")
+    if not isinstance(raw, list):
+        return
+    # Through ``NodeRecord.from_dict`` rather than straight off the dict: a
+    # hand-edited nodes.json is a supported thing to have, and an entry
+    # without an id is given one there. Importing the raw dict would have
+    # silently dropped exactly the records an operator wrote by hand.
+    with session_scope() as db:
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            node = NodeRecord.from_dict(item)
+            db.merge(
+                _NodeRow(
+                    id=node.id,
+                    address=node.address,
+                    is_control_plane=node.is_control_plane,
+                    record=node.to_dict(),
+                )
+            )
+    logger.info(
+        "imported %d node(s) from %s into the state database", len(raw), registry_path()
+    )
+
+
 def list_nodes() -> list[NodeRecord]:
     """Every node in the registry, control plane first, then by name.
 
@@ -214,13 +276,10 @@ def list_nodes() -> list[NodeRecord]:
         StateFileError: The file exists but could not be read or parsed. A
             registry we cannot read is not an empty cluster.
     """
-    data = read_state_file(registry_path(), expect=dict)
-    if not data:
-        return []
-    raw = data.get("nodes")
-    if not isinstance(raw, list):
-        return []
-    nodes = [NodeRecord.from_dict(item) for item in raw if isinstance(item, dict)]
+    _migrate_from_json()
+    with session_scope() as db:
+        rows = list(db.execute(select(_NodeRow)).scalars())
+    nodes = [NodeRecord.from_dict(dict(row.record)) for row in rows]
     return _sorted(nodes)
 
 
@@ -229,10 +288,27 @@ def _sorted(nodes: Iterable[NodeRecord]) -> list[NodeRecord]:
 
 
 def _save(nodes: Iterable[NodeRecord]) -> None:
-    write_json_atomic(
-        registry_path(),
-        {"version": 1, "nodes": [node.to_dict() for node in _sorted(nodes)]},
-    )
+    """Replace the whole registry, in one transaction.
+
+    Whole-set because that is the shape every caller has — add, update and
+    remove each rebuild the list — and one transaction so a reader sees the
+    previous registry or the new one, never half of either.
+    """
+    wanted = {node.id: node for node in nodes}
+    with session_scope() as db:
+        for row in list(db.execute(select(_NodeRow)).scalars()):
+            if row.id not in wanted:
+                db.delete(row)
+        for node in wanted.values():
+            record = node.to_dict()
+            db.merge(
+                _NodeRow(
+                    id=node.id,
+                    address=node.address,
+                    is_control_plane=node.is_control_plane,
+                    record=record,
+                )
+            )
 
 
 def get_node(node_id: str) -> NodeRecord | None:

--- a/spark_pulse/tools/node_registry.py
+++ b/spark_pulse/tools/node_registry.py
@@ -15,9 +15,18 @@ node keeps its id across a rename or a re-address, and the machine-id is read
 only by :func:`read_machine_id` and used only by :func:`diagnose`, which warns
 when two nodes report the same one.
 
-State lives in ``~/.config/spark-pulse/nodes.json`` and goes through
-:mod:`spark_pulse.tools.atomic_json`, so a crash mid-write cannot lose the
-registry and an unreadable file is a hard error rather than an empty cluster.
+State lives in the state database (:mod:`spark_pulse.db`). A pre-existing
+``~/.config/spark-pulse/nodes.json`` is imported once, keyed on the ``meta``
+table rather than on an empty ``nodes`` table — see :data:`_IMPORT_KEY` — and a
+``nodes.json`` that exists but cannot be parsed is a hard error rather than an
+empty cluster.
+
+Writes are per row. Every mutation here changes exactly one node, so it reads
+one row and writes one row; :func:`_save` is kept for the bulk case, where the
+caller has a whole registry rather than one change. Both are serialised by
+:data:`_MUTATION_LOCK`, because every rule this module enforces — one control
+plane, one node per address — is set-wide, and so every mutation is a
+look-then-write.
 
 :func:`register_self` is what puts the control node in the registry on first
 run. It is idempotent across restarts and it **fills blanks only**: a value an
@@ -27,14 +36,16 @@ operator has typed is never replaced by a discovered one.
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
+from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 from sqlalchemy import JSON, Boolean, String, select
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from spark_pulse.db import Base, is_done, mark_done, session_scope
 from spark_pulse.tools.atomic_json import read_state_file
@@ -208,9 +219,6 @@ class Finding:
         return data
 
 
-# ── Persistence ──────────────────────────────────────────────────────────────
-
-
 # ── The table ────────────────────────────────────────────────────────────────
 
 #: Recorded once ``nodes.json`` has been imported. In ``meta`` rather than
@@ -235,6 +243,103 @@ class _NodeRow(Base):
     record: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
 
 
+def _row_of(node: NodeRecord) -> _NodeRow:
+    """The row for a record: two queried columns, and the record as a document.
+
+    ``address`` and ``is_control_plane`` are duplicated out of the document
+    because they are what the uniqueness rules are checked against, and a check
+    that scanned the document would have to read every node to write one.
+    """
+    return _NodeRow(
+        id=node.id,
+        address=node.address,
+        is_control_plane=node.is_control_plane,
+        record=node.to_dict(),
+    )
+
+
+# ── Per-row access ───────────────────────────────────────────────────────────
+
+
+#: Held across every look-then-write in this module.
+#:
+#: Each rule here is set-wide — one control plane, one node per address — so
+#: every mutation reads the registry before it writes, and two threads that
+#: each *check, then write* both find the address free and both register it.
+#: The whole-set save hid half of that behind a different bug: the second
+#: writer replaced the entire registry with the list it had read before the
+#: first landed, so the duplicate never appeared because the first node had
+#: been deleted instead. Per-row writes remove the deletion, which leaves the
+#: check-then-write exposed, which is what this closes. Reentrant because
+#: :func:`register_self` decides between :func:`add_node` and
+#: :func:`update_node` while holding it — that decision is itself a
+#: look-then-write, and two of them racing is how a cluster ends up with two
+#: control-plane records.
+_MUTATION_LOCK = threading.RLock()
+
+
+def _transaction() -> AbstractContextManager[None]:
+    """Serialise a look-then-write. See :data:`_MUTATION_LOCK`."""
+    return _MUTATION_LOCK
+
+
+def _get(db: Session, node_id: str) -> NodeRecord | None:
+    """One node by primary key, without loading the registry."""
+    row = db.get(_NodeRow, node_id)
+    return NodeRecord.from_dict(dict(row.record)) if row is not None else None
+
+
+def _upsert(db: Session, node: NodeRecord) -> None:
+    """Write one node, leaving every other row untouched.
+
+    This is the point of the per-row layer: marking a single peer ``dead`` used
+    to rewrite every node in the registry, which on PostgreSQL means taking a
+    row lock on each one for a change that concerns exactly one.
+    """
+    db.merge(_row_of(node))
+
+
+def _delete(db: Session, node_id: str) -> bool:
+    """Drop one node. ``False`` when there was nothing to drop."""
+    row = db.get(_NodeRow, node_id)
+    if row is None:
+        return False
+    db.delete(row)
+    return True
+
+
+def _control_plane_row(db: Session) -> _NodeRow | None:
+    """The control-plane row, by its indexed column rather than by scanning."""
+    return (
+        db.execute(select(_NodeRow).where(_NodeRow.is_control_plane.is_(True)))
+        .scalars()
+        .first()
+    )
+
+
+def _refuse_duplicate_address(
+    db: Session, address: str, *, except_id: str = ""
+) -> None:
+    """Raise if another node already answers at ``address``.
+
+    Takes the session it is checked in, so the check and the write it guards
+    are the same transaction and the check cannot read a registry the write
+    then lands on top of. Two *processes* would still need a unique constraint
+    to be stopped; one control plane is what this program runs, and
+    :data:`_MUTATION_LOCK` covers its threads.
+
+    An empty address is not a collision: the control plane is allowed to exist
+    before discovery has found one.
+    """
+    if not address:
+        return
+    query = select(_NodeRow.id).where(_NodeRow.address == address)
+    if except_id:
+        query = query.where(_NodeRow.id != except_id)
+    if db.execute(query).first() is not None:
+        raise ValueError(f"a node with address {address} is already registered")
+
+
 def _migrate_from_json() -> None:
     """Import ``nodes.json`` once, if there is one. See §3.3."""
     if is_done(_IMPORT_KEY):
@@ -255,15 +360,7 @@ def _migrate_from_json() -> None:
         for item in raw:
             if not isinstance(item, dict):
                 continue
-            node = NodeRecord.from_dict(item)
-            db.merge(
-                _NodeRow(
-                    id=node.id,
-                    address=node.address,
-                    is_control_plane=node.is_control_plane,
-                    record=node.to_dict(),
-                )
-            )
+            _upsert(db, NodeRecord.from_dict(item))
     logger.info(
         "imported %d node(s) from %s into the state database", len(raw), registry_path()
     )
@@ -288,43 +385,42 @@ def _sorted(nodes: Iterable[NodeRecord]) -> list[NodeRecord]:
 
 
 def _save(nodes: Iterable[NodeRecord]) -> None:
-    """Replace the whole registry, in one transaction.
+    """Replace the whole registry with ``nodes``, in one transaction.
 
-    Whole-set because that is the shape every caller has — add, update and
-    remove each rebuild the list — and one transaction so a reader sees the
-    previous registry or the new one, never half of either.
+    *Replace*: a node absent from ``nodes`` is deleted. That is the contract a
+    caller holding a whole registry wants — reconciliation against an external
+    source of truth, or a restore — and it is why this is not the path a single
+    change takes: :func:`update_node` renaming one peer through here would read
+    and rewrite every other one, and would delete any node a concurrent writer
+    had added since ``nodes`` was read. Single changes go through
+    :func:`_upsert` and :func:`_delete` instead.
+
+    One transaction, so a reader sees the previous registry or the new one and
+    never half of either.
     """
     wanted = {node.id: node for node in nodes}
-    with session_scope() as db:
-        for row in list(db.execute(select(_NodeRow)).scalars()):
-            if row.id not in wanted:
-                db.delete(row)
-        for node in wanted.values():
-            record = node.to_dict()
-            db.merge(
-                _NodeRow(
-                    id=node.id,
-                    address=node.address,
-                    is_control_plane=node.is_control_plane,
-                    record=record,
-                )
-            )
+    with _transaction():
+        with session_scope() as db:
+            for row in list(db.execute(select(_NodeRow)).scalars()):
+                if row.id not in wanted:
+                    db.delete(row)
+            for node in wanted.values():
+                _upsert(db, node)
 
 
 def get_node(node_id: str) -> NodeRecord | None:
     """The node with ``node_id``, or ``None``."""
-    for node in list_nodes():
-        if node.id == node_id:
-            return node
-    return None
+    _migrate_from_json()
+    with session_scope() as db:
+        return _get(db, node_id)
 
 
 def self_node() -> NodeRecord | None:
     """The control-plane record, or ``None`` before :func:`register_self`."""
-    for node in list_nodes():
-        if node.is_control_plane:
-            return node
-    return None
+    _migrate_from_json()
+    with session_scope() as db:
+        row = _control_plane_row(db)
+        return NodeRecord.from_dict(dict(row.record)) if row is not None else None
 
 
 def add_node(
@@ -353,12 +449,6 @@ def add_node(
     if state not in NODE_STATES:
         raise ValueError(f"state must be one of {', '.join(NODE_STATES)}")
 
-    nodes = list_nodes()
-    if address and any(n.address == address for n in nodes):
-        raise ValueError(f"a node with address {address} is already registered")
-    if is_control_plane and any(n.is_control_plane for n in nodes):
-        raise ValueError("the control plane is already registered")
-
     node = NodeRecord(
         id=mint_node_id(),
         name=name or address,
@@ -373,8 +463,13 @@ def add_node(
         last_seen=_now() if is_control_plane else None,
         machine_id=machine_id,
     )
-    nodes.append(node)
-    _save(nodes)
+    with _transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            _refuse_duplicate_address(db, address)
+            if is_control_plane and _control_plane_row(db) is not None:
+                raise ValueError("the control plane is already registered")
+            _upsert(db, node)
     return node
 
 
@@ -422,21 +517,16 @@ def update_node(node_id: str, **changes: Any) -> NodeRecord:
                 "empty when it is not known"
             )
 
-    nodes = list_nodes()
-    for index, node in enumerate(nodes):
-        if node.id != node_id:
-            continue
-        updated = replace(node, **changes)
-        if updated.address and any(
-            other.address == updated.address and other.id != node_id for other in nodes
-        ):
-            raise ValueError(
-                f"a node with address {updated.address} is already registered"
-            )
-        nodes[index] = updated
-        _save(nodes)
-        return updated
-    raise KeyError(node_id)
+    with _transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            current = _get(db, node_id)
+            if current is None:
+                raise KeyError(node_id)
+            updated = replace(current, **changes)
+            _refuse_duplicate_address(db, updated.address, except_id=node_id)
+            _upsert(db, updated)
+    return updated
 
 
 def remove_node(node_id: str) -> NodeRecord:
@@ -450,16 +540,18 @@ def remove_node(node_id: str) -> NodeRecord:
         KeyError: No such node.
         ValueError: The node is the control plane, which cannot forget itself.
     """
-    nodes = list_nodes()
-    for index, node in enumerate(nodes):
-        if node.id != node_id:
-            continue
-        if node.is_control_plane:
-            raise ValueError("the control plane cannot be removed from the registry")
-        nodes.pop(index)
-        _save(nodes)
-        return node
-    raise KeyError(node_id)
+    with _transaction():
+        _migrate_from_json()
+        with session_scope() as db:
+            node = _get(db, node_id)
+            if node is None:
+                raise KeyError(node_id)
+            if node.is_control_plane:
+                raise ValueError(
+                    "the control plane cannot be removed from the registry"
+                )
+            _delete(db, node_id)
+    return node
 
 
 # ── The control node registers itself ────────────────────────────────────────
@@ -553,37 +645,44 @@ def register_self(*, name: str = "") -> NodeRecord:
     so an address or an interface name an operator corrected by hand survives
     the next restart. ``last_seen`` and ``machine_id`` are refreshed each time
     because they are observations, not settings.
+
+    "Is there a control node already?" and the write that follows are one
+    decision, so they are taken under :data:`_MUTATION_LOCK`: two startups
+    racing — the lifespan hook and an agent re-enrolling — would otherwise both
+    see no control node and one of them would fail on the uniqueness rule
+    rather than adopting the record the other had just written.
     """
     import socket
 
     discovered = _discovered_self()
     default_name = name.strip() or socket.gethostname() or "control"
 
-    existing = self_node()
-    if existing is None:
-        return add_node(
-            name=default_name,
-            is_control_plane=True,
-            state="healthy",
-            machine_id=read_machine_id(),
-            **discovered,
-        )
+    with _transaction():
+        existing = self_node()
+        if existing is None:
+            return add_node(
+                name=default_name,
+                is_control_plane=True,
+                state="healthy",
+                machine_id=read_machine_id(),
+                **discovered,
+            )
 
-    changes: dict[str, Any] = {}
-    if not existing.name:
-        changes["name"] = default_name
-    if not existing.address and discovered["address"]:
-        changes["address"] = discovered["address"]
-    if not existing.ethernet_interface and discovered["ethernet_interface"]:
-        changes["ethernet_interface"] = discovered["ethernet_interface"]
-    if not existing.infiniband_interfaces and discovered["infiniband_interfaces"]:
-        changes["infiniband_interfaces"] = discovered["infiniband_interfaces"]
-    if not existing.fabric_mode and discovered["fabric_mode"]:
-        changes["fabric_mode"] = discovered["fabric_mode"]
-    changes["state"] = "healthy"
-    changes["last_seen"] = _now()
-    changes["machine_id"] = read_machine_id()
-    return update_node(existing.id, **changes)
+        changes: dict[str, Any] = {}
+        if not existing.name:
+            changes["name"] = default_name
+        if not existing.address and discovered["address"]:
+            changes["address"] = discovered["address"]
+        if not existing.ethernet_interface and discovered["ethernet_interface"]:
+            changes["ethernet_interface"] = discovered["ethernet_interface"]
+        if not existing.infiniband_interfaces and discovered["infiniband_interfaces"]:
+            changes["infiniband_interfaces"] = discovered["infiniband_interfaces"]
+        if not existing.fabric_mode and discovered["fabric_mode"]:
+            changes["fabric_mode"] = discovered["fabric_mode"]
+        changes["state"] = "healthy"
+        changes["last_seen"] = _now()
+        changes["machine_id"] = read_machine_id()
+        return update_node(existing.id, **changes)
 
 
 # ── Diagnostics ──────────────────────────────────────────────────────────────

--- a/spark_pulse/tools/node_registry.py
+++ b/spark_pulse/tools/node_registry.py
@@ -47,7 +47,7 @@ from typing import Any, Iterable
 from sqlalchemy import JSON, Boolean, String, select
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
-from spark_pulse.db import Base, is_done, mark_done, session_scope
+from spark_pulse.db import Base, is_done, mark_done_within, session_scope
 from spark_pulse.tools.atomic_json import read_state_file
 
 logger = logging.getLogger(__name__)
@@ -295,8 +295,20 @@ def _upsert(db: Session, node: NodeRecord) -> None:
     This is the point of the per-row layer: marking a single peer ``dead`` used
     to rewrite every node in the registry, which on PostgreSQL means taking a
     row lock on each one for a change that concerns exactly one.
+
+    ``get``-then-write rather than ``merge``: see the house rule in
+    :mod:`spark_pulse.db` — merge chooses UPDATE from a load it performs
+    itself and then matches nothing on PostgreSQL, which surfaces as a
+    ``StaleDataError`` out of ``update_node`` instead of the ``KeyError`` a
+    caller expects.
     """
-    db.merge(_row_of(node))
+    row = db.get(_NodeRow, node.id)
+    if row is None:
+        db.add(_row_of(node))
+    else:
+        row.address = node.address
+        row.is_control_plane = node.is_control_plane
+        row.record = node.to_dict()
 
 
 def _delete(db: Session, node_id: str) -> bool:
@@ -347,16 +359,27 @@ def _migrate_from_json() -> None:
     data = read_state_file(registry_path(), expect=dict)
     if data is None:
         return
-    if not mark_done(_IMPORT_KEY, registry_path().name):
-        return
     raw = data.get("nodes")
     if not isinstance(raw, list):
+        # Checked *before* the marker: a file whose shape we do not understand
+        # must not be recorded as imported, or a hand-edited registry is
+        # discarded permanently and silently.
+        logger.error(
+            "%s has no usable 'nodes' list; not importing it, and not "
+            "recording it as imported",
+            registry_path(),
+        )
         return
-    # Through ``NodeRecord.from_dict`` rather than straight off the dict: a
-    # hand-edited nodes.json is a supported thing to have, and an entry
-    # without an id is given one there. Importing the raw dict would have
-    # silently dropped exactly the records an operator wrote by hand.
+    # The marker and the rows commit together. Marking first and writing
+    # afterwards leaves a window in which the marker says the file was taken
+    # while none of it was — and the marker is what stops it being tried
+    # again, so the registry would be empty for good.
     with session_scope() as db:
+        if not mark_done_within(db, _IMPORT_KEY, registry_path().name):
+            return
+        # Through ``NodeRecord.from_dict`` rather than straight off the dict:
+        # a hand-edited nodes.json is a supported thing to have, and an entry
+        # without an id is given one there.
         for item in raw:
             if not isinstance(item, dict):
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,25 @@ if str(REPO_ROOT) not in sys.path:
 
 
 @pytest.fixture(autouse=True)
+def isolate_the_database(tmp_path, monkeypatch):
+    """A private database per test.
+
+    The default URL points at the package's gitignored ``data/`` directory in
+    simulation, which every test would otherwise share — so state would leak
+    between tests in whatever order they happened to run. A file rather than
+    ``:memory:`` on purpose: the file path is what production uses, including
+    the WAL pragmas and the 0600, and a store only exercised in memory is a
+    store whose real configuration nothing tests.
+    """
+    from spark_pulse import db
+
+    monkeypatch.setenv("SPARK_PULSE_DATABASE_URL", f"sqlite:///{tmp_path / 'test.db'}")
+    db.configure(f"sqlite:///{tmp_path / 'test.db'}")
+    yield
+    db.dispose()
+
+
+@pytest.fixture(autouse=True)
 def isolate_imported_recipes(tmp_path, monkeypatch):
     """Keep recipe listing away from the developer's real ~/.config import dir.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ different working tree.
 import sys
 from pathlib import Path
 
+import os
+
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -16,23 +18,117 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 
-@pytest.fixture(autouse=True)
-def isolate_the_database(tmp_path, monkeypatch):
-    """A private database per test.
+#: The backend the suite runs against, read once. Empty, or a SQLite URL,
+#: means "a private SQLite file per test". Anything else — a PostgreSQL URL in
+#: CI — means "that server, cleaned between tests".
+#:
+#: Read at import and *removed from the environment*, because the per-test
+#: fixture sets the variable itself. Leaving it would make the fixture
+#: override the very URL an operator asked for, which is how a PostgreSQL job
+#: silently runs on SQLite and reports success for a backend it never touched.
+_BASE_DATABASE_URL = os.environ.pop("SPARK_PULSE_DATABASE_URL", "")
+_EXTERNAL_DATABASE = bool(_BASE_DATABASE_URL) and not _BASE_DATABASE_URL.startswith(
+    "sqlite"
+)
 
-    The default URL points at the package's gitignored ``data/`` directory in
-    simulation, which every test would otherwise share — so state would leak
-    between tests in whatever order they happened to run. A file rather than
-    ``:memory:`` on purpose: the file path is what production uses, including
-    the WAL pragmas and the 0600, and a store only exercised in memory is a
-    store whose real configuration nothing tests.
+
+@pytest.fixture(scope="session", autouse=True)
+def _external_database_once():
+    """Build the engine for a server backend exactly once for the whole run.
+
+    Reconfiguring per test disposes and rebuilds the connection pool every
+    time, which against PostgreSQL means thousands of pools over a run and
+    connection exhaustion long before the end of it. SQLite pays nothing for
+    a fresh engine — a server does.
+    """
+    if not _EXTERNAL_DATABASE:
+        yield
+        return
+    from spark_pulse import db
+
+    db.configure(_BASE_DATABASE_URL)
+    db.engine()  # create the schema once
+    yield
+    db.dispose()
+
+
+@pytest.fixture(autouse=True)
+def isolate_the_database(tmp_path, monkeypatch, _external_database_once):
+    """A clean database per test, on whichever backend is configured.
+
+    On SQLite that is a private file — a file rather than ``:memory:``,
+    because the file path is what production uses, WAL pragmas and mode bits
+    included, and a store only exercised in memory is a store whose real
+    configuration nothing tests.
+
+    On a server backend there is one database, built once, and every row is
+    deleted between tests. Truncating rather than recreating is deliberate: it
+    is what makes a CI run against PostgreSQL exercise the same tables,
+    indexes and constraints the product will actually have.
     """
     from spark_pulse import db
 
-    monkeypatch.setenv("SPARK_PULSE_DATABASE_URL", f"sqlite:///{tmp_path / 'test.db'}")
-    db.configure(f"sqlite:///{tmp_path / 'test.db'}")
+    if _EXTERNAL_DATABASE:
+        monkeypatch.setenv("SPARK_PULSE_DATABASE_URL", _BASE_DATABASE_URL)
+        _empty_every_table(db)
+        yield
+        return
+
+    url = f"sqlite:///{tmp_path / 'test.db'}"
+    monkeypatch.setenv("SPARK_PULSE_DATABASE_URL", url)
+    db.configure(url)
     yield
     db.dispose()
+
+
+def _empty_every_table(db) -> None:
+    """Delete every row, leaving the schema alone.
+
+    Every table SQLAlchemy knows about, which is every table whose module has
+    been imported — ``db.engine()`` imports them all up front for exactly this
+    reason, so a store imported late in the run cannot keep its rows across
+    tests and have the leak look like flakiness.
+    """
+    from sqlalchemy import delete as sa_delete
+
+    # The schema is created once, by the session fixture. Creating it again
+    # here raced with itself and failed on a duplicate type name; all this
+    # needs to do is empty what is already there.
+    with db.session_scope() as session:
+        for table in reversed(db.Base.metadata.sorted_tables):
+            session.execute(sa_delete(table))
+
+
+@pytest.fixture(autouse=True)
+def isolate_the_legacy_import_sources(tmp_path, monkeypatch):
+    """Point every JSON migration source at tmp_path.
+
+    Each store imports its old JSON file once, on first read. Those paths
+    default to the operator's own ``~/.config/spark-pulse``, so without this a
+    test would import — and a test asserting a fresh store would see — the
+    real deployments, nodes and customizations of the machine running the
+    suite.
+    """
+    # ``importlib.import_module`` by full name gets the real submodule.
+    # ``from spark_pulse.tools import x`` — and ``import spark_pulse.tools.x
+    # as x``, which reads the same attribute — get the *mock* under
+    # SIMULATION_MODE, and the mock has no file to point anywhere. The paths
+    # being isolated belong to the real modules.
+    import importlib
+
+    benchmarking = importlib.import_module("spark_pulse.tools.benchmarking")
+    custom_recipes = importlib.import_module("spark_pulse.tools.custom_recipes")
+    deployment_records = importlib.import_module("spark_pulse.tools.deployment_records")
+    node_registry = importlib.import_module("spark_pulse.tools.node_registry")
+
+    monkeypatch.setattr(
+        deployment_records, "RECORDS_FILE", tmp_path / "deployments.json"
+    )
+    monkeypatch.setattr(node_registry, "_REGISTRY_PATH", tmp_path / "nodes.json")
+    monkeypatch.setattr(
+        custom_recipes, "_CUSTOM_PATH", tmp_path / "custom-recipes.json"
+    )
+    monkeypatch.setattr(benchmarking, "_BENCHMARKS_PATH", tmp_path / "benchmarks.json")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,24 @@ async def agent_node(join_agent):
     return await join_agent("spark-a")
 
 
+@pytest.fixture
+def a_runnable_agent_binary():
+    """Skip unless this machine has an agent binary it can execute.
+
+    ``host_binary`` finds a packaged binary for this triple or a local cargo
+    build, and on a runner with neither it raises. Tests that only need the
+    *bundle* already skip through ``agent_bundle``; these are the ones that
+    reach for the binary directly, and without this they reported "no agent
+    binary" as a failure of the code under test rather than of the machine.
+    """
+    from spark_pulse.agent.bundle import MissingAgentBinary, host_binary
+
+    try:
+        return host_binary()
+    except MissingAgentBinary as exc:
+        pytest.skip(str(exc))
+
+
 @pytest.fixture(scope="session")
 def agent_bundle():
     """The bundle the installer ships: one static binary.

--- a/tests/test_agent_bundle.py
+++ b/tests/test_agent_bundle.py
@@ -117,7 +117,7 @@ def test_the_verify_command_is_what_the_installer_runs():
     assert VERIFY_COMMAND == "--help"
 
 
-def test_the_cache_returns_the_same_bytes_or_nothing(tmp_path):
+def test_the_cache_returns_the_same_bytes_or_nothing(tmp_path, a_runnable_agent_binary):
     bundle = build_bundle(
         target=host_target(), binary=host_binary(), cache_dir=tmp_path
     )
@@ -132,7 +132,7 @@ def test_pruning_keeps_the_newest(tmp_path):
     assert len(list(tmp_path.glob("*.tar.gz"))) == 2
 
 
-def test_a_binary_is_located_by_triple_never_searched_for():
+def test_a_binary_is_located_by_triple_never_searched_for(a_runnable_agent_binary):
     """A bundle assembled from whatever happened to be on the path is the
     failure mode this design removed: the old one vendored the control plane's
     own site-packages and shipped whatever it found there.

--- a/tests/test_agent_doctor.py
+++ b/tests/test_agent_doctor.py
@@ -528,7 +528,7 @@ async def test_without_ssh_only_the_control_plane_and_agent_checks_run(
 
 
 async def test_the_control_node_is_diagnosed_by_the_same_function(
-    agent_server, tmp_path
+    agent_server, tmp_path, a_runnable_agent_binary
 ):
     """No special case. The control node's own agent, through ``diagnose``."""
     local = await start_local_agent(

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import datetime as dt
 import random
 
+import hashlib
+
 import pytest
 from cryptography import x509
 
@@ -214,8 +216,34 @@ def test_token_mints_a_random_uuid_not_the_name(ledger):
 
 
 def test_the_token_itself_is_never_stored(ledger, tmp_path):
+    """Only the SHA-256 is kept, so a stolen state store yields no token.
+
+    Asserted against what the store actually holds rather than against a
+    serialisation of it: the ledger lives in the database now, and what matters
+    is that the secret is absent from whatever is written, not from the shape
+    it used to be written in. On SQLite that is the bytes of the file, which
+    would catch the secret leaking into any column or index; on a server
+    backend the file is on another machine, so it is the rows themselves.
+    """
+    from pathlib import Path
+
+    from sqlalchemy import text
+    from sqlalchemy.engine import make_url
+
+    from spark_pulse import db as database
+
     secret = ledger.mint_token("spark-a")
-    assert secret not in (tmp_path / "enrollment.json").read_text()
+    url = make_url(database.database_url())
+    if url.get_backend_name() == "sqlite":
+        database.dispose()  # flush the pool so the file on disk is complete
+        stored = Path(url.database or "").read_bytes()
+    else:
+        with database.session_scope() as session:
+            rows = session.execute(text("SELECT * FROM enrollment_tokens")).all()
+        stored = repr(rows).encode()
+
+    assert secret.encode() not in stored
+    assert hashlib.sha256(secret.encode()).hexdigest().encode() in stored
 
 
 def test_token_reuse_is_refused_and_says_so(ledger):
@@ -256,6 +284,155 @@ def test_ledger_survives_a_reload(tmp_path):
     second = EnrollmentLedger(tmp_path / "e.json")
     assert second.get(node_id).state == NodeState.ACCEPTED.value
     assert second.authorize(node_id)
+
+
+def test_the_json_import_runs_once_and_a_removal_does_not_undo_it(tmp_path):
+    """Keyed on the ``meta`` table, never on "are the tables empty".
+
+    Removing the last node empties them, and an import keyed on emptiness
+    would then readmit exactly the node an operator had deliberately removed —
+    which for a membership list is the worst of the stores to get wrong.
+    """
+    import json
+
+    path = tmp_path / "e.json"
+    path.write_text(
+        json.dumps(
+            {
+                "nodes": {"node-1": {"node_id": "node-1", "state": "accepted"}},
+                "tokens": {},
+            }
+        )
+    )
+    assert EnrollmentLedger(path).get("node-1").state == NodeState.ACCEPTED.value
+
+    EnrollmentLedger(path).remove("node-1")
+
+    assert EnrollmentLedger(path).get("node-1") is None
+
+
+# ── One row at a time ───────────────────────────────────────────────────────
+#
+# Two ledgers over one database is how these state "somebody else wrote a row
+# we have not seen". It is also the only cheap way to observe *which* rows a
+# write touched: a write that rewrote the whole ledger from its own working
+# copy shows up as the other ledger's node quietly disappearing.
+
+
+def test_accepting_one_node_leaves_a_node_it_never_saw_alone(tmp_path):
+    """One acceptance writes one row.
+
+    The whole-ledger write deleted every row absent from the working copy, so
+    admitting a node erased any node enrolled after this ledger last read.
+    """
+    first = EnrollmentLedger(tmp_path / "e.json")
+    second = EnrollmentLedger(tmp_path / "e.json")
+    mine = first.redeem_token(first.mint_token("spark-a"))
+    theirs = second.redeem_token(second.mint_token("spark-b"))
+
+    first.record_issue(mine, public_key_fingerprint="k", not_after=1.0)
+
+    reloaded = EnrollmentLedger(tmp_path / "e.json")
+    assert reloaded.get(mine).state == NodeState.ACCEPTED.value
+    assert reloaded.get(theirs) is not None
+
+
+def test_denying_one_node_leaves_a_node_it_never_saw_alone(tmp_path):
+    """Denial is the mutation on the connection path, and it is one row."""
+    first = EnrollmentLedger(tmp_path / "e.json")
+    second = EnrollmentLedger(tmp_path / "e.json")
+    mine = first.redeem_token(first.mint_token("spark-a"))
+    theirs = second.redeem_token(second.mint_token("spark-b"))
+
+    first.deny(mine, "operator said so")
+
+    reloaded = EnrollmentLedger(tmp_path / "e.json")
+    assert reloaded.get(mine).state == NodeState.DENIED.value
+    assert reloaded.get(theirs) is not None
+
+
+def test_removing_a_node_deletes_that_row_and_no_other(tmp_path):
+    """A removal names the node it removes, rather than everything else."""
+    first = EnrollmentLedger(tmp_path / "e.json")
+    second = EnrollmentLedger(tmp_path / "e.json")
+    mine = first.redeem_token(first.mint_token("spark-a"))
+    theirs = second.redeem_token(second.mint_token("spark-b"))
+
+    first.remove(mine)
+
+    reloaded = EnrollmentLedger(tmp_path / "e.json")
+    assert reloaded.get(mine) is None
+    assert reloaded.get(theirs) is not None
+
+
+def test_a_redemption_stores_the_spent_token_and_the_node_together(ledger, tmp_path):
+    """Half a redemption is a token that can be spent a second time."""
+    secret = ledger.mint_token("spark-a")
+    node_id = ledger.redeem_token(secret)
+
+    reloaded = EnrollmentLedger(tmp_path / "enrollment.json")
+    assert reloaded.get(node_id).state == NodeState.PENDING.value
+    with pytest.raises(EnrollmentRejected, match="already used"):
+        reloaded.redeem_token(secret)
+
+
+def test_a_certificate_count_is_not_reset_by_a_ledger_that_missed_the_others(tmp_path):
+    """``issued`` is the "re-enrolling in a loop" signal, and it is a counter.
+
+    A counter is the one field a narrow write can silently roll back: this
+    ledger's copy says zero because it has not read since. Writing one over a
+    stored two is the reading that says nothing is wrong.
+    """
+    first = EnrollmentLedger(tmp_path / "e.json")
+    node_id = first.redeem_token(first.mint_token("spark-a"))
+    second = EnrollmentLedger(tmp_path / "e.json")
+    second.record_issue(node_id, public_key_fingerprint="k", not_after=1.0)
+    second.record_issue(node_id, public_key_fingerprint="k", not_after=1.0)
+
+    assert first.record_issue(node_id, public_key_fingerprint="k", not_after=1.0).issued
+    assert EnrollmentLedger(tmp_path / "e.json").get(node_id).issued == 3
+
+
+def test_a_heartbeat_reaches_the_database_with_that_nodes_next_write(tmp_path):
+    """Ten-second heartbeats are not ten-second database writes."""
+    ledger = EnrollmentLedger(tmp_path / "e.json")
+    node_id = ledger.redeem_token(ledger.mint_token("spark-a"))
+
+    ledger.note_seen(node_id)
+    seen = ledger.get(node_id).last_seen
+    assert seen > 0
+    assert EnrollmentLedger(tmp_path / "e.json").get(node_id).last_seen == 0.0
+
+    ledger.record_issue(node_id, public_key_fingerprint="k", not_after=1.0)
+    assert EnrollmentLedger(tmp_path / "e.json").get(node_id).last_seen == seen
+
+
+def test_the_housekeeping_sweep_is_the_write_that_reconciles_the_whole_ledger(tmp_path):
+    """The whole-ledger write keeps its semantics: absent from the set, gone.
+
+    That is why nothing on the enrollment or connection path uses it any more.
+    Housekeeping is where reconciling the tables with the working copy is the
+    job rather than a side effect of saving one node.
+    """
+    first = EnrollmentLedger(tmp_path / "e.json")
+    second = EnrollmentLedger(tmp_path / "e.json")
+    theirs = second.redeem_token(second.mint_token("spark-b"))
+    first.mint_token("spark-a")
+
+    assert first.sweep(now=9e9) == 1
+
+    reloaded = EnrollmentLedger(tmp_path / "e.json")
+    assert reloaded.get(theirs) is None
+
+
+def test_minting_a_token_deletes_the_tokens_its_sweep_dropped(tmp_path):
+    """A token dropped from memory and left in the table comes back on reload."""
+    ledger = EnrollmentLedger(tmp_path / "e.json")
+    ledger.mint_token("spark-a", ttl=-2 * TOKEN_TTL_SECONDS)
+    ledger.mint_token("spark-b")
+
+    reloaded = EnrollmentLedger(tmp_path / "e.json")
+    assert reloaded.sweep(now=9e9) == 1
 
 
 # ── Membership and reimage detection ────────────────────────────────────────

--- a/tests/test_agent_rust_interop.py
+++ b/tests/test_agent_rust_interop.py
@@ -50,13 +50,29 @@ def rust_agent() -> Path:
     all — never when the build fails, because a build failure is the finding.
     """
     cargo = _cargo()
-    if cargo is None:
+    # protoc as well as cargo: build.rs regenerates the protocol types, so a
+    # machine with cargo and no protoc cannot build this crate at all. That is
+    # "no toolchain here", not "the agent is broken" — and the difference
+    # matters, because GitHub's ubuntu runner ships cargo and not protoc, so
+    # every job that did not install protoc reported 27 build failures as
+    # findings about the agent.
+    missing = [
+        name
+        for name, found in (("cargo", cargo), ("protoc", shutil.which("protoc")))
+        if not found
+    ]
+    if missing:
         # A skip here is how a cross-language suite quietly stops running. The
-        # CI job that *does* have a toolchain sets this, so a missing cargo
+        # CI job that *does* have a toolchain sets this, so a missing tool
         # there is a broken job rather than a machine without Rust.
         if os.environ.get("SPARK_PULSE_REQUIRE_RUST"):
-            pytest.fail("SPARK_PULSE_REQUIRE_RUST is set but there is no cargo on PATH")
-        pytest.skip("no cargo on PATH; the Rust agent cannot be built here")
+            pytest.fail(
+                "SPARK_PULSE_REQUIRE_RUST is set but "
+                f"{' and '.join(missing)} is not on PATH"
+            )
+        pytest.skip(
+            f"no {' or '.join(missing)} on PATH; the Rust agent cannot be built here"
+        )
     build = subprocess.run(
         [cargo, "build", "--quiet"],
         cwd=CRATE,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from spark_pulse import auth
+import time
+
+from spark_pulse import auth, sessions
 
 
 class DummyRequest:
@@ -213,8 +215,9 @@ class TestAuthMiddleware:
         monkeypatch.setitem(auth.config._data, "oidc_client_id", "client-id")
         monkeypatch.setitem(auth.config._data, "oidc_client_secret", "secret")
         mw = auth.AuthMiddleware(None)
-        valid_token = "valid-token-123"
-        auth._active_tokens[valid_token] = {"user": {"name": "Alice"}}
+        valid_token = sessions.create(
+            user={"name": "Alice"}, expires_at=time.time() + 3600
+        )
 
         request = self._make_request("/api/recipes", cookie_token=valid_token)
         call_next_called = []
@@ -225,8 +228,12 @@ class TestAuthMiddleware:
 
         _result = asyncio.run(mw.dispatch(request, call_next))
         assert len(call_next_called) == 1
-        # Middleware attaches the full token data (including "user" key)
-        assert request.state.user == {"user": {"name": "Alice"}}
+        # The middleware attaches the whole session. The claims are the part
+        # a handler reads; the rest is the provider's tokens and timestamps,
+        # which are present in production too — the old assertion only held
+        # because the test inserted a partial dict the real flow never writes.
+        assert request.state.user["user"] == {"name": "Alice"}
+        assert "expires_at" in request.state.user
 
 
 # ── Auth routes tests ───────────────────────────────────────────────────────
@@ -305,10 +312,10 @@ class TestAuthRoutes:
         client = TestClient(app)
 
         # Insert a valid token
-        valid_token = "test-token-456"
-        auth._active_tokens[valid_token] = {
-            "user": {"name": "Bob", "email": "bob@example.com"},
-        }
+        valid_token = sessions.create(
+            user={"name": "Bob", "email": "bob@example.com"},
+            expires_at=time.time() + 3600,
+        )
 
         resp = client.get(
             "/auth/me",
@@ -380,8 +387,7 @@ class TestSessionExpiry:
     """``expires_at`` was recorded at login and then never read.
 
     A session therefore outlived the provider's own token for as long as the
-    process ran, and ``_active_tokens`` grew for every login that ever
-    happened. The cookie's ``max-age`` governs only the browser; a client that
+    process ran, and the store grew for every login that ever happened. The cookie's ``max-age`` governs only the browser; a client that
     keeps sending an expired cookie was honoured indefinitely.
     """
 
@@ -398,17 +404,14 @@ class TestSessionExpiry:
         assert auth._session_expired({}) is False
 
     def test_sweeping_drops_only_the_expired(self):
-        import time
+        sessions.clear()
+        old = sessions.create(expires_at=1.0)
+        live = sessions.create(expires_at=time.time() + 3600)
 
-        auth._active_tokens.clear()
-        auth._active_tokens["old"] = {"expires_at": 1.0}
-        auth._active_tokens["new"] = {"expires_at": time.time() + 3600}
+        assert sessions.sweep() == 1
 
-        auth._sweep_sessions()
-
-        assert "old" not in auth._active_tokens
-        assert "new" in auth._active_tokens
-        auth._active_tokens.clear()
+        assert sessions.get(old) is None
+        assert sessions.get(live) is not None
 
     def test_get_me_refuses_an_expired_session(self, monkeypatch):
         from fastapi.testclient import TestClient
@@ -422,9 +425,9 @@ class TestSessionExpiry:
         monkeypatch.setitem(auth.config._data, "oidc_client_id", "client-id")
         monkeypatch.setitem(auth.config._data, "oidc_client_secret", "secret")
 
-        auth._active_tokens["stale"] = {"user": {"name": "Bob"}, "expires_at": 1.0}
+        stale = sessions.create(user={"name": "Bob"}, expires_at=1.0)
         with TestClient(create_app()) as client:
-            resp = client.get("/auth/me", cookies={"token": "stale"})
+            resp = client.get("/auth/me", cookies={"token": stale})
 
         assert resp.status_code == 401
-        assert "stale" not in auth._active_tokens, "an expired session is dropped"
+        assert sessions.count() == 0, "an expired session is dropped as it is read"

--- a/tests/test_blobs.py
+++ b/tests/test_blobs.py
@@ -1,0 +1,176 @@
+"""File content in the database, and the cache it is materialised into.
+
+The interesting cases are all about the cache being a cache: it must be
+rebuilt when the content changed, left alone when it did not, and pruned when
+a file was removed from the scope. A cache that is merely *usually* right is
+worse than no cache, because the thing on the far end of this is a mod that
+gets executed inside a container.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spark_pulse import blobs
+
+
+def test_a_file_round_trips(tmp_path):
+    blobs.put("mod:demo", "run.sh", b"#!/bin/sh\necho hi\n", mode=0o755)
+
+    assert blobs.get("mod:demo", "run.sh") == b"#!/bin/sh\necho hi\n"
+
+
+def test_listing_reports_paths_digests_and_modes(tmp_path):
+    blobs.put("mod:demo", "run.sh", b"a", mode=0o755)
+    blobs.put("mod:demo", "template.jinja", b"b")
+
+    listed = blobs.listing("mod:demo")
+
+    assert [p for p, _d, _m in listed] == ["run.sh", "template.jinja"]
+    assert dict((p, m) for p, _d, m in listed)["run.sh"] == 0o755
+
+
+def test_scopes_do_not_see_each_other(tmp_path):
+    blobs.put("mod:one", "run.sh", b"one")
+    blobs.put("mod:two", "run.sh", b"two")
+
+    assert blobs.get("mod:one", "run.sh") == b"one"
+    assert blobs.get("mod:two", "run.sh") == b"two"
+
+
+def test_removing_a_scope_takes_all_of_it(tmp_path):
+    blobs.put("mod:demo", "run.sh", b"a")
+    blobs.put("mod:demo", "nested/thing.txt", b"b")
+
+    assert blobs.remove_scope("mod:demo") == 2
+
+    assert blobs.listing("mod:demo") == []
+
+
+# ── Paths that would escape ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["/etc/passwd", "../outside", "nested/../../outside", "", "./../x"],
+)
+def test_a_path_that_escapes_its_scope_is_refused(hostile, tmp_path):
+    """The same rule the agent applies to an incoming tar.
+
+    What is on the other end of this is a directory on disk and then a
+    container, and an absolute or climbing path reaches outside both.
+    """
+    with pytest.raises(blobs.UnsafeBlobPath):
+        blobs.put("mod:demo", hostile, b"x")
+
+
+def test_an_ordinary_nested_path_is_allowed(tmp_path):
+    blobs.put("mod:demo", "patches/vllm/fix.diff", b"x")
+
+    assert blobs.get("mod:demo", "patches/vllm/fix.diff") == b"x"
+
+
+# ── The cache ───────────────────────────────────────────────────────────────
+
+
+def test_materialize_writes_the_scope_to_disk(tmp_path):
+    blobs.put("mod:demo", "run.sh", b"#!/bin/sh\n", mode=0o755)
+    blobs.put("mod:demo", "nested/template.jinja", b"tmpl")
+
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+
+    assert (root / "run.sh").read_bytes() == b"#!/bin/sh\n"
+    assert (root / "nested" / "template.jinja").read_bytes() == b"tmpl"
+    assert (root / "run.sh").stat().st_mode & 0o777 == 0o755
+
+
+def test_a_warm_cache_is_not_rewritten(tmp_path):
+    """Unchanged content must not be rewritten.
+
+    Asserted through mtime rather than by counting writes, because what would
+    break is exactly what an observer sees: a mod directory that looks
+    modified on every deploy invalidates anything downstream that watches it.
+    """
+    blobs.put("mod:demo", "run.sh", b"same")
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+    stamp = (root / "run.sh").stat().st_mtime_ns
+
+    blobs.materialize("mod:demo", root)
+
+    assert (root / "run.sh").stat().st_mtime_ns == stamp
+
+
+def test_changed_content_replaces_the_cached_copy(tmp_path):
+    blobs.put("mod:demo", "run.sh", b"old")
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+
+    blobs.put("mod:demo", "run.sh", b"new")
+    blobs.materialize("mod:demo", root)
+
+    assert (root / "run.sh").read_bytes() == b"new"
+
+
+def test_a_file_removed_from_the_scope_is_removed_from_the_cache(tmp_path):
+    """A mod that dropped a script must not keep running it."""
+    blobs.put("mod:demo", "run.sh", b"keep")
+    blobs.put("mod:demo", "old.sh", b"gone")
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+    assert (root / "old.sh").exists()
+
+    blobs.remove("mod:demo", "old.sh")
+    blobs.materialize("mod:demo", root)
+
+    assert not (root / "old.sh").exists()
+    assert (root / "run.sh").read_bytes() == b"keep"
+
+
+def test_a_stale_file_a_local_edit_left_behind_is_corrected(tmp_path):
+    """The database is the primary source; the disk is a cache of it.
+
+    Someone editing the cached copy directly must not change what a deploy
+    uses, or the two control planes stop agreeing — which is the thing this
+    move exists to fix.
+    """
+    blobs.put("mod:demo", "run.sh", b"authoritative")
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+    (root / "run.sh").write_bytes(b"tampered locally")
+
+    blobs.materialize("mod:demo", root)
+
+    assert (root / "run.sh").read_bytes() == b"authoritative"
+
+
+# ── Importing what is already on disk ───────────────────────────────────────
+
+
+def test_import_tree_loads_a_directory(tmp_path):
+    source = tmp_path / "mod"
+    (source / "nested").mkdir(parents=True)
+    (source / "run.sh").write_bytes(b"#!/bin/sh\n")
+    (source / "run.sh").chmod(0o755)
+    (source / "nested" / "t.jinja").write_bytes(b"tmpl")
+
+    assert blobs.import_tree("mod:demo", source) == 2
+
+    assert blobs.get("mod:demo", "run.sh") == b"#!/bin/sh\n"
+    assert dict((p, m) for p, _d, m in blobs.listing("mod:demo"))["run.sh"] == 0o755
+
+
+def test_importing_a_missing_directory_is_not_an_error(tmp_path):
+    assert blobs.import_tree("mod:demo", tmp_path / "nope") == 0
+
+
+def test_a_directory_survives_the_round_trip(tmp_path):
+    """Import, materialise elsewhere, and get the same tree back."""
+    source = tmp_path / "mod"
+    (source / "nested").mkdir(parents=True)
+    (source / "run.sh").write_bytes(b"#!/bin/sh\necho hi\n")
+    (source / "run.sh").chmod(0o755)
+    (source / "nested" / "t.jinja").write_bytes(b"tmpl")
+
+    blobs.import_tree("mod:demo", source)
+    root = blobs.materialize("mod:demo", tmp_path / "elsewhere")
+
+    assert (root / "run.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert (root / "run.sh").stat().st_mode & 0o777 == 0o755
+    assert (root / "nested" / "t.jinja").read_bytes() == b"tmpl"

--- a/tests/test_blobs.py
+++ b/tests/test_blobs.py
@@ -174,3 +174,43 @@ def test_a_directory_survives_the_round_trip(tmp_path):
     assert (root / "run.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
     assert (root / "run.sh").stat().st_mode & 0o777 == 0o755
     assert (root / "nested" / "t.jinja").read_bytes() == b"tmpl"
+
+
+def test_a_mode_only_change_reaches_the_cache(tmp_path):
+    """Content unchanged, permissions changed — the cache must follow.
+
+    ``materialize`` skips a file whose digest already matches, and the chmod
+    used to live only on the write branch. A mod's ``run.sh`` promoted to
+    0755 therefore stayed non-executable in the cache: the exact case the
+    column's docstring says the mode is stored for.
+    """
+    blobs.put("mod:demo", "run.sh", b"#!/bin/sh\n", mode=0o644)
+    root = blobs.materialize("mod:demo", tmp_path / "cache")
+    assert (root / "run.sh").stat().st_mode & 0o777 == 0o644
+
+    blobs.put("mod:demo", "run.sh", b"#!/bin/sh\n", mode=0o755)
+    blobs.materialize("mod:demo", root)
+
+    assert (root / "run.sh").stat().st_mode & 0o777 == 0o755
+
+
+def test_materializing_an_unknown_scope_does_not_erase_the_destination(tmp_path):
+    """The sweep reconciles a directory against a scope. With no scope there
+    is nothing to reconcile against, and deleting everything is not the
+    answer — the caller chose that path, so a typo would take an operator's
+    mod directory with it."""
+    destination = tmp_path / "not-a-cache"
+    destination.mkdir()
+    (destination / "precious.txt").write_bytes(b"do not delete me")
+
+    blobs.materialize("mod:never-stored", destination)
+
+    assert (destination / "precious.txt").read_bytes() == b"do not delete me"
+
+
+def test_the_scope_root_is_not_a_file_in_it(tmp_path):
+    """``Path(".").parts`` is empty, so the traversal guard passed it through
+    and ``materialize`` then called ``write_bytes`` on a directory."""
+    for root_ish in (".", "./"):
+        with pytest.raises(blobs.UnsafeBlobPath):
+            blobs.put("mod:demo", root_ish, b"x")

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,357 @@
+"""The master key, and what happens when it is absent, wrong, or rotated badly.
+
+Secrets used to be a 0600 file on one machine. They are becoming rows in a
+database that a replica, a backup and a ``pg_dump`` can all read, so they are
+encrypted before they are written. Everything asserted here is a property an
+operator depends on but cannot see: that two encryptions of one password do
+not look alike, that a row someone edited fails loudly instead of decrypting
+to something else, and that a missing key stops a secret from being stored
+rather than storing it in the clear.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import pytest
+
+from spark_pulse import crypto
+
+SECRET = "hf_aVeryRealLookingHuggingFaceToken"
+
+
+@pytest.fixture
+def key(monkeypatch):
+    """A master key for the duration of one test, and its base64 form."""
+    generated = crypto.generate_key()
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, generated)
+    return generated
+
+
+@pytest.fixture
+def no_key(monkeypatch):
+    """An instance with nothing configured — the upgrade-day default."""
+    monkeypatch.delenv(crypto.MASTER_KEY_ENV, raising=False)
+
+
+# ── The round trip ──────────────────────────────────────────────────────────
+
+
+def test_a_secret_comes_back_exactly_as_it_went_in(key):
+    assert crypto.decrypt(crypto.encrypt(SECRET)) == SECRET
+
+
+def test_an_empty_secret_round_trips_rather_than_being_treated_as_absent(key):
+    """A cleared secret is a value, not a missing one.
+
+    ``delete_secret`` and ``save_secret("")`` are different operations in the
+    config API this will back, so the empty string has to survive the trip.
+    """
+    assert crypto.decrypt(crypto.encrypt("")) == ""
+
+
+def test_a_secret_with_non_ascii_characters_survives(key):
+    """Passphrases are not ASCII, and the stored form is.
+
+    The bytes go through base64 and the text through UTF-8; getting either
+    direction wrong shows up here rather than on some operator's password.
+    """
+    original = "pässwörd–with–ünicode–✓"
+    assert crypto.decrypt(crypto.encrypt(original)) == original
+
+
+def test_a_freshly_generated_key_is_immediately_usable(monkeypatch):
+    """The command the documentation gives an operator has to actually work."""
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, crypto.generate_key())
+    assert crypto.decrypt(crypto.encrypt(SECRET)) == SECRET
+
+
+def test_generate_key_produces_thirty_two_distinct_random_bytes():
+    first, second = crypto.generate_key(), crypto.generate_key()
+    assert len(base64.b64decode(first)) == crypto.KEY_BYTES
+    assert first != second, "two calls returned the same key"
+
+
+# ── Nonce hygiene ───────────────────────────────────────────────────────────
+
+
+def test_encrypting_the_same_secret_twice_reuses_neither_nonce_nor_ciphertext(key):
+    """A repeated nonce under one GCM key exposes the authentication subkey.
+
+    It is also the visible half of the problem: identical ciphertexts would
+    tell anyone with read access to the table which two accounts share a
+    password, without decrypting anything.
+    """
+    first, second = crypto.encrypt(SECRET), crypto.encrypt(SECRET)
+
+    assert first != second
+    assert first.split(".")[1] != second.split(".")[1], "the nonce repeated"
+    assert first.split(".")[2] != second.split(".")[2]
+    assert crypto.decrypt(first) == crypto.decrypt(second) == SECRET
+
+
+def test_many_encryptions_of_one_secret_never_repeat_a_nonce(key):
+    nonces = {crypto.encrypt(SECRET).split(".")[1] for _ in range(200)}
+    assert len(nonces) == 200
+
+
+# ── What the stored form leaks ──────────────────────────────────────────────
+
+
+def test_the_stored_form_contains_neither_the_plaintext_nor_the_key(key):
+    """The whole reason this module exists, stated as an assertion.
+
+    Checked against the key in every encoding an operator might have pasted,
+    because a stored form that happened to embed the base64 key would be no
+    better than the plaintext file it replaces.
+    """
+    token = crypto.encrypt(SECRET)
+    raw_key = base64.b64decode(key)
+
+    assert SECRET not in token
+    assert key not in token
+    assert key.rstrip("=") not in token
+    assert base64.urlsafe_b64encode(raw_key).decode().rstrip("=") not in token
+    assert raw_key.hex() not in token
+    assert raw_key not in token.encode("utf-8")
+
+
+def test_the_stored_form_announces_its_version_before_anything_encoded(key):
+    """A ``SELECT`` has to be readable without decoding anything.
+
+    The tag leads so that the day a ``v2`` exists, telling the two apart is a
+    string comparison rather than an inference from length.
+    """
+    token = crypto.encrypt(SECRET)
+
+    assert token.startswith("v1.")
+    assert crypto.is_encrypted(token)
+    assert re.fullmatch(r"v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+", token), token
+
+
+def test_a_legacy_plaintext_value_is_not_mistaken_for_a_token(key):
+    """The one-time JSON import has to tell the two apart without decrypting.
+
+    Deciding by catching a decryption failure would make a genuine wrong-key
+    error look like a legacy row, and re-encrypt someone's ciphertext as if it
+    were the password itself.
+    """
+    assert not crypto.is_encrypted(SECRET)
+    assert not crypto.is_encrypted("")
+    assert crypto.is_encrypted(crypto.encrypt(SECRET))
+
+
+# ── Wrong key, and tampering ────────────────────────────────────────────────
+
+
+def test_a_secret_written_under_one_key_is_refused_under_another(monkeypatch, key):
+    """The badly-rotated-key case, which must not look like corruption."""
+    token = crypto.encrypt(SECRET)
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, crypto.generate_key())
+
+    with pytest.raises(crypto.DecryptionError) as raised:
+        crypto.decrypt(token)
+    assert crypto.MASTER_KEY_ENV in str(raised.value)
+    assert "altered" in str(raised.value)
+
+
+def test_a_wrong_key_raises_a_different_error_from_a_missing_one(monkeypatch, key):
+    """An operator has to know which of the two mistakes they made.
+
+    Both are "secrets stopped working after I touched the environment", and
+    the fixes — set the variable, versus put the old key back — have nothing
+    in common.
+    """
+    token = crypto.encrypt(SECRET)
+
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, crypto.generate_key())
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(token)
+
+    monkeypatch.delenv(crypto.MASTER_KEY_ENV)
+    with pytest.raises(crypto.MasterKeyError):
+        crypto.decrypt(token)
+
+    assert not issubclass(crypto.MasterKeyError, crypto.DecryptionError)
+    assert not issubclass(crypto.DecryptionError, crypto.MasterKeyError)
+
+
+def test_an_edited_ciphertext_fails_authentication_instead_of_decrypting(key):
+    """A row changed in the database — by a bad migration or by someone with
+    write access and no read access — must not decrypt to chosen bytes."""
+    version, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+    flipped = ("B" if ciphertext[0] != "B" else "C") + ciphertext[1:]
+
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(".".join((version, nonce, flipped)))
+
+
+def test_an_edited_nonce_fails_authentication(key):
+    version, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+    flipped = ("B" if nonce[0] != "B" else "C") + nonce[1:]
+
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(".".join((version, flipped, ciphertext)))
+
+
+def test_a_truncated_ciphertext_is_rejected_rather_than_half_decrypted(key):
+    version, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(".".join((version, nonce, ciphertext[:-4])))
+
+
+def test_a_truncated_nonce_is_reported_as_corruption_not_as_a_new_format(key):
+    """v1 has only ever emitted twelve bytes, so a short one is an edit."""
+    version, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+
+    with pytest.raises(crypto.DecryptionError) as raised:
+        crypto.decrypt(".".join((version, nonce[:8], ciphertext)))
+    assert "nonce" in str(raised.value)
+
+
+def test_relabelling_a_token_as_a_later_version_does_not_open_it(key):
+    """The version tag is the AEAD's associated data, so it cannot be moved.
+
+    Without that binding, a stored value could be re-tagged and handed to a
+    future parser that expects different bytes behind the same key.
+    """
+    _, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(".".join(("v2", nonce, ciphertext)))
+
+
+def test_something_that_is_not_a_token_at_all_is_refused(key):
+    for value in ("", SECRET, "v1.", "v1.abc", "v1.a.b.c", "v2.abc.def"):
+        with pytest.raises(crypto.DecryptionError):
+            crypto.decrypt(value)
+
+
+def test_a_token_whose_base64_is_damaged_is_reported_as_corrupt(key):
+    _, nonce, ciphertext = crypto.encrypt(SECRET).split(".")
+
+    with pytest.raises(crypto.DecryptionError) as raised:
+        crypto.decrypt(".".join(("v1", nonce, ciphertext + "*!")))
+    assert "corrupt" in str(raised.value)
+
+
+# ── No key, and bad keys ────────────────────────────────────────────────────
+
+
+def test_without_a_key_encrypting_refuses_rather_than_storing_plaintext(no_key):
+    """The documented choice: refuse to store, never fall back to the clear.
+
+    A plaintext fallback is silent — the operator who typoed the variable name
+    gets a working system and a readable database — and it is ambiguous,
+    because nothing reading the column afterwards can tell which values were
+    protected.
+    """
+    with pytest.raises(crypto.MasterKeyError) as raised:
+        crypto.encrypt(SECRET)
+
+    message = str(raised.value)
+    assert crypto.MASTER_KEY_ENV in message
+    assert "generate_key" in message, "the message must say what to run"
+
+
+def test_without_a_key_decrypting_says_the_key_is_missing(no_key):
+    with pytest.raises(crypto.MasterKeyError):
+        crypto.decrypt("v1.AAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAA")
+
+
+def test_a_caller_can_ask_whether_secrets_can_be_stored_before_trying(
+    monkeypatch, no_key
+):
+    """So the refusal reads as a policy, not as a traceback from a save."""
+    assert crypto.is_configured() is False
+
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, crypto.generate_key())
+    assert crypto.is_configured() is True
+
+
+def test_an_exported_but_empty_key_counts_as_absent(monkeypatch):
+    """``Environment=SPARK_PULSE_MASTER_KEY=`` in a unit file produces one.
+
+    Reporting that as "wrong length" would send the operator looking for a
+    truncated paste that does not exist.
+    """
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, "   ")
+
+    assert crypto.is_configured() is False
+    with pytest.raises(crypto.MasterKeyError) as raised:
+        crypto.encrypt(SECRET)
+    assert "not set" in str(raised.value)
+
+
+def test_a_key_of_the_wrong_length_is_named_as_such(monkeypatch):
+    """The commonest paste error, and it must not be silently padded."""
+    monkeypatch.setenv(
+        crypto.MASTER_KEY_ENV, base64.b64encode(b"\x01" * 16).decode("ascii")
+    )
+
+    with pytest.raises(crypto.MasterKeyError) as raised:
+        crypto.encrypt(SECRET)
+    assert "16 bytes" in str(raised.value)
+    assert str(crypto.KEY_BYTES) in str(raised.value)
+
+
+def test_a_key_that_is_not_base64_is_named_as_such(monkeypatch):
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, "not base64 at all !!")
+
+    with pytest.raises(crypto.MasterKeyError) as raised:
+        crypto.encrypt(SECRET)
+    assert "base64" in str(raised.value)
+
+
+def test_a_key_pasted_with_surrounding_whitespace_still_works(monkeypatch):
+    """``$(...)`` in a shell brings a trailing newline with it."""
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, f"\n  {crypto.generate_key()}\t\n")
+
+    assert crypto.decrypt(crypto.encrypt(SECRET)) == SECRET
+
+
+def test_a_key_in_the_url_safe_alphabet_or_without_padding_still_works(monkeypatch):
+    """Secret managers and shells hand back ``-``/``_``, and strip ``=``.
+
+    Refusing a key that is materially correct helps nobody, and the operator
+    debugging it has no way to see which character offended.
+    """
+    raw = base64.b64decode(crypto.generate_key())
+
+    monkeypatch.setenv(
+        crypto.MASTER_KEY_ENV, base64.urlsafe_b64encode(raw).decode("ascii")
+    )
+    token = crypto.encrypt(SECRET)
+
+    monkeypatch.setenv(
+        crypto.MASTER_KEY_ENV,
+        base64.b64encode(raw).decode("ascii").rstrip("="),
+    )
+    assert crypto.decrypt(token) == SECRET, "the same key was read as a different one"
+
+
+def test_the_key_is_re_read_rather_than_cached_for_the_life_of_the_process(
+    monkeypatch, key
+):
+    """A cached key would survive a rotation the supervisor already performed,
+    and would make every test after the first one here lie."""
+    token = crypto.encrypt(SECRET)
+    rotated = crypto.generate_key()
+
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, rotated)
+    with pytest.raises(crypto.DecryptionError):
+        crypto.decrypt(token)
+
+    monkeypatch.setenv(crypto.MASTER_KEY_ENV, key)
+    assert crypto.decrypt(token) == SECRET
+
+
+def test_every_failure_here_is_catchable_as_one_category(no_key):
+    """Callers that only need "secrets are unavailable" get one except clause."""
+    assert issubclass(crypto.MasterKeyError, crypto.CryptoError)
+    assert issubclass(crypto.DecryptionError, crypto.CryptoError)
+
+    with pytest.raises(crypto.CryptoError):
+        crypto.encrypt(SECRET)

--- a/tests/test_db_and_sessions.py
+++ b/tests/test_db_and_sessions.py
@@ -387,3 +387,43 @@ def test_schema_creation_is_idempotent(tmp_path):
     db._create_schema(engine)
 
     assert sessions.count() == 0
+
+
+def test_the_wal_sidecars_are_not_world_readable(tmp_path):
+    """The `-wal` file holds the rows most recently written.
+
+    SQLite copies the database file's mode onto the `-wal` and `-shm`
+    sidecars at the moment it creates them, and connecting is what creates
+    them. Chmodding the database *after* the first connection therefore
+    secured the database and left the sidecars at the umask default — on a
+    first run, containing every session token the process had just minted.
+    """
+    path = tmp_path / "state.db"
+    db.configure(f"sqlite:///{path}")
+    sessions.create(user={"sub": "alice"}, expires_at=time.time() + 60)
+
+    wal = path.with_name(path.name + "-wal")
+    assert wal.exists(), "WAL mode should have produced a -wal sidecar"
+    for created in (path, wal):
+        assert (
+            created.stat().st_mode & 0o077 == 0
+        ), f"{created.name} is readable by others"
+
+
+def test_a_model_module_that_cannot_import_is_not_swallowed(monkeypatch):
+    """Hiding it emits a schema without that table, and the failure then
+    surfaces as "no such table" at whichever call site got there first —
+    which is what importing them all up front exists to prevent."""
+    import importlib
+
+    real = importlib.import_module
+
+    def explode(name, *args, **kwargs):
+        if name == "spark_pulse.sessions":
+            raise ImportError("a dependency of this module is broken")
+        return real(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", explode)
+
+    with pytest.raises(ImportError):
+        db._load_models()

--- a/tests/test_db_and_sessions.py
+++ b/tests/test_db_and_sessions.py
@@ -289,6 +289,42 @@ class TestTheLegacyImportRunsOnce:
 
         assert store.load() == []
 
+    def test_a_per_row_write_imports_the_legacy_file_before_it_writes(
+        self, tmp_path, monkeypatch
+    ):
+        """The import is keyed on ``meta``, not on which call happened first.
+
+        ``upsert`` can be the first thing a process does — a deploy that starts
+        before anything has listed. If it skipped the import, its row would be
+        the only row, and the operator's existing deployments would arrive on
+        whichever later call did remember, over the top of it.
+        """
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+
+        store.upsert({"id": "dep-2", "status": "pending", "runtime": "native"})
+
+        assert {r["id"] for r in store.load()} == {"dep-1", "dep-2"}
+
+    def test_a_per_row_delete_of_the_last_record_does_not_resurrect_the_file(
+        self, tmp_path, monkeypatch
+    ):
+        """The same guarantee ``delete`` has, through the batched form."""
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+
+        assert store.delete_many(["dep-1"]) == 1
+
+        assert store.load() == [], "the legacy file was imported a second time"
+
     def test_a_file_restored_after_a_fresh_start_is_still_imported(
         self, tmp_path, monkeypatch
     ):
@@ -303,3 +339,51 @@ class TestTheLegacyImportRunsOnce:
         self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
 
         assert [r["id"] for r in store.load()] == ["dep-1"]
+
+
+def test_concurrent_schema_creation_does_not_fail(tmp_path):
+    """Two control planes starting at once must both come up.
+
+    ``create_all`` checks what exists and then creates what does not, and
+    those are two steps. Once there is more than one instance against one
+    database that is the *ordinary* startup, not a rare race — both see a
+    table missing, both create it, and the loser gets a duplicate-object
+    error from the server. Six agents sharing one PostgreSQL reproduced it
+    immediately while this branch was being written.
+
+    The loser's answer is to look again, not to fail.
+    """
+    import threading
+
+    from sqlalchemy import create_engine
+
+    url = f"sqlite:///{tmp_path / 'race.db'}"
+    db._load_models()
+    failures = []
+
+    def build():
+        try:
+            engine = create_engine(url)
+            db._create_schema(engine)
+            engine.dispose()
+        except Exception as exc:  # noqa: BLE001 — the point is to catch any
+            failures.append(exc)
+
+    threads = [threading.Thread(target=build) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert failures == []
+
+
+def test_schema_creation_is_idempotent(tmp_path):
+    """Called twice against the same database, the second is a no-op."""
+    db.configure(f"sqlite:///{tmp_path / 'twice.db'}")
+    engine = db.engine()
+
+    db._create_schema(engine)
+    db._create_schema(engine)
+
+    assert sessions.count() == 0

--- a/tests/test_db_and_sessions.py
+++ b/tests/test_db_and_sessions.py
@@ -1,0 +1,232 @@
+"""The state store, and the seam that makes the backend replaceable.
+
+``docs/cluster-agent-plan.md`` §3.3 chose SQLite in WAL mode. The reason this
+goes through SQLAlchemy rather than the ``sqlite3`` driver is the second half
+of that decision — that one appliance becoming several is a change to a URL —
+and a claim like that is worth a test rather than a comment.
+
+:func:`test_every_table_emits_postgresql_ddl` is that test. It compiles the
+schema for the PostgreSQL dialect without a PostgreSQL server, so a column
+type that only SQLite has fails here rather than on the day somebody sets
+``SPARK_PULSE_DATABASE_URL``. It cannot prove the queries behave identically —
+only a real server does that — and it does prove the schema is portable, which
+is the half that is cheap to get wrong and expensive to discover.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateTable
+
+from spark_pulse import db, sessions
+
+
+# ── The engine ──────────────────────────────────────────────────────────────
+
+
+def test_the_sqlite_file_is_not_world_readable(tmp_path):
+    """The rows hold OIDC access and refresh tokens.
+
+    In memory those were unreachable by other users on the machine; in a file
+    at the default 0644 they are readable by every one of them.
+    """
+    path = tmp_path / "state.db"
+    db.configure(f"sqlite:///{path}")
+    sessions.create(user={"sub": "alice"}, expires_at=time.time() + 60)
+
+    assert path.exists()
+    assert path.stat().st_mode & 0o077 == 0
+
+
+def test_sqlite_runs_in_wal_mode(tmp_path):
+    """§3.3 says WAL, and the reason is readers.
+
+    Without it a writer blocks every reader for the length of its
+    transaction; with it readers never block at all — which is what makes one
+    file safe for the several worker processes this exists to allow.
+    """
+    path = tmp_path / "state.db"
+    db.configure(f"sqlite:///{path}")
+    sessions.create(user={"sub": "alice"}, expires_at=time.time() + 60)
+
+    with sqlite3.connect(path) as raw:
+        mode = raw.execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode.lower() == "wal"
+
+
+def test_the_engine_is_rebuilt_when_the_url_changes(tmp_path):
+    """Two databases, and nothing leaks between them."""
+    first, second = tmp_path / "one.db", tmp_path / "two.db"
+
+    db.configure(f"sqlite:///{first}")
+    token = sessions.create(user={"sub": "alice"}, expires_at=time.time() + 60)
+    assert sessions.get(token) is not None
+
+    db.configure(f"sqlite:///{second}")
+    assert sessions.get(token) is None, "a different database answered for the first"
+
+    db.configure(f"sqlite:///{first}")
+    assert sessions.get(token) is not None, "the first database lost its row"
+
+
+def test_a_failed_write_leaves_nothing_behind(tmp_path):
+    """``session_scope`` rolls back, so half a change is not a state to reach."""
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    before = sessions.count()
+
+    with pytest.raises(RuntimeError):
+        with db.session_scope() as active:
+            active.add(sessions.Session(token="doomed", expires_at=0.0, user={}))
+            raise RuntimeError("something went wrong mid-transaction")
+
+    assert sessions.count() == before
+    assert sessions.get("doomed") is None
+
+
+# ── Portability ─────────────────────────────────────────────────────────────
+
+
+def test_every_table_emits_postgresql_ddl():
+    """The scale case, checked without a PostgreSQL server.
+
+    Compiling the schema for the PostgreSQL dialect catches the thing that
+    actually breaks a backend swap: a column type, default or constraint that
+    only one backend has. It is not a promise that every query behaves
+    identically — that needs a real server — but it is the half that would
+    otherwise be discovered by an operator rather than by us.
+    """
+    dialect = postgresql.dialect()
+
+    for table in db.Base.metadata.sorted_tables:
+        statement = str(CreateTable(table).compile(dialect=dialect))
+        assert f"CREATE TABLE {table.name}" in statement.replace('"', "")
+        # The spellings SQLite tolerates and PostgreSQL does not.
+        assert "AUTOINCREMENT" not in statement.upper()
+        assert "DATETIME" not in statement.upper()
+
+
+def test_the_schema_is_created_on_first_use(tmp_path):
+    """No migration step to forget, and no empty-database failure mode."""
+    path = tmp_path / "fresh.db"
+    db.configure(f"sqlite:///{path}")
+
+    assert sessions.count() == 0  # touching it is enough
+
+    with sqlite3.connect(path) as raw:
+        tables = {
+            row[0]
+            for row in raw.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert "sessions" in tables
+
+
+# ── Sessions ────────────────────────────────────────────────────────────────
+
+
+def test_a_session_round_trips(tmp_path):
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    token = sessions.create(
+        access_token="at",
+        refresh_token="rt",
+        expires_at=time.time() + 3600,
+        user={"sub": "alice", "email": "alice@example.com"},
+        created_at="2026-09-06T00:00:00+00:00",
+    )
+
+    stored = sessions.get(token)
+
+    assert stored is not None
+    assert stored["access_token"] == "at"
+    assert stored["refresh_token"] == "rt"
+    assert stored["user"]["sub"] == "alice"
+    assert stored["created_at"] == "2026-09-06T00:00:00+00:00"
+
+
+def test_a_minted_id_is_not_guessable(tmp_path):
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+
+    ids = {sessions.create(expires_at=time.time() + 60) for _ in range(50)}
+
+    assert len(ids) == 50
+    assert all(len(i) >= 32 for i in ids)
+
+
+def test_an_expired_session_is_dropped_as_it_is_read(tmp_path):
+    """What keeps the table bounded without a scheduled job.
+
+    The busiest thing in the system reads sessions, so the busiest thing in
+    the system is what cleans them.
+    """
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    token = sessions.create(expires_at=time.time() - 1)
+
+    assert sessions.get(token) is None
+    assert sessions.count() == 0
+
+
+def test_a_session_with_no_expiry_recorded_survives(tmp_path):
+    """Rows written before expiry was tracked must not all die at once."""
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    token = sessions.create(expires_at=0.0, user={"sub": "alice"})
+
+    assert sessions.get(token) is not None
+
+
+def test_removing_a_session_is_idempotent(tmp_path):
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    token = sessions.create(expires_at=time.time() + 60)
+
+    assert sessions.remove(token) is True
+    assert sessions.remove(token) is False
+    assert sessions.remove("") is False
+
+
+def test_sweeping_takes_the_expired_and_leaves_the_rest(tmp_path):
+    db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+    live = sessions.create(expires_at=time.time() + 3600)
+    sessions.create(expires_at=time.time() - 1)
+    sessions.create(expires_at=time.time() - 500)
+    forever = sessions.create(expires_at=0.0)
+
+    assert sessions.sweep() == 2
+
+    assert sessions.get(live) is not None
+    assert sessions.get(forever) is not None, "no expiry recorded is not expired"
+    assert sessions.count() == 2
+
+
+def test_a_session_survives_a_restart(tmp_path):
+    """The whole point of leaving the dictionary behind.
+
+    Disposing the engine and building a new one against the same file is what
+    a process restart is, from the database's side.
+    """
+    path = tmp_path / "state.db"
+    db.configure(f"sqlite:///{path}")
+    token = sessions.create(user={"sub": "alice"}, expires_at=time.time() + 3600)
+
+    db.dispose()
+    db.configure(f"sqlite:///{path}")
+
+    assert sessions.get(token) is not None, "the session did not survive a restart"
+
+
+def test_two_engines_on_one_file_see_each_others_writes(tmp_path):
+    """The multi-worker case, which is why a shared store exists at all.
+
+    Two engines against one file stand in for two uvicorn workers: a session
+    minted by one has to be readable by the other, which is exactly what the
+    in-memory dictionary could not do.
+    """
+    path = tmp_path / "state.db"
+    db.configure(f"sqlite:///{path}")
+    token = sessions.create(user={"sub": "alice"}, expires_at=time.time() + 3600)
+
+    db.dispose()  # the second "worker" builds its own engine
+    db.configure(f"sqlite:///{path}")
+
+    assert sessions.get(token) is not None

--- a/tests/test_db_and_sessions.py
+++ b/tests/test_db_and_sessions.py
@@ -230,3 +230,76 @@ def test_two_engines_on_one_file_see_each_others_writes(tmp_path):
     db.configure(f"sqlite:///{path}")
 
     assert sessions.get(token) is not None
+
+
+# ── The one-time import ─────────────────────────────────────────────────────
+
+
+class TestTheLegacyImportRunsOnce:
+    """A JSON file is imported once, and "once" cannot mean "whenever empty".
+
+    Keying the import off an empty table is the obvious implementation and is
+    wrong in a way that only shows up later: deleting the last deployment
+    empties the table, so the next read re-imports the file and resurrects
+    every deployment the operator had removed. It is the same shape as the
+    zombie record fixed in #40, arriving by a different route.
+    """
+
+    def _seed(self, path, records):
+        import json
+
+        path.write_text(json.dumps(records))
+
+    def test_records_are_imported_from_the_legacy_file(self, tmp_path, monkeypatch):
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+
+        assert [r["id"] for r in store.load()] == ["dep-1"]
+
+    def test_deleting_the_last_record_does_not_resurrect_the_file(
+        self, tmp_path, monkeypatch
+    ):
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+        assert len(store.load()) == 1
+
+        assert store.delete("dep-1") is True
+
+        assert store.load() == [], "the legacy file was imported a second time"
+        assert legacy.exists(), "the operator's file is left where it was"
+
+    def test_saving_an_empty_set_stays_empty(self, tmp_path, monkeypatch):
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+        store.load()
+
+        store.save([])
+
+        assert store.load() == []
+
+    def test_a_file_restored_after_a_fresh_start_is_still_imported(
+        self, tmp_path, monkeypatch
+    ):
+        """A fresh install must not record an import it never performed."""
+        from spark_pulse.tools import deployment_records as store
+
+        db.configure(f"sqlite:///{tmp_path / 'state.db'}")
+        legacy = tmp_path / "deployments.json"
+        monkeypatch.setattr(store, "RECORDS_FILE", legacy)
+        assert store.load() == []  # nothing to import yet
+
+        self._seed(legacy, [{"id": "dep-1", "status": "running", "runtime": "native"}])
+
+        assert [r["id"] for r in store.load()] == ["dep-1"]

--- a/tests/test_e2e_oidc.py
+++ b/tests/test_e2e_oidc.py
@@ -12,9 +12,13 @@ from __future__ import annotations
 import os
 from urllib.parse import parse_qs, urlparse
 
+import time
+
 import httpx
 import pytest
 import oidc_provider_mock
+
+from spark_pulse import sessions
 
 from spark_pulse.app import create_app
 from spark_pulse.config import config
@@ -181,13 +185,12 @@ class TestTokenManagement:
 
     def test_logout_invalidates_token(self):
         """Logout should invalidate the current token."""
-        from spark_pulse import auth
 
         # Manually insert a valid token
-        valid_token = "test-token-logout"
-        auth._active_tokens[valid_token] = {
-            "user": {"name": "Alice", "email": "alice@example.com"},
-        }
+        valid_token = sessions.create(
+            user={"name": "Alice", "email": "alice@example.com"},
+            expires_at=time.time() + 3600,
+        )
 
         # Verify token is valid
         from fastapi.testclient import TestClient
@@ -249,13 +252,12 @@ class TestAuthMiddleware:
 
     def test_protected_path_accessible_with_valid_cookie(self):
         """Protected API paths should be accessible with a valid cookie."""
-        from spark_pulse import auth
 
         # Manually insert a valid token
-        valid_token = "test-token-protected"
-        auth._active_tokens[valid_token] = {
-            "user": {"name": "Bob", "email": "bob@example.com"},
-        }
+        valid_token = sessions.create(
+            user={"name": "Bob", "email": "bob@example.com"},
+            expires_at=time.time() + 3600,
+        )
 
         from fastapi.testclient import TestClient
 

--- a/tests/test_e2e_oidc_flow.py
+++ b/tests/test_e2e_oidc_flow.py
@@ -32,7 +32,7 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from spark_pulse import auth
+from spark_pulse import auth, sessions
 from spark_pulse.app import create_app
 from spark_pulse.config import config
 
@@ -94,11 +94,11 @@ def client(discovery_front, monkeypatch):
     monkeypatch.setitem(config._data, "oidc_provider_url", discovery_front)
     monkeypatch.setitem(config._data, "oidc_client_id", "spark-pulse-test")
     monkeypatch.setitem(config._data, "oidc_client_secret", "test-secret")
-    auth._active_tokens.clear()
+    sessions.clear()
     auth._pending_states.clear()
     with TestClient(create_app(), raise_server_exceptions=False) as test_client:
         yield test_client
-    auth._active_tokens.clear()
+    sessions.clear()
     auth._pending_states.clear()
 
 

--- a/tests/test_router_custom_recipes.py
+++ b/tests/test_router_custom_recipes.py
@@ -94,8 +94,11 @@ class TestSaveCustomization:
         mock_custom_path.write_text(json.dumps({"r": {"command": "old"}}))
         resp = app_client.put("/api/recipes/customize/r", json={"model": "new"})
         assert resp.status_code == 200
-        # The stored file should have both
-        stored = json.loads(mock_custom_path.read_text())
+        # Read back through the store: the seeded file is only its one-time
+        # migration source, so a write after that does not land there.
+        import spark_pulse.tools.custom_recipes as cr
+
+        stored = cr.load_customizations()
         assert stored["r"]["command"] == "old"
         assert stored["r"]["model"] == "new"
 
@@ -122,7 +125,9 @@ class TestDeleteCustomization:
         mock_custom_path.write_text(json.dumps({"r1": {}, "r2": {}}))
         resp = app_client.delete("/api/recipes/customize/r1")
         assert resp.status_code == 200
-        stored = json.loads(mock_custom_path.read_text())
+        import spark_pulse.tools.custom_recipes as cr
+
+        stored = cr.load_customizations()
         assert "r1" not in stored
         assert "r2" in stored
 

--- a/tests/test_router_deployment_metrics.py
+++ b/tests/test_router_deployment_metrics.py
@@ -8,7 +8,6 @@ list, never as a chart of nothing.
 
 from __future__ import annotations
 
-import json
 
 import pytest
 from fastapi.testclient import TestClient
@@ -40,7 +39,14 @@ def client(store, sampler):
 
 
 def write(store, *records):
-    store.write_text(json.dumps(list(records)))
+    """Set the deployment set to exactly ``records``.
+
+    Through the store rather than by writing the JSON file: state lives in the
+    database, and the file is only its one-time migration source — so writing
+    it a second time changes nothing.
+    """
+    del store  # kept so the fixture still scopes the state to this test
+    tools.deployment_records.save(list(records))
 
 
 def record(**overrides):

--- a/tests/test_router_deployment_metrics.py
+++ b/tests/test_router_deployment_metrics.py
@@ -34,7 +34,20 @@ def sampler():
 
 @pytest.fixture
 def client(store, sampler):
+    """The API, with the *background* sampler stopped.
+
+    ``create_app``'s lifespan starts the sampler thread, and that thread
+    sweeps once immediately and then every interval. These tests drive
+    ``sample_once`` themselves and count the readings it produces, so a thread
+    sampling alongside them adds ticks nobody asked for — which showed up in
+    CI as ``assert 3 == 2`` and never locally, because it needs the test to
+    outlive one interval and CI is the slow machine.
+
+    The sampler *object* is kept, so snapshots taken through the API still see
+    what the test recorded; only the thread goes.
+    """
     with TestClient(create_app()) as test_client:
+        sampler.stop()
         yield test_client
 
 

--- a/tests/test_router_deployments.py
+++ b/tests/test_router_deployments.py
@@ -401,7 +401,9 @@ class TestLegacyRecords:
         assert response.json()["status"] == "stopped"
         getpgid.assert_called_once_with(4242)
         assert killpg.call_args[0] == (4242, signal.SIGTERM)
-        assert json.loads(env["records"].read_text())[0]["status"] == "stopped"
+        # Through the store: state lives in the database now, and the seeded
+        # JSON file is only its migration source.
+        assert tools.deployment_records.load()[0]["status"] == "stopped"
 
     def test_a_process_that_is_already_gone_still_marks_the_record(self, client, env):
         self._seed(env)
@@ -425,7 +427,7 @@ class TestLegacyRecords:
         response = client.delete("/api/deployments/legacy")
 
         assert response.json() == {"deleted": True, "id": "legacy"}
-        assert json.loads(env["records"].read_text()) == []
+        assert tools.deployment_records.load() == []
 
     def test_deleting_one_stops_it_first(self, env):
         """Forgetting a deployment is not the same as ending it."""
@@ -534,7 +536,7 @@ class TestUnreadableRecordFile:
         )
 
         assert response.status_code == 200
-        assert json.loads(env["records"].read_text())[0]["id"] == response.json()["id"]
+        assert tools.deployment_records.load()[0]["id"] == response.json()["id"]
         leftovers = [
             p for p in env["records"].parent.iterdir() if p.name.endswith(".tmp")
         ]

--- a/tests/test_state_durability.py
+++ b/tests/test_state_durability.py
@@ -20,6 +20,7 @@ import importlib
 import json
 import os
 import stat
+import threading
 from pathlib import Path
 
 import pytest
@@ -303,6 +304,200 @@ class TestDeploymentStateFile:
         state_file.write_text("[[[")
         with pytest.raises(StateFileError):
             nr._load_records()
+
+
+# ── Per-row writes ───────────────────────────────────────────────────────────
+
+
+@contextlib.contextmanager
+def sql_recorded():
+    """Every statement the shared engine executes inside the block."""
+    from sqlalchemy import event
+
+    from spark_pulse import db
+
+    executed: list[tuple[str, object]] = []
+
+    def observe(_conn, _cursor, statement, parameters, _context, _many):
+        executed.append((statement, parameters))
+
+    active = db.engine()
+    event.listen(active, "before_cursor_execute", observe)
+    try:
+        yield executed
+    finally:
+        event.remove(active, "before_cursor_execute", observe)
+
+
+def _writes(executed: list[tuple[str, object]], verb: str) -> list[tuple[str, object]]:
+    return [(s, p) for s, p in executed if s.lstrip().upper().startswith(verb)]
+
+
+THREE = [
+    {"id": "dep-1", "status": "running", "port": 8000},
+    {"id": "dep-2", "status": "running", "port": 8001},
+    {"id": "dep-3", "status": "stopped", "port": 8002},
+]
+
+
+class TestPerRowWrites:
+    """One deployment can change without the rest being rewritten.
+
+    The whole-set :func:`save` is still what ``native_runtime`` calls and still
+    means "the set is now exactly this", deletions included. What it may not go
+    on doing is *writing* the whole set: on PostgreSQL that is a dead tuple and
+    a WAL record for every deployment on the machine each time one of them
+    changes status, and the cost grows with the size of the cluster rather than
+    with the size of the change.
+    """
+
+    def test_the_whole_set_save_still_removes_what_is_absent(self, state_file):
+        records.save(THREE)
+
+        records.save(THREE[:1])
+
+        assert [r["id"] for r in records.load()] == ["dep-1"]
+
+    def test_saving_the_whole_set_writes_only_the_row_that_changed(self, state_file):
+        records.save(THREE)
+        changed = [dict(r) for r in THREE]
+        changed[1]["status"] = "stopped"
+
+        with sql_recorded() as executed:
+            records.save(changed)
+
+        updates = _writes(executed, "UPDATE")
+        assert len(updates) == 1, executed
+        assert "dep-2" in repr(updates[0][1])
+        assert "dep-1" not in repr(updates[0][1])
+
+    def test_saving_a_set_nothing_changed_in_writes_nothing_at_all(self, state_file):
+        records.save(THREE)
+
+        with sql_recorded() as executed:
+            records.save(THREE)
+
+        assert _writes(executed, "UPDATE") == []
+        assert _writes(executed, "INSERT") == []
+        assert _writes(executed, "DELETE") == []
+
+    def test_upsert_stores_one_record_and_leaves_the_others_alone(self, state_file):
+        """The difference from ``save``, which would have deleted the others."""
+        records.save(THREE)
+
+        records.upsert({"id": "dep-2", "status": "stopped", "port": 8001})
+
+        assert {r["id"]: r["status"] for r in records.load()} == {
+            "dep-1": "running",
+            "dep-2": "stopped",
+            "dep-3": "stopped",
+        }
+
+    def test_upsert_inserts_a_record_that_was_not_stored_yet(self, state_file):
+        records.save(THREE)
+
+        records.upsert({"id": "dep-4", "status": "pending"})
+
+        assert records.get("dep-4") == {"id": "dep-4", "status": "pending"}
+        assert len(records.load()) == 4
+
+    def test_a_record_with_no_id_is_refused_rather_than_silently_dropped(
+        self, state_file
+    ):
+        with pytest.raises(ValueError):
+            records.upsert({"status": "running"})
+
+    def test_update_merges_onto_what_is_stored_not_onto_the_callers_copy(
+        self, state_file
+    ):
+        """The lost update the mutex exists to prevent, in per-row form."""
+        records.save(THREE)
+        stale = records.get("dep-1")  # a caller's copy, taken early
+        records.update("dep-1", port=9999)  # somebody else changes a field
+
+        stale["status"] = "stopped"
+        records.update("dep-1", status=stale["status"])
+
+        stored = records.get("dep-1")
+        assert stored["status"] == "stopped"
+        assert stored["port"] == 9999, "the stale copy's port was written back"
+
+    def test_update_answers_none_for_a_record_that_is_gone(self, state_file):
+        records.save(THREE)
+        assert records.update("dep-9", status="stopped") is None
+
+    def test_delete_many_removes_exactly_the_named_rows(self, state_file):
+        records.save(THREE)
+
+        assert records.delete_many(["dep-1", "dep-3", "dep-9"]) == 2
+
+        assert [r["id"] for r in records.load()] == ["dep-2"]
+
+    def test_a_per_row_write_waits_for_a_whole_set_write_to_finish(self, state_file):
+        """Both kinds of write take the same mutex, or neither of them is safe."""
+        records.save(THREE)
+        done = threading.Event()
+
+        def stop_it():
+            records.update("dep-1", status="stopped")
+            done.set()
+
+        worker = threading.Thread(target=stop_it)
+        with records.transaction():
+            worker.start()
+            assert not done.wait(0.2), "the per-row write did not take the mutex"
+
+        assert done.wait(5)
+        worker.join()
+        assert records.get("dep-1")["status"] == "stopped"
+
+    def test_a_redaction_on_load_does_not_delete_a_record_created_since(
+        self, state_file, monkeypatch
+    ):
+        """``load`` repairs the records it read, and touches nothing else.
+
+        The redaction used to write the whole set back, which on a *read* path
+        means deleting whatever another thread created while the read was in
+        flight — and ``load`` holds no mutex, so that window is real.
+        ``_redact`` runs inside it, which makes it the seam that can stand in
+        for the other thread.
+        """
+        records.save([{"id": "dep-1", "launch_command": "run -e HF_TOKEN=hunter2"}])
+        redact = records._redact
+
+        def redact_and_race(command):
+            records.upsert({"id": "dep-2", "status": "running"})
+            return redact(command)
+
+        monkeypatch.setattr(records, "_redact", redact_and_race)
+
+        loaded = records.load()
+
+        assert loaded[0]["launch_command"] == "run -e HF_TOKEN=[REDACTED]"
+        assert records.get("dep-1")["launch_command"].endswith("[REDACTED]")
+        assert records.get("dep-2") is not None, "the concurrent record was deleted"
+
+    def test_reconciling_legacy_records_writes_back_only_those_it_decided(
+        self, state_file, monkeypatch
+    ):
+        """A PID sweep is about legacy records, and must not touch the rest.
+
+        ``_pid_is_alive`` is the seam for the same reason ``_redact`` is: it
+        runs between the load and the write-back, so a record that appears
+        there is one the sweep never read.
+        """
+        records.save([{"id": "old", "status": "running", "pid": 4242}])
+
+        def probe_and_race(_pid):
+            records.upsert({"id": "new", "status": "running", "runtime": "native"})
+            return False
+
+        monkeypatch.setattr(records, "_pid_is_alive", probe_and_race)
+
+        assert [r["id"] for r in records.list_legacy()] == ["old"]
+
+        assert records.get("old")["status"] == "stopped"
+        assert records.get("new") is not None, "a native deployment was purged"
 
 
 # ── Startup refuses on an unreadable state file ──────────────────────────────

--- a/tests/test_state_durability.py
+++ b/tests/test_state_durability.py
@@ -43,6 +43,28 @@ def _temp_leftovers(directory: Path) -> list[Path]:
 
 
 @contextlib.contextmanager
+def crashing_commit():
+    """Fail every database commit for the duration of the block.
+
+    The successor to :func:`crashing_replace`: what used to be a torn rename
+    is now a transaction that does not commit, and the property under test —
+    the previous state survives — is the same one.
+    """
+    from sqlalchemy.orm import Session as SaSession
+
+    original = SaSession.commit
+
+    def boom(self):
+        raise OSError("simulated crash before the transaction committed")
+
+    SaSession.commit = boom
+    try:
+        yield
+    finally:
+        SaSession.commit = original
+
+
+@contextlib.contextmanager
 def crashing_replace():
     """Fail every ``os.replace`` for the duration of the block.
 
@@ -240,10 +262,18 @@ class TestDeploymentStateFile:
         assert len(list(state_file.parent.glob("deployments.json.corrupt.*"))) == 1
         assert str(exc.value.quarantine_path) in str(exc.value)
 
-    def test_crash_before_replace_keeps_the_previous_deployments(self, state_file):
+    def test_a_crash_mid_write_keeps_the_previous_deployments(self, state_file):
+        """The property survives the move from a JSON file to the database.
+
+        It used to be the atomic rename that gave it: a torn write left the
+        old file in place. Now it is the transaction — ``session_scope``
+        rolls back — and the guarantee an operator depends on is unchanged:
+        a write that fails leaves the previous set of deployments intact,
+        never half of it.
+        """
         records.save(SAMPLE)
 
-        with crashing_replace():
+        with crashing_commit():
             with pytest.raises(OSError):
                 records.save([])
 
@@ -261,13 +291,15 @@ class TestDeploymentStateFile:
             records.check_state_file()
 
     def test_native_runtime_records_share_the_durable_path(self, state_file):
+        """One store, reached the same way from both modules."""
         nr = importlib.import_module("spark_pulse.tools.native_runtime")
         nr._save_records(SAMPLE)
 
-        assert json.loads(state_file.read_text()) == SAMPLE
-        assert _temp_leftovers(state_file.parent) == []
         assert nr._load_records() == SAMPLE
+        assert records.load() == SAMPLE
 
+        # And an unreadable *legacy* file is still refused rather than read as
+        # an empty cluster, because that file is the migration source.
         state_file.write_text("[[[")
         with pytest.raises(StateFileError):
             nr._load_records()

--- a/tests/test_tools_benchmarking_real.py
+++ b/tests/test_tools_benchmarking_real.py
@@ -20,10 +20,13 @@ from __future__ import annotations
 import importlib
 import json
 import sys
+import threading
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
 from filelock import FileLock
+from sqlalchemy import event
 
 import spark_pulse.tools as tools_pkg
 
@@ -97,13 +100,41 @@ def store(tmp_path, monkeypatch):
 
 
 def _seed(path, records: list[dict]) -> None:
-    """Write records straight to the store and drop the in-memory cache."""
-    path.write_text(json.dumps(records))
+    """Put records straight into the store and drop the in-memory cache."""
+    del path  # kept so callers still scope state to their fixture
+    benchmarking._save(records)
     benchmarking._reset_cache()
 
 
 def _on_disk(path) -> list[dict]:
-    return json.loads(path.read_text())
+    del path  # kept so callers still scope state to their fixture
+    return benchmarking._load()
+
+
+@contextmanager
+def _rows_written():
+    """Collect the INSERT/UPDATE/DELETE statements the block sends to ``benchmarks``.
+
+    The difference between a whole-set save and a per-row write is invisible in
+    the data — both leave the store correct — and visible only in how much of
+    the table was rewritten to get there. Counting statements is the only way
+    to assert the property the per-row path exists for.
+    """
+    from spark_pulse.db import engine
+
+    statements: list[str] = []
+
+    def _watch(conn, cursor, statement, parameters, context, executemany):
+        head = statement.strip().split(maxsplit=1)[0].upper()
+        if head in ("INSERT", "UPDATE", "DELETE") and "benchmarks" in statement:
+            statements.append(statement)
+
+    live = engine()
+    event.listen(live, "before_cursor_execute", _watch)
+    try:
+        yield statements
+    finally:
+        event.remove(live, "before_cursor_execute", _watch)
 
 
 class _FakeBenchy:
@@ -159,15 +190,21 @@ class TestCreateBenchmark:
 
         assert _on_disk(store) == [record]
 
-    def test_generates_a_unique_id_and_appends_to_existing_records(self, store):
+    def test_generates_a_unique_id_and_adds_to_the_existing_records(self, store):
+        """As a set: row order is not part of what the store promises.
+
+        ``_load`` orders by id so both backends answer the same way, which is
+        not insertion order and was never guaranteed to be. What ordering
+        callers see is ``list_benchmarks``', and that sorts by ``started_at``.
+        """
         _seed(store, [_record("old-1")])
 
         first = benchmarking.create_benchmark("dep-1")
         second = benchmarking.create_benchmark("dep-2")
 
         assert first["benchmark_id"] != second["benchmark_id"]
-        ids = [b["benchmark_id"] for b in _on_disk(store)]
-        assert ids == ["old-1", first["benchmark_id"], second["benchmark_id"]]
+        ids = {b["benchmark_id"] for b in _on_disk(store)}
+        assert ids == {"old-1", first["benchmark_id"], second["benchmark_id"]}
 
     def test_defaults_params_to_an_empty_dict(self, store):
         assert benchmarking.create_benchmark("dep-1")["params"] == {}
@@ -630,12 +667,18 @@ class TestBaselineComparison:
 
 
 class TestPersistence:
-    def test_saves_through_a_temp_file_and_leaves_none_behind(self, store):
-        benchmarking.create_benchmark("dep-1")
+    def test_a_created_benchmark_is_readable_again(self, store):
+        """Was: the temp file was renamed and left none behind.
 
-        assert store.exists()
-        assert not store.with_suffix(".tmp").exists()
-        assert isinstance(_on_disk(store), list)
+        Storage is the database now, so the property worth pinning is the one
+        the file mechanics existed to provide — a create is durable and reads
+        back — rather than how it reached the disk.
+        """
+        created = benchmarking.create_benchmark("dep-1")
+
+        stored = _on_disk(store)
+        assert isinstance(stored, list)
+        assert [b["benchmark_id"] for b in stored] == [created["benchmark_id"]]
 
     def test_a_failed_write_leaves_the_previous_contents_intact(self, store):
         _seed(store, [_record("keep")])
@@ -647,12 +690,165 @@ class TestPersistence:
 
         assert [b["benchmark_id"] for b in _on_disk(store)] == ["keep"]
 
-    def test_reset_cache_forces_a_reload_from_disk(self, store):
+    def test_reset_cache_forces_a_reload_from_the_store(self, store):
         _seed(store, [_record("first")])
         assert benchmarking.get_benchmark("first") is not None
 
-        store.write_text(json.dumps([_record("second")]))
+        benchmarking._save([_record("second")])
         assert benchmarking.get_benchmark("second") is None  # still cached
 
         benchmarking._reset_cache()
         assert benchmarking.get_benchmark("second") is not None
+
+
+# ── Per-row writes ───────────────────────────────────────────────────────────
+
+
+class TestPerRowWrites:
+    """One benchmark changing must cost one row, not the whole history."""
+
+    def test_creating_a_benchmark_writes_only_its_own_row(self, store):
+        _seed(store, [_record("a"), _record("b"), _record("c")])
+
+        with _rows_written() as statements:
+            benchmarking.create_benchmark("dep-1")
+
+        assert len(statements) == 1
+
+    def test_finishing_a_benchmark_writes_only_its_own_row(self, store, benchy):
+        benchy()
+        _seed(store, [_record("a"), _record("b")])
+        record = benchmarking.create_benchmark("dep-1")
+
+        with _rows_written() as statements:
+            benchmarking.execute_benchmark(record["benchmark_id"])
+
+        assert len(statements) == 1
+
+    def test_the_whole_set_save_writes_only_the_records_that_changed(self, store):
+        """The kept API, no longer paying for the rows it was handed unchanged."""
+        _seed(store, [_record("a"), _record("b"), _record("c")])
+
+        with _rows_written() as statements:
+            benchmarking._save(
+                [
+                    _record("a"),
+                    _record("b", status="error", results={"error": "boom"}),
+                    _record("c"),
+                ]
+            )
+
+        assert len(statements) == 1
+        assert benchmarking._get_row("b")["status"] == "error"
+
+    def test_the_whole_set_save_still_removes_records_absent_from_the_set(self, store):
+        """The one thing a per-row write must not quietly take away."""
+        _seed(store, [_record("gone"), _record("kept")])
+
+        benchmarking._save([_record("kept")])
+
+        assert [b["benchmark_id"] for b in _on_disk(store)] == ["kept"]
+
+    def test_a_record_with_no_id_is_refused_rather_than_written_nowhere(self, store):
+        """The whole-set save skips these as noise; one on its own is a caller bug."""
+        with pytest.raises(ValueError):
+            benchmarking._upsert_row({"deployment_id": "dep-1"})
+
+    def test_a_create_waits_for_a_whole_set_save_already_in_flight(self, store):
+        """The lost update the whole-set path was serialised to prevent.
+
+        A whole-set save deletes every row absent from the list it loaded, so a
+        create that landed while one was in flight would be deleted by it. The
+        per-row write takes the same mutex, so it waits instead.
+        """
+        _seed(store, [_record("existing")])
+        holding = threading.Event()
+        release = threading.Event()
+        created: list[dict] = []
+
+        def whole_set_save():
+            with benchmarking._atomic_benchmarks() as data:
+                holding.set()
+                release.wait(5)
+                data.append(_record("from-the-whole-set"))
+
+        def create():
+            created.append(benchmarking.create_benchmark("dep-1"))
+
+        writer = threading.Thread(target=whole_set_save)
+        writer.start()
+        assert holding.wait(5)
+        creator = threading.Thread(target=create)
+        creator.start()
+        creator.join(0.3)
+        assert creator.is_alive(), "the create did not wait for the mutex"
+
+        release.set()
+        writer.join(5)
+        creator.join(5)
+
+        assert {b["benchmark_id"] for b in _on_disk(store)} == {
+            "existing",
+            "from-the-whole-set",
+            created[0]["benchmark_id"],
+        }
+
+
+# ── Retention ────────────────────────────────────────────────────────────────
+
+
+class TestRetention:
+    def test_expired_records_are_deleted_from_the_store_not_merely_hidden(self, store):
+        """The purge used to filter the answer and leave the rows.
+
+        It logged "Purged N expired benchmark records" every time it ran, on a
+        store that never lost one — so retention was a claim in the log and the
+        table grew without bound.
+        """
+        _seed(
+            store,
+            [
+                _record("fresh", started_at=YESTERDAY),
+                _record("stale", started_at=EXPIRED),
+            ],
+        )
+
+        benchmarking.list_benchmarks()
+
+        assert [b["benchmark_id"] for b in _on_disk(store)] == ["fresh"]
+
+    def test_purging_the_last_record_does_not_re_import_the_json_file(self, store):
+        """The import is keyed on the ``meta`` table, never on an empty table.
+
+        Emptying the store by retention is exactly the state a "is the table
+        empty" check would mistake for a fresh install — and it would import
+        the ninety-day-old records straight back.
+        """
+        store.write_text(json.dumps([_record("stale", started_at=EXPIRED)]))
+        benchmarking._reset_cache()
+
+        assert benchmarking.list_benchmarks() == []
+        assert benchmarking.list_benchmarks() == []
+        assert _on_disk(store) == []
+
+    def test_a_point_read_triggers_the_one_time_json_import(self, store, benchy):
+        """``execute_benchmark`` reads one row now, so the import must happen there."""
+        store.write_text(
+            json.dumps(
+                [
+                    _record(
+                        "from-json",
+                        status="running",
+                        completed_at=None,
+                        results=None,
+                        params={"port": 8000},
+                    )
+                ]
+            )
+        )
+        benchmarking._reset_cache()
+        benchy(result={"throughput": 12.0})
+
+        benchmarking.execute_benchmark("from-json")
+
+        assert benchmarking.get_benchmark("from-json")["status"] == "completed"

--- a/tests/test_tools_custom_recipes.py
+++ b/tests/test_tools_custom_recipes.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import threading
+from contextlib import contextmanager
 from unittest.mock import patch
 
+import pytest
+from sqlalchemy import event
 
 from spark_pulse.tools import custom_recipes
 
@@ -55,28 +59,42 @@ class TestLoadCustomizations:
 class TestSaveCustomizations:
     """Test saving customizations to disk."""
 
-    def test_writes_json_file(self, tmp_path):
-        """Should write a valid JSON file."""
+    def test_what_is_saved_is_what_loads(self, tmp_path):
+        """The round trip, asserted through the API rather than the storage.
+
+        These used to read the JSON file back. Customizations live in the
+        database now, so what is worth pinning is that a save is visible to
+        the next load — which is the property the file assertions stood in
+        for."""
         data = {"recipe-1": {"command": "echo test"}}
-        fpath = tmp_path / "custom.json"
 
-        with patch.object(custom_recipes, "_CUSTOM_PATH", fpath):
-            custom_recipes.save_customizations(data)
+        custom_recipes.save_customizations(data)
 
-        assert fpath.exists()
-        loaded = json.loads(fpath.read_text())
-        assert loaded == data
+        assert custom_recipes.load_customizations() == data
 
-    def test_creates_parent_dir(self, tmp_path):
-        """Should create parent directory if missing."""
-        nested = tmp_path / "deep" / "nested" / "dir.json"
+    def test_saving_replaces_rather_than_merges(self, tmp_path):
+        custom_recipes.save_customizations({"gone": {"command": "old"}})
 
-        with patch.object(custom_recipes, "_CUSTOM_PATH", nested):
-            custom_recipes.save_customizations({})
+        custom_recipes.save_customizations({"kept": {"command": "new"}})
 
-        assert nested.parent.exists()
+        assert custom_recipes.load_customizations() == {"kept": {"command": "new"}}
 
-    def test_atomic_write_via_tmp(self, tmp_path):
+    def test_a_failed_save_leaves_the_previous_set(self, tmp_path):
+        """What the temp-file-and-rename gave, now given by the transaction."""
+        from sqlalchemy.orm import Session as SaSession
+
+        custom_recipes.save_customizations({"kept": {"command": "original"}})
+        original = SaSession.commit
+        SaSession.commit = lambda self: (_ for _ in ()).throw(OSError("disk full"))
+        try:
+            with pytest.raises(OSError):
+                custom_recipes.save_customizations({"other": {"command": "new"}})
+        finally:
+            SaSession.commit = original
+
+        assert custom_recipes.load_customizations() == {"kept": {"command": "original"}}
+
+    def _removed_test_atomic_write_via_tmp(self, tmp_path):
         """Should use atomic write (tmp + rename)."""
         fpath = tmp_path / "custom.json"
         original_write = tmp_path / "custom.json.tmp"
@@ -133,8 +151,7 @@ class TestSaveCustomization:
 
         assert result["command"] == "echo hi"
 
-        # Verify file has the entry
-        stored = json.loads(fpath.read_text())
+        stored = custom_recipes.load_customizations()
         assert "new-recipe" in stored
 
     def test_merges_into_existing(self, tmp_path):
@@ -151,7 +168,7 @@ class TestSaveCustomization:
         # Result is the merged dict for new-recipe
         assert result["model"] == "new-model"
         # File should have both entries
-        stored = json.loads(fpath.read_text())
+        stored = custom_recipes.load_customizations()
         assert "other-recipe" in stored
         assert "new-recipe" in stored
 
@@ -173,7 +190,7 @@ class TestSaveCustomization:
         assert "defaults" in result
 
         # Verify file state
-        stored = json.loads(fpath.read_text())
+        stored = custom_recipes.load_customizations()
         assert stored["r"]["command"] == "new-cmd"
         assert "description" not in stored["r"]
 
@@ -335,3 +352,153 @@ class TestGetCustomizedRecipe:
             with patch("spark_pulse.tools.recipes.get_recipe", return_value=None):
                 result = custom_recipes.get_customized_recipe("missing")
                 assert result is None
+
+
+# ── Test: per-recipe writes ─────────────────────────────────────────────────
+
+
+@contextmanager
+def _rows_written():
+    """Collect the INSERT/UPDATE/DELETE statements the block sends to the table.
+
+    Whether one recipe or all of them were rewritten is invisible in the data —
+    both leave the store correct — and visible only in the statements it took.
+    """
+    from spark_pulse.db import engine
+
+    statements: list[str] = []
+
+    def _watch(conn, cursor, statement, parameters, context, executemany):
+        head = statement.strip().split(maxsplit=1)[0].upper()
+        if head in ("INSERT", "UPDATE", "DELETE") and "recipe_customizations" in (
+            statement
+        ):
+            statements.append(statement)
+
+    live = engine()
+    event.listen(live, "before_cursor_execute", _watch)
+    try:
+        yield statements
+    finally:
+        event.remove(live, "before_cursor_execute", _watch)
+
+
+class TestPerRecipeWrites:
+    """Customizing one recipe must cost one row, not every customized recipe."""
+
+    def test_saving_one_recipe_writes_only_that_row(self):
+        custom_recipes.save_customizations(
+            {"r1": {"command": "a"}, "r2": {"command": "b"}, "r3": {"command": "c"}}
+        )
+
+        with _rows_written() as statements:
+            custom_recipes.save_customization("r2", {"model": "m"})
+
+        assert len(statements) == 1
+        assert custom_recipes.get_customization("r1") == {"command": "a"}
+
+    def test_deleting_one_recipe_writes_only_that_row(self):
+        custom_recipes.save_customizations(
+            {"r1": {"command": "a"}, "r2": {"command": "b"}, "r3": {"command": "c"}}
+        )
+
+        with _rows_written() as statements:
+            custom_recipes.delete_customization("r2")
+
+        assert len(statements) == 1
+        assert set(custom_recipes.load_customizations()) == {"r1", "r3"}
+
+    def test_a_save_with_nothing_customizable_in_it_creates_no_row(self):
+        """And leaves every other recipe where it was."""
+        custom_recipes.save_customizations({"r2": {"command": "b"}})
+
+        assert custom_recipes.save_customization("r1", {"description": "only"}) == {}
+
+        assert custom_recipes.load_customizations() == {"r2": {"command": "b"}}
+
+    def test_the_whole_set_save_writes_only_the_recipes_that_changed(self):
+        """The kept API, no longer paying for the rows it was handed unchanged."""
+        custom_recipes.save_customizations(
+            {"r1": {"command": "a"}, "r2": {"command": "b"}, "r3": {"command": "c"}}
+        )
+
+        with _rows_written() as statements:
+            custom_recipes.save_customizations(
+                {
+                    "r1": {"command": "a"},
+                    "r2": {"command": "CHANGED"},
+                    "r3": {"command": "c"},
+                }
+            )
+
+        assert len(statements) == 1
+        assert custom_recipes.get_customization("r2") == {"command": "CHANGED"}
+
+    def test_a_single_recipe_save_waits_for_a_whole_set_write_in_flight(self):
+        """The lost update the mutex exists for.
+
+        A whole-set save deletes every recipe absent from the set it was given,
+        so a per-recipe save landing in the middle of one would be deleted by
+        it. Both take the same mutex, so the second one waits.
+        """
+        finished = threading.Event()
+
+        def save_one():
+            custom_recipes.save_customization("r", {"command": "x"})
+            finished.set()
+
+        with custom_recipes.transaction():
+            worker = threading.Thread(target=save_one)
+            worker.start()
+            assert not finished.wait(0.3), "the save did not wait for the mutex"
+
+        worker.join(5)
+        assert finished.is_set()
+        assert custom_recipes.get_customization("r") == {"command": "x"}
+
+
+# ── Test: the one-time JSON import ──────────────────────────────────────────
+
+
+class TestTheOneTimeImport:
+    def test_a_point_read_triggers_the_import(self, tmp_path):
+        """``get_customization`` reads one row now, so it must import there too."""
+        fpath = tmp_path / "custom.json"
+        fpath.write_text(json.dumps({"r": {"command": "from-json"}}), encoding="utf-8")
+
+        with patch.object(custom_recipes, "_CUSTOM_PATH", fpath):
+            assert custom_recipes.get_customization("r") == {"command": "from-json"}
+
+    def test_the_import_does_not_run_again_after_the_last_row_is_deleted(
+        self, tmp_path
+    ):
+        """Keyed on the ``meta`` table, never on "is the table empty".
+
+        Deleting the last customization empties the table, which is exactly the
+        state an emptiness check would mistake for a fresh install — and it
+        would import the deleted recipe straight back.
+        """
+        fpath = tmp_path / "custom.json"
+        fpath.write_text(json.dumps({"r": {"command": "from-json"}}), encoding="utf-8")
+
+        with patch.object(custom_recipes, "_CUSTOM_PATH", fpath):
+            assert custom_recipes.delete_customization("r") is True
+
+            assert custom_recipes.get_customization("r") is None
+            assert custom_recipes.load_customizations() == {}
+
+    def test_a_whole_set_save_is_not_undone_by_an_import_that_had_not_run(
+        self, tmp_path
+    ):
+        """The save has to import first, or its deletions are reversed.
+
+        Writing before the import means the import merges the old file in
+        afterwards, resurrecting every recipe the caller had just removed.
+        """
+        fpath = tmp_path / "custom.json"
+        fpath.write_text(json.dumps({"gone": {"command": "old"}}), encoding="utf-8")
+
+        with patch.object(custom_recipes, "_CUSTOM_PATH", fpath):
+            custom_recipes.save_customizations({"kept": {"command": "new"}})
+
+            assert custom_recipes.load_customizations() == {"kept": {"command": "new"}}

--- a/tests/test_tools_native_runtime.py
+++ b/tests/test_tools_native_runtime.py
@@ -706,6 +706,57 @@ class TestMods:
         assert plan.workdir == "/workspace/vllm"
 
 
+class TestRecordWrites:
+    """``native_runtime`` still hands the store the whole list.
+
+    That shape is not changing — it is what every caller here has — and it is
+    no longer what gets written. The store diffs the set it is given, so a
+    status change on one deployment costs one row rather than an UPDATE for
+    every deployment on the machine.
+    """
+
+    def _seed(self, count):
+        tools.deployment_records.save(
+            [
+                {"id": f"dep-{i}", "status": "running", "runtime": "native"}
+                for i in range(count)
+            ]
+        )
+
+    def test_updating_one_record_writes_only_that_row(self, records):
+        store = importlib.import_module("spark_pulse.tools.deployment_records")
+        self._seed(3)
+        written: list[str] = []
+        apply_record = store._apply
+
+        def spy(row, record):
+            changed = apply_record(row, record)
+            if changed:
+                written.append(row.id)
+            return changed
+
+        with patch.object(store, "_apply", spy):
+            updated = nr._update_record("dep-1", status="stopped")
+
+        assert updated["status"] == "stopped"
+        assert written == ["dep-1"]
+
+    def test_updating_one_record_leaves_the_others_as_they_were(self, records):
+        self._seed(3)
+
+        nr._update_record("dep-1", status="stopped")
+
+        assert {r["id"]: r["status"] for r in tools.deployment_records.load()} == {
+            "dep-0": "running",
+            "dep-1": "stopped",
+            "dep-2": "running",
+        }
+
+    def test_updating_a_record_that_is_gone_answers_none(self, records):
+        self._seed(1)
+        assert nr._update_record("dep-9", status="stopped") is None
+
+
 class TestLifecycle:
     def _running(self, native, docker):
         plan = native.plan("qwen3-8b")

--- a/tests/test_tools_native_runtime.py
+++ b/tests/test_tools_native_runtime.py
@@ -439,7 +439,10 @@ class TestStart:
         plan = native.plan("qwen3-8b")
         native.start(plan, docker=docker, wait=True)
 
-        saved = json.loads(records.read_text())
+        # Read back through the store rather than off the file: state lives
+        # in the database now, and what this asserts is that the record
+        # persisted, not where it landed.
+        saved = tools.deployment_records.load()
         assert [d["id"] for d in saved] == [plan.deployment_id]
         assert saved[0]["runtime"] == "native"
 
@@ -724,7 +727,7 @@ class TestLifecycle:
         plan = self._running(native, docker)
 
         assert native.delete_deployment(plan.deployment_id, docker=docker) is True
-        assert json.loads(records.read_text()) == []
+        assert tools.deployment_records.load() == []
 
     def test_delete_of_an_unknown_deployment_is_false(self, native, docker):
         assert native.delete_deployment("nope", docker=docker) is False
@@ -762,7 +765,7 @@ class TestLifecycle:
     def test_list_adopts_an_unknown_labelled_container(self, native, docker, records):
         """Reconciliation: a managed container with no record is adopted."""
         plan = self._running(native, docker)
-        records.write_text(json.dumps([]))
+        tools.deployment_records.save([])  # the container outlives its record
 
         listed = native.list_deployments(docker=docker)
 

--- a/tests/test_tools_node_registry.py
+++ b/tests/test_tools_node_registry.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import json
 import sys
 import types
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import pytest
+from sqlalchemy import event
 
 import spark_pulse.tools  # noqa: F401 — ensures the package is loaded
 import spark_pulse.tools.node_registry  # noqa: F401 — the real submodule
@@ -55,6 +58,30 @@ def registry_in_tmp(tmp_path, monkeypatch):
     path = tmp_path / "nodes.json"
     monkeypatch.setattr(node_registry, "_REGISTRY_PATH", path)
     return path
+
+
+@contextmanager
+def statements_against_the_nodes_table():
+    """Every SQL statement the block sends that names the ``nodes`` table.
+
+    Counted at the driver rather than by patching the registry, so what is
+    asserted is what the database is actually asked to do — on either backend,
+    whose SQL differs in spelling but not in how many statements it takes.
+    """
+    from spark_pulse import db
+
+    engine = db.engine()
+    seen: list[str] = []
+
+    def capture(_conn, _cursor, statement, _params, _context, _many):
+        if "nodes" in statement:
+            seen.append(statement)
+
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        yield seen
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
 
 
 class TestIdentity:
@@ -164,6 +191,234 @@ class TestPersistence:
         (node,) = node_registry.list_nodes()
         assert len(node.id) == 32
         assert node.address == "10.0.0.11"
+
+
+class TestPerRowWrites:
+    """One change is one row.
+
+    The first cut of the database store rewrote the whole registry on every
+    write: renaming one peer read every node and merged every node back. That
+    is a cost that grows with the cluster, and — worse — it makes a write
+    depend on a set that was read before it, which is how a concurrent add is
+    silently deleted. These pin the shape that replaced it.
+    """
+
+    @staticmethod
+    def _writes(statements):
+        return [
+            statement
+            for statement in statements
+            if statement.lstrip().upper().startswith(("INSERT", "UPDATE", "DELETE"))
+        ]
+
+    def test_changing_one_node_costs_the_same_in_a_registry_of_three_and_of_forty(
+        self,
+    ):
+        """The whole point: the price of an edit is the edit, not the cluster."""
+        small = [node_registry.add_node(address=f"10.0.1.{i}") for i in range(1, 4)]
+        with statements_against_the_nodes_table() as in_a_small_registry:
+            node_registry.update_node(small[0].id, name="renamed")
+
+        for i in range(1, 38):
+            node_registry.add_node(address=f"10.0.2.{i}")
+        with statements_against_the_nodes_table() as in_a_large_registry:
+            node_registry.update_node(small[1].id, name="renamed-too")
+
+        assert len(in_a_large_registry) == len(in_a_small_registry)
+        assert len(self._writes(in_a_large_registry)) == 1
+
+    def test_reading_one_node_costs_the_same_in_a_registry_of_three_and_of_forty(self):
+        small = [node_registry.add_node(address=f"10.0.1.{i}") for i in range(1, 4)]
+        with statements_against_the_nodes_table() as in_a_small_registry:
+            assert node_registry.get_node(small[0].id) is not None
+
+        for i in range(1, 38):
+            node_registry.add_node(address=f"10.0.2.{i}")
+        with statements_against_the_nodes_table() as in_a_large_registry:
+            assert node_registry.get_node(small[1].id) is not None
+
+        assert len(in_a_large_registry) == len(in_a_small_registry) == 1
+
+    def test_forgetting_one_node_deletes_that_row_and_writes_no_other(self):
+        """A whole-set save spelled "forget one" as "replace all but one"."""
+        doomed = node_registry.add_node(address="10.0.0.11")
+        node_registry.add_node(address="10.0.0.12")
+        node_registry.add_node(address="10.0.0.13")
+
+        with statements_against_the_nodes_table() as statements:
+            node_registry.remove_node(doomed.id)
+
+        (write,) = self._writes(statements)
+        assert write.lstrip().upper().startswith("DELETE")
+        assert len(node_registry.list_nodes()) == 2
+
+    def test_nodes_added_from_several_threads_at_once_all_survive(self):
+        """The lost update the whole-set save made possible, run for real.
+
+        Each thread read the registry, appended its node and wrote the whole
+        list back, so whichever thread wrote last erased every node registered
+        while it was thinking. A cluster brought up by a script that enrolls
+        its peers in parallel would end up with one of them.
+        """
+        addresses = [f"10.0.0.{i}" for i in range(2, 22)]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            minted = {
+                node.id
+                for node in pool.map(
+                    lambda address: node_registry.add_node(address=address), addresses
+                )
+            }
+
+        assert len(minted) == len(addresses)
+        assert {node.id for node in node_registry.list_nodes()} == minted
+
+    def test_edits_to_different_nodes_from_different_threads_all_stick(self):
+        nodes = [node_registry.add_node(address=f"10.0.0.{i}") for i in range(2, 12)]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(
+                pool.map(
+                    lambda node: node_registry.update_node(
+                        node.id, name=f"renamed-{node.address}"
+                    ),
+                    nodes,
+                )
+            )
+
+        assert {node.name for node in node_registry.list_nodes()} == {
+            f"renamed-{node.address}" for node in nodes
+        }
+
+    def test_two_threads_racing_for_one_address_produce_one_node_not_two(self):
+        """Per-row writes stop deleting the loser, so the check has to hold.
+
+        Uniqueness used to be enforced by an accident: both threads inserted,
+        and the second one's whole-set save deleted the first. Now that a write
+        touches one row, "is this address free?" and the insert have to be one
+        indivisible step or the registry ends up with two nodes at one address
+        and pre-flight resolves it to whichever the query happened to return.
+        """
+        outcomes = []
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            for future in [
+                pool.submit(node_registry.add_node, address="10.0.0.11")
+                for _ in range(8)
+            ]:
+                try:
+                    outcomes.append(future.result())
+                except ValueError as exc:
+                    assert "already registered" in str(exc)
+
+        assert len(outcomes) == 1
+        assert [node.address for node in node_registry.list_nodes()] == ["10.0.0.11"]
+
+    def test_two_threads_racing_to_register_the_control_plane_agree_on_one(self):
+        """Two startups — the lifespan hook and a re-enrolling agent — racing."""
+        outcomes = []
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            for future in [
+                pool.submit(
+                    node_registry.add_node, name="control", is_control_plane=True
+                )
+                for _ in range(4)
+            ]:
+                try:
+                    outcomes.append(future.result())
+                except ValueError as exc:
+                    assert "already registered" in str(exc)
+
+        assert len(outcomes) == 1
+        assert len([n for n in node_registry.list_nodes() if n.is_control_plane]) == 1
+
+
+class TestWholeSetSave:
+    """The bulk path is still there, and still means *replace*.
+
+    Per-row writes are what a single change uses; a caller holding an entire
+    registry — a reconciliation against an external source of truth, a restore
+    — still needs "make the stored set be exactly this", including the
+    deletions that implies.
+    """
+
+    def test_saving_a_set_deletes_the_nodes_absent_from_it(self):
+        kept = node_registry.add_node(address="10.0.0.11")
+        node_registry.add_node(address="10.0.0.12")
+
+        node_registry._save([kept])
+
+        assert [node.id for node in node_registry.list_nodes()] == [kept.id]
+
+    def test_saving_a_set_inserts_and_updates_in_the_same_call(self):
+        existing = node_registry.add_node(address="10.0.0.11", name="old")
+        arriving = node_registry.NodeRecord(
+            id=node_registry.mint_node_id(), name="new", address="10.0.0.12"
+        )
+
+        from dataclasses import replace as dataclass_replace
+
+        node_registry._save([dataclass_replace(existing, name="renamed"), arriving])
+
+        by_id = {node.id: node for node in node_registry.list_nodes()}
+        assert by_id[existing.id].name == "renamed"
+        assert by_id[arriving.id].name == "new"
+
+
+class TestTheOneTimeImport:
+    """``nodes.json`` is imported once, and "once" is a fact in ``meta``.
+
+    Now that every entry point — including the writes — imports before it
+    touches the table, the guard against a second import matters at more call
+    sites than it did when only :func:`list_nodes` could trigger one.
+    """
+
+    def test_forgetting_the_last_node_does_not_resurrect_it_from_the_file(
+        self, registry_in_tmp
+    ):
+        """The reason the key lives in ``meta`` and not in ``SELECT count(*)``.
+
+        The file is deliberately left on disk after the import, so an import
+        that keyed on an empty table would run again the moment an operator
+        forgot the last node — and hand it straight back.
+        """
+        registry_in_tmp.write_text(
+            json.dumps({"version": 1, "nodes": [{"address": "10.0.0.11"}]})
+        )
+        (imported,) = node_registry.list_nodes()
+
+        node_registry.remove_node(imported.id)
+
+        assert registry_in_tmp.exists()
+        assert node_registry.list_nodes() == []
+        assert node_registry.get_node(imported.id) is None
+
+    def test_a_write_that_arrives_first_imports_the_file_before_it_checks(
+        self, registry_in_tmp
+    ):
+        """Otherwise the import lands on top of the write it should have blocked.
+
+        ``add_node`` refuses an address the registry already holds. If the
+        first call after a restart were a write and it checked before the
+        import, the file's node would not be there to collide with — and the
+        import would then arrive and leave two nodes at 10.0.0.11.
+        """
+        registry_in_tmp.write_text(
+            json.dumps({"version": 1, "nodes": [{"address": "10.0.0.11"}]})
+        )
+
+        with pytest.raises(ValueError, match="already registered"):
+            node_registry.add_node(address="10.0.0.11")
+
+        assert [node.address for node in node_registry.list_nodes()] == ["10.0.0.11"]
+
+    def test_an_edit_made_after_the_import_is_not_undone_by_a_later_read(
+        self, registry_in_tmp
+    ):
+        registry_in_tmp.write_text(
+            json.dumps({"version": 1, "nodes": [{"address": "10.0.0.11"}]})
+        )
+        (imported,) = node_registry.list_nodes()
+        node_registry.update_node(imported.id, address="192.168.50.4")
+
+        assert [node.address for node in node_registry.list_nodes()] == ["192.168.50.4"]
 
 
 class TestValidation:

--- a/tests/test_tools_node_registry.py
+++ b/tests/test_tools_node_registry.py
@@ -108,7 +108,6 @@ class TestPersistence:
             infiniband_interfaces=["ib0", "ib1"],
             state="healthy",
         )
-        assert registry_in_tmp.exists()
 
         reloaded = node_registry.get_node(node.id)
         assert reloaded == node
@@ -135,11 +134,28 @@ class TestPersistence:
             "zulu",
         ]
 
-    def test_the_file_records_a_version(self, registry_in_tmp):
-        node_registry.add_node(address="10.0.0.11")
-        data = json.loads(registry_in_tmp.read_text())
-        assert data["version"] == 1
-        assert len(data["nodes"]) == 1
+    def test_a_stored_node_keeps_every_field(self, registry_in_tmp):
+        """What the ``version`` key used to guard, asserted directly.
+
+        The JSON file carried a format version so a future reader could tell
+        shapes apart. State is in the database now and the schema plays that
+        role, so what is worth pinning here is the thing the version existed
+        to protect: a record survives storage with every field intact.
+        """
+        node = node_registry.add_node(
+            name="spark-02",
+            address="10.0.0.11",
+            ssh_user="spark",
+            infiniband_interfaces=["rocep1s0f0", "rocep1s0f1"],
+            fabric_mode="direct",
+            state="healthy",
+        )
+
+        (stored,) = node_registry.list_nodes()
+
+        assert stored == node
+        assert stored.infiniband_interfaces == ("rocep1s0f0", "rocep1s0f1")
+        assert stored.fabric_mode == "direct"
 
     def test_a_hand_edited_record_without_an_id_is_given_one(self, registry_in_tmp):
         registry_in_tmp.write_text(


### PR DESCRIPTION
State moves out of eight JSON/YAML files into one SQLAlchemy-backed database. `docs/cluster-agent-plan.md` §3.3 already chose this — *"SQLite in WAL mode replaces the JSON file as the source of truth for desired state"* — and `enrollment.py` has said "desired state moves to SQLite in a later step" since it was written.

**SQLAlchemy rather than the `sqlite3` driver, for the dialect boundary.** The scale case is `SPARK_PULSE_DATABASE_URL=postgresql+psycopg://…` plus `pip install spark-pulse[postgres]`, and nothing else anywhere.

## The PostgreSQL CI job is what made the rest honest

Until it existed, the only evidence for that claim was a test compiling the schema for the PostgreSQL dialect with no server behind it — which proves the column types are portable and nothing about whether the queries *run*. Standing it up found three real bugs within minutes, none visible on SQLite:

| | |
|---|---|
| **`Session.merge()` is unsafe as an upsert** | It chooses UPDATE from a load it performs itself, then matches nothing: `StaleDataError: UPDATE statement on table 'blobs' expected to update 1 row(s); 0 were matched`. Every store used it. The decision is written out now — get, then add or assign — putting it inside the transaction where it can be held. Recorded as a house rule in `db.py`. |
| **`create_all()` races itself** | It checks-then-creates, so two control planes starting against one database — the *ordinary* startup once there is more than one instance, not a rare race — both create the same table and the loser dies on `duplicate key ... "pg_type_typname_nsp_index"`. The loser now looks again. Verified with six concurrent creators, zero failures. |
| **A migration key overflowed its column** | The ledger's key was a file path in a `String(128)`. SQLite ignores the length; PostgreSQL raises `StringDataRightTruncation` — so a config directory nested deeper than ~90 characters was a control plane that starts on SQLite and fails its first insert on PostgreSQL. |

The job also **asserts it really ran against PostgreSQL**, by checking the server holds the tables afterwards. That is not hypothetical: the harness silently ignored an externally-set URL and would have reported success for a backend it never touched, until `conftest` was taught to stop overriding the variable it was given.

## What moved, and what deliberately did not

Nine tables: `deployments`, `nodes`, `enrollment_nodes`, `enrollment_tokens`, `benchmarks`, `recipe_customizations`, `sessions`, `blobs`, `meta`.

Each store imports its old file **once**, recorded in `meta` — not inferred from an empty table, because deleting the last row would re-import and resurrect what an operator removed. I got that wrong first and the tests caught it; it is the same shape as the zombie record fixed in #40.

**Sessions** were the natural first move: ephemeral by definition, so nothing to migrate and nothing to lose. A session now survives a restart, and two workers see the same one.

**File content** (`blobs.py`) is the interesting case. Recipes and mods *are* files, and what consumes them wants a `Path` — a mod is copied wholesale into a container. So this changes which copy is authoritative rather than removing the files: the database holds the content, the filesystem holds a digest-addressed cache rebuilt when stale. One control plane behaves exactly as today because its cache is always warm; several finally agree with each other.

**Still files, on purpose:** the CA key and node certificates (0600, read by external tooling — and a *node's* identity cannot live in a database it has no access to), user-editable recipe and mod directories, and the caches.

## Per-row writes

Saving one changed deployment rewrote every deployment. Each store keeps its whole-set API — callers still use it, and it still removes rows absent from the set — but single-entity callers now write one row. The read-modify-write serialisation is unchanged: narrowing a write is not a substitute for serialising the decision behind it.

## A master key for secrets

`crypto.py` reads `SPARK_PULSE_MASTER_KEY` and does AES-256-GCM with a fresh nonce per encryption, so secrets can live in a shared database without living in it in the clear. **Wiring the existing secrets onto it is the next step, not this one** — `settings.json` and `secrets.json` are untouched here.

## Gates

pytest **3210 passed on SQLite** and **3210 on PostgreSQL** · black, ruff clean.

## Honest notes

- Six agents built parts of this in parallel and I pointed all of them at one PostgreSQL database. Their concurrent `create_all` and truncation is how the race above was found — but it was my orchestration error, and three agents hit session limits partway. Their partial work was reviewed, completed and validated serially before this commit.
- The whole-set API remaining alongside per-row is deliberate: changing storage *and* access pattern together would have made neither reviewable.
- PostgreSQL is validated by the unit suite, not by E2E — the Playwright job still runs against SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV
