### PR TITLE
fix: custom mode had no way in, and refused every v2 recipe

### DIFF
--- a/spark_pulse/routers/custom_files.py
+++ b/spark_pulse/routers/custom_files.py
@@ -8,6 +8,7 @@ live immediately, with no checkout and nothing to sync.
 
 from fastapi import APIRouter, HTTPException, UploadFile, File, Form
 
+from spark_pulse.tools import recipe_schema
 from spark_pulse.tools.custom_files import (
     discover_custom_recipes,
     discover_custom_mods,
@@ -30,35 +31,41 @@ router = APIRouter(prefix="/api/custom-files", tags=["custom-files"])
 def validate_recipe_endpoint(content: dict):
     """Validate a recipe YAML without saving it.
 
-    Content: {"content": "name: ...\\nmodel: ..."}
+    Content: ``{"content": "name: ...\\nmodel: ..."}``
+
+    Answers through :mod:`spark_pulse.tools.recipe_schema`, which is the same
+    parser a deploy uses. It used to check three fields of its own —
+    ``name``, ``model`` and ``container`` — and ``container`` is a *v1* field.
+    A valid v2 recipe names an ``engine`` and has no container, so the editor
+    refused every one of them with "container is required", which is not a
+    thing wrong with the recipe.
+
+    Errors come back per field rather than as one sentence, because the point
+    of validating before saving is to be told *where* to look.
     """
     yaml_content = content.get("content", "")
     if not yaml_content.strip():
         raise HTTPException(status_code=400, detail="YAML content cannot be empty")
-    import yaml
 
     try:
-        data = yaml.safe_load(yaml_content)
-        if not isinstance(data, dict):
-            raise ValueError("YAML must be a mapping")
+        recipe = recipe_schema.parse_recipe(yaml_content)
+    except recipe_schema.RecipeValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": str(exc),
+                "errors": [e.model_dump() for e in exc.errors],
+            },
+        ) from exc
 
-        # Check required fields
-        errors = []
-        if not data.get("name"):
-            errors.append("name is required")
-        if not data.get("model"):
-            errors.append("model is required")
-        if not data.get("container"):
-            errors.append("container is required")
-
-        if errors:
-            raise ValueError("; ".join(errors))
-
-        return {"valid": True, "name": data.get("name", "")}
-    except HTTPException:
-        raise
-    except (yaml.YAMLError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    return {
+        "valid": True,
+        "name": recipe.name,
+        "recipe_version": recipe_schema.detect_version(
+            {"recipe_version": getattr(recipe, "recipe_version", "1")}
+        ),
+        "model": getattr(recipe, "model", "") or "",
+    }
 
 
 # ── Custom Recipes ────────────────────────────────────────────────────────

--- a/tests/test_router_custom_files.py
+++ b/tests/test_router_custom_files.py
@@ -233,3 +233,115 @@ class TestUploadMod:
         assert data["id"] == "custom/stub-mod"
         assert data["name"] == "stub-mod"
         assert data["saved"] is True
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+
+V1_RECIPE = """
+name: A v1 Recipe
+model: org/model-name
+container: vllm-node
+command: vllm serve org/model-name --port {port}
+defaults:
+  port: 8000
+""".strip()
+
+V2_RECIPE = """
+recipe_version: "2"
+name: A v2 Recipe
+model: org/model-name
+engine: vllm
+params:
+  port: 8000
+engines:
+  vllm:
+    args: --enable-prefix-caching
+""".strip()
+
+
+class TestValidateRecipe:
+    """``POST /api/custom-files/recipes/validate``.
+
+    The endpoint used to check three fields of its own — ``name``, ``model``
+    and ``container`` — and ``container`` is a *v1* field. A v2 recipe names an
+    ``engine`` and has no container, so the editor refused every valid one with
+    "container is required", which is not a thing wrong with the recipe. It
+    answers through the same parser a deploy uses now.
+    """
+
+    def test_a_v1_recipe_is_accepted(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": V1_RECIPE}
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "valid": True,
+            "name": "A v1 Recipe",
+            "recipe_version": "1",
+            "model": "org/model-name",
+        }
+
+    def test_a_v2_recipe_is_accepted(self, app_client):
+        """The bug this endpoint had: a valid v2 recipe was refused outright."""
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": V2_RECIPE}
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["valid"] is True
+        assert body["recipe_version"] == "2"
+        assert body["name"] == "A v2 Recipe"
+
+    def test_a_v2_recipe_is_not_asked_for_a_container(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": V2_RECIPE}
+        )
+
+        assert "container" not in response.text
+
+    def test_each_problem_is_reported_against_its_own_field(self, app_client):
+        """One sentence tells you something is wrong; a field tells you where."""
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": "name: Only a name"}
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        paths = {e["path"] for e in detail["errors"]}
+        assert "container" in paths
+        assert "command" in paths
+        assert detail["message"]
+
+    def test_a_version_nothing_implements_is_refused_by_name(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate",
+            json={"content": 'recipe_version: "9"\nname: Future\n'},
+        )
+
+        assert response.status_code == 400
+        assert "recipe_version" in str(response.json()["detail"])
+
+    def test_yaml_that_is_not_a_mapping_is_refused(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": "- just\n- a list\n"}
+        )
+
+        assert response.status_code == 400
+
+    def test_broken_yaml_is_refused_rather_than_raised(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": "name: [unclosed\n"}
+        )
+
+        assert response.status_code == 400
+
+    def test_empty_content_says_so(self, app_client):
+        response = app_client.post(
+            "/api/custom-files/recipes/validate", json={"content": "   "}
+        )
+
+        assert response.status_code == 400
+        assert "empty" in str(response.json()["detail"]).lower()

--- a/web/src/components/NewRecipeModal.tsx
+++ b/web/src/components/NewRecipeModal.tsx
@@ -11,6 +11,69 @@ interface ValidationIssue {
   message: string;
 }
 
+/** The recipe starters, one per format.
+ *
+ * v2 is the default because it is the format the engines are described in —
+ * v1 puts the whole launch into one vLLM-specific command template, and a
+ * recipe written that way can only ever run on vLLM. v1 stays offered because
+ * it stays valid forever and there are plenty of them about.
+ */
+const TEMPLATES: Record<"2" | "1", string> = {
+  "2": `recipe_version: "2"
+
+# What this recipe is called in the list.
+name: My Custom Recipe
+
+# The model to serve. It has to be in the local catalogue, or the deploy will
+# offer to download it.
+model: org/model-name
+
+# Which engine runs it, and the per-engine flags.
+engine: vllm
+params:
+  port: 8000
+  tensor_parallel: 1
+engines:
+  vllm:
+    args: --enable-prefix-caching
+`,
+  "1": `# The original format: one vLLM command template, filled in from defaults.
+name: My Custom Recipe
+model: org/model-name
+container: vllm-node
+command: vllm serve org/model-name --port {port}
+defaults:
+  port: 8000
+`,
+};
+
+/** Unpack whatever the validator said into per-field issues.
+ *
+ * It answers `{message, errors: [{path, message}]}` — the point of validating
+ * before saving is to be told *where* to look, not to be handed one sentence.
+ * A plain-string detail is still handled: not every failure on this path comes
+ * from the schema.
+ */
+function readValidationErrors(payload: unknown): ValidationIssue[] {
+  const detail = (payload as { detail?: unknown })?.detail;
+  if (typeof detail === "string") return [{ field: "yaml", message: detail }];
+  if (detail && typeof detail === "object") {
+    const errors = (detail as { errors?: unknown }).errors;
+    if (Array.isArray(errors) && errors.length) {
+      return errors.map((e) => {
+        const { path, message } = e as { path?: string; message?: string };
+        return {
+          field: path || "yaml",
+          message: path ? `${path}: ${message ?? ""}` : (message ?? "invalid"),
+        };
+      });
+    }
+    const message = (detail as { message?: string }).message;
+    if (message) return [{ field: "yaml", message }];
+  }
+  return [{ field: "yaml", message: "Validation failed" }];
+}
+
 export default function NewRecipeModal({
   open,
   onClose,
@@ -31,6 +94,7 @@ export default function NewRecipeModal({
   const [errorModal, setErrorModal] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [step, setStep] = useState<"upload" | "preview">("upload");
+  const [format, setFormat] = useState<"2" | "1">("2");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const processFile = useCallback(async (file: File) => {
@@ -52,9 +116,7 @@ export default function NewRecipeModal({
       });
 
       if (!validateResp.ok) {
-        const errData = await validateResp.json().catch(() => ({}));
-        const msg = errData.detail || "Invalid YAML";
-        setValidationErrors([{ field: "yaml", message: msg }]);
+        setValidationErrors(readValidationErrors(await validateResp.json().catch(() => ({}))));
         return;
       }
 
@@ -100,8 +162,7 @@ export default function NewRecipeModal({
     setStep("upload");
     setFilename("");
     setValidationErrors([]);
-    // Set a default YAML template
-    setContent("# Name of the recipe\nname: My Custom Recipe\n\n# Model identifier\nmodel: <model-id>\n\n# Container image\ncontainer: vllm-node");
+    setContent(TEMPLATES[format]);
     setRecipeName("My Custom Recipe");
   };
 
@@ -120,13 +181,15 @@ export default function NewRecipeModal({
       });
 
       if (!validateResp.ok) {
-        const errData = await validateResp.json().catch(() => ({}));
-        setValidationErrors([{ field: "yaml", message: errData.detail || "Validation failed" }]);
+        setValidationErrors(readValidationErrors(await validateResp.json().catch(() => ({}))));
         return;
       }
 
-      const nameMatch = content.match(/^name:\s*(.+)$/m);
-      setRecipeName(nameMatch?.[1].trim() || recipeName);
+      // The name comes from the parser rather than from a regex over the
+      // source: quoting, an anchor, a folded scalar — the YAML is already
+      // parsed on the other side, so asking it is both shorter and right.
+      const parsed = await validateResp.json().catch(() => ({}));
+      setRecipeName(String(parsed.name || recipeName));
     } catch (e) {
       setValidationErrors([{ field: "yaml", message: e instanceof Error ? e.message : "Validation failed" }]);
     }
@@ -138,7 +201,10 @@ export default function NewRecipeModal({
       const slug = recipeName.trim().toLowerCase().replace(/\s+/g, "-");
       const recipeId = `custom/${slug}`;
 
-      // Backend validates again on save
+      // The write itself only requires the YAML to parse. That is deliberate
+      // on the backend's side — listing is lenient too, so a half-written
+      // recipe an operator means to come back to still appears — which is why
+      // "Validate recipe" above is the step that actually checks the schema.
       const saveResp = await fetch(`/api/custom-files/recipes/${recipeId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -147,8 +213,8 @@ export default function NewRecipeModal({
       });
 
       if (!saveResp.ok) {
-        const errData = await saveResp.json().catch(() => ({}));
-        setErrorModal(errData.detail || "Failed to save recipe");
+        const issues = readValidationErrors(await saveResp.json().catch(() => ({})));
+        setErrorModal(issues.map((i) => i.message).join("\n"));
         return;
       }
 
@@ -297,30 +363,65 @@ export default function NewRecipeModal({
               )}
               {mode === "manual" && (
                 <>
-                  {/* Manual YAML Editor */}
+                  {/* Manual YAML editor */}
                   <div>
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="text-sm font-medium">YAML Content</label>
-                      <button
-                        onClick={handleSaveManual}
-                        disabled={!content.trim()}
-                        className="px-3 py-1 rounded-lg bg-primary/20 text-primary hover:bg-primary/30 text-sm font-medium transition-colors disabled:opacity-50"
-                      >
-                        Validate & Preview
-                      </button>
+                    <div className="flex items-center justify-between mb-2 gap-3 flex-wrap">
+                      <label className="text-sm font-medium" htmlFor="recipe-yaml">
+                        Recipe YAML
+                      </label>
+                      <div className="flex items-center gap-2">
+                        {/* Both formats validate; v2 is the one the engines
+                            are described in. Switching only replaces an
+                            untouched starter — nobody's edits are thrown away
+                            by a click on a format button. */}
+                        <div className="flex items-center rounded-lg border border-border overflow-hidden text-xs">
+                          {(["2", "1"] as const).map((v) => (
+                            <button
+                              key={v}
+                              type="button"
+                              aria-pressed={format === v}
+                              onClick={() => {
+                                setFormat(v);
+                                const untouched = Object.values(TEMPLATES).includes(content);
+                                if (untouched) setContent(TEMPLATES[v]);
+                              }}
+                              className={`px-2.5 py-1 transition-colors ${
+                                format === v
+                                  ? "bg-primary/15 text-primary font-medium"
+                                  : "text-text-muted hover:text-text"
+                              }`}
+                            >
+                              v{v}
+                            </button>
+                          ))}
+                        </div>
+                        <button
+                          onClick={handleSaveManual}
+                          disabled={!content.trim()}
+                          className="px-3 py-1 rounded-lg bg-primary/20 text-primary hover:bg-primary/30 text-sm font-medium transition-colors disabled:opacity-50"
+                        >
+                          Validate recipe
+                        </button>
+                      </div>
                     </div>
                     <textarea
+                      id="recipe-yaml"
                       value={content}
                       onChange={(e) => {
                         setContent(e.target.value);
-                        // Auto-update name from YAML
+                        // A cheap read for the header while typing; the
+                        // authoritative name comes from the parser on validate.
                         const nameMatch = e.target.value.match(/^name:\s*(.+)$/m);
                         if (nameMatch) setRecipeName(nameMatch[1].trim());
                       }}
                       className="w-full h-[400px] px-4 py-3 rounded-lg bg-bg border border-border focus:border-primary focus:outline-none font-mono text-sm resize-y"
                       spellCheck={false}
-                      placeholder="name: My Recipe&#10;model: <model-id>&#10;container: vllm-node"
+                      placeholder={TEMPLATES["2"]}
                     />
+                    <p className="text-xs text-text-muted mt-1.5">
+                      Both recipe formats are accepted. Validation reports each problem against
+                      the field it belongs to.
+                    </p>
                   </div>
                 </>
               )}

--- a/web/src/pages/RecipesPage.tsx
+++ b/web/src/pages/RecipesPage.tsx
@@ -506,38 +506,44 @@ export default function RecipesPage() {
         <div className="space-y-6">
           {showCustom ? (
             <>
-              {customRecipes.length > 0 && (
-                <>
-                  <div className="flex items-center justify-between">
-                    <p className="text-sm text-text-muted">
-                      {customRecipes.length} custom recipe{customRecipes.length > 1 ? "s" : ""}
-                    </p>
-                    <button
-                      onClick={() => setShowNewRecipe(true)}
-                      className="px-3 py-1.5 rounded-lg bg-primary hover:bg-primary-hover text-white text-sm font-medium flex items-center gap-1.5 transition-colors"
-                    >
-                      <Plus size={14} />
-                      New Recipe
-                    </button>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    {customRecipes.map((r) => (
-                      <BaseCard
-                        key={r.id}
-                        icon={<FileText size={16} className="shrink-0 text-primary" />}
-                        title={r.name}
-                        subtitle={r.filename}
-                        onClick={() => handleOpenCustomRecipe(r)}
-                      />
-                    ))}
-                  </div>
-                </>
-              )}
-              {customRecipes.length === 0 && (
+              {/* The create button sits outside the "we already have some"
+                  branch. It used to be inside it, so the state everybody
+                  starts in — no custom recipes — offered no way to make the
+                  first one: an empty page saying "create a new recipe to get
+                  started" beside no button that would. */}
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-text-muted">
+                  {customRecipes.length === 0
+                    ? "No custom recipes yet"
+                    : `${customRecipes.length} custom recipe${customRecipes.length > 1 ? "s" : ""}`}
+                </p>
+                <button
+                  onClick={() => setShowNewRecipe(true)}
+                  className="px-3 py-1.5 rounded-lg bg-primary hover:bg-primary-hover text-white text-sm font-medium flex items-center gap-1.5 transition-colors"
+                >
+                  <Plus size={14} />
+                  New Recipe
+                </button>
+              </div>
+              {customRecipes.length > 0 ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {customRecipes.map((r) => (
+                    <BaseCard
+                      key={r.id}
+                      icon={<FileText size={16} className="shrink-0 text-primary" />}
+                      title={r.name}
+                      subtitle={r.filename}
+                      onClick={() => handleOpenCustomRecipe(r)}
+                    />
+                  ))}
+                </div>
+              ) : (
                 <div className="text-center py-20 text-text-muted">
                   <FileText size={48} className="mx-auto mb-4 opacity-30" />
                   <p className="text-lg font-medium">No custom recipes</p>
-                  <p className="text-sm mt-1">Upload a YAML file or create a new recipe.</p>
+                  <p className="text-sm mt-1">
+                    Upload a YAML file, or write one here — v1 and v2 recipes are both accepted.
+                  </p>
                 </div>
               )}
             </>
@@ -602,28 +608,35 @@ export default function RecipesPage() {
         <div className="space-y-4">
           {showCustom ? (
             <>
+              {/* Same as the recipes tab: the button that makes the first one
+                  cannot live inside the branch that needs one to exist. */}
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-text-muted">
+                  {customMods.length === 0
+                    ? "No custom mods yet"
+                    : `${customMods.length} custom mod${customMods.length > 1 ? "s" : ""}`}
+                </p>
+                <button
+                  onClick={() => setShowNewMod(true)}
+                  className="px-3 py-1.5 rounded-lg bg-primary hover:bg-primary-hover text-white text-sm font-medium flex items-center gap-1.5 transition-colors"
+                >
+                  <Plus size={14} />
+                  New Mod
+                </button>
+              </div>
               {customMods.length === 0 && (
                 <div className="py-20 text-center text-text-muted">
                   <Wrench size={48} className="mx-auto mb-4 opacity-30" />
                   <p className="text-lg font-medium">No custom mods</p>
-                  <p className="text-sm mt-1 opacity-70">Create a new mod to get started.</p>
+                  <p className="text-sm mt-1 opacity-70">
+                    A mod is a <code className="font-mono">run.sh</code> that runs inside the
+                    container before the engine starts.
+                  </p>
                 </div>
               )}
 
               {customMods.length > 0 && (
                 <>
-                  <div className="flex items-center justify-between">
-                    <p className="text-sm text-text-muted">
-                      {customMods.length} custom mod{customMods.length > 1 ? "s" : ""}
-                    </p>
-                    <button
-                      onClick={() => setShowNewMod(true)}
-                      className="px-3 py-1.5 rounded-lg bg-primary hover:bg-primary-hover text-white text-sm font-medium flex items-center gap-1.5 transition-colors"
-                    >
-                      <Plus size={14} />
-                      New Mod
-                    </button>
-                  </div>
                   <div className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2">
                     {customMods.map((m) => (
                       <BaseCard

--- a/web/src/tests/components/NewRecipeModal.test.tsx
+++ b/web/src/tests/components/NewRecipeModal.test.tsx
@@ -184,7 +184,7 @@ describe("NewRecipeModal", () => {
       const editor = screen.getByRole("textbox");
       await userEvent.clear(editor);
       await userEvent.type(editor, "name: Typed Recipe");
-      await userEvent.click(screen.getByRole("button", { name: "Validate & Preview" }));
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
 
       expect(await screen.findByDisplayValue("Typed Recipe")).toBeInTheDocument();
     });
@@ -194,7 +194,7 @@ describe("NewRecipeModal", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
       fetchMock().mockReturnValue(rejected("model is required"));
-      await userEvent.click(screen.getByRole("button", { name: "Validate & Preview" }));
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
 
       expect(await screen.findByText("model is required")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /Save Recipe/ })).not.toBeInTheDocument();
@@ -205,7 +205,7 @@ describe("NewRecipeModal", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
       fetchMock().mockRejectedValue(new Error("validator offline"));
-      await userEvent.click(screen.getByRole("button", { name: "Validate & Preview" }));
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
 
       expect(await screen.findByText("validator offline")).toBeInTheDocument();
     });
@@ -216,7 +216,7 @@ describe("NewRecipeModal", () => {
       const { onClose } = renderModal();
 
       await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
-      await userEvent.click(screen.getByRole("button", { name: "Validate & Preview" }));
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
       await screen.findByRole("heading", { name: "Preview Recipe" });
 
       await userEvent.click(screen.getByRole("button", { name: "Back" }));
@@ -225,13 +225,92 @@ describe("NewRecipeModal", () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
+    /** v2 is the format the engines are described in; v1 puts the whole
+     *  launch into one vLLM-specific command template, so a recipe written
+     *  that way can only ever run on vLLM. */
+    it("starts from the v2 template", async () => {
+      renderModal();
+
+      await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
+
+      const editor = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(editor.value).toContain('recipe_version: "2"');
+      expect(editor.value).toContain("engine: vllm");
+      expect(screen.getByRole("button", { name: "v2" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("offers v1 for the recipes that are still written that way", async () => {
+      renderModal();
+      await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
+
+      await userEvent.click(screen.getByRole("button", { name: "v1" }));
+
+      const editor = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(editor.value).toContain("container: vllm-node");
+      expect(editor.value).not.toContain('recipe_version: "2"');
+    });
+
+    /** Switching format replaces an untouched starter and nothing else: a
+     *  click on a format button must not throw away what somebody wrote. */
+    it("does not overwrite YAML the operator has edited", async () => {
+      renderModal();
+      await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
+      const editor = screen.getByRole("textbox");
+      await userEvent.clear(editor);
+      await userEvent.type(editor, "name: Mine");
+
+      await userEvent.click(screen.getByRole("button", { name: "v1" }));
+
+      expect((editor as HTMLTextAreaElement).value).toBe("name: Mine");
+    });
+
+    /** One sentence tells you something is wrong; a field tells you where. */
+    it("reports each problem against the field it belongs to", async () => {
+      renderModal();
+      await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
+      fetchMock().mockReturnValue(
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () =>
+            Promise.resolve({
+              detail: {
+                message: "Invalid recipe",
+                errors: [
+                  { path: "model", message: "field required" },
+                  { path: "engines.vllm", message: "unknown engine" },
+                ],
+              },
+            }),
+        } as Response),
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
+
+      expect(await screen.findByText("model: field required")).toBeInTheDocument();
+      expect(screen.getByText("engines.vllm: unknown engine")).toBeInTheDocument();
+    });
+
+    it("still reads a plain-string reason", async () => {
+      renderModal();
+      await userEvent.click(screen.getByRole("button", { name: "Enter YAML manually" }));
+      fetchMock().mockReturnValue(rejected("YAML content cannot be empty"));
+
+      await userEvent.click(screen.getByRole("button", { name: "Validate recipe" }));
+
+      expect(await screen.findByText("YAML content cannot be empty")).toBeInTheDocument();
+    });
+
     it("cannot be previewed while the editor is empty", async () => {
       renderModal();
 
       await userEvent.click(screen.getByRole("button", { name: "Manual" }));
       await userEvent.clear(screen.getByRole("textbox"));
 
-      expect(screen.getByRole("button", { name: "Validate & Preview" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Validate recipe" })).toBeDisabled();
     });
   });
 

--- a/web/src/tests/components/RecipesPage.test.tsx
+++ b/web/src/tests/components/RecipesPage.test.tsx
@@ -753,6 +753,45 @@ describe("RecipesPage", () => {
       expect(screen.getByText("No custom mods")).toBeInTheDocument();
     });
 
+    /** The dead end this fixes: the "New Recipe" button used to be rendered
+     *  inside `{customRecipes.length > 0 && …}`, so the state everybody starts
+     *  in offered no way to create the first one — an empty page saying
+     *  "create a new recipe to get started" beside no button that would. */
+    it("offers to create the first recipe when there are none", async () => {
+      vi.mocked(listCustomRecipes).mockResolvedValue([]);
+      vi.mocked(listCustomMods).mockResolvedValue([]);
+      render(<RecipesPage />);
+      await screen.findByText("Qwen3 8B");
+
+      await enterCustomMode();
+
+      await screen.findByText("No custom recipes");
+      expect(screen.getByRole("button", { name: /New Recipe/ })).toBeInTheDocument();
+    });
+
+    it("offers to create the first mod when there are none", async () => {
+      vi.mocked(listCustomRecipes).mockResolvedValue([]);
+      vi.mocked(listCustomMods).mockResolvedValue([]);
+      render(<RecipesPage />);
+      await screen.findByText("Qwen3 8B");
+      await enterCustomMode();
+
+      await userEvent.click(screen.getByRole("button", { name: /Mods \(0\)/ }));
+
+      expect(screen.getByText("No custom mods")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /New Mod/ })).toBeInTheDocument();
+    });
+
+    it("still offers to create one when some already exist", async () => {
+      render(<RecipesPage />);
+      await screen.findByText("Qwen3 8B");
+
+      await enterCustomMode();
+
+      await screen.findByText("Mine");
+      expect(screen.getByRole("button", { name: /New Recipe/ })).toBeInTheDocument();
+    });
+
     it("surfaces a custom directory it could not read", async () => {
       vi.mocked(listCustomRecipes).mockRejectedValue(new Error("config dir missing"));
       render(<RecipesPage />);


### PR DESCRIPTION
> Stacked on #45 → #44. Merge those first; this diff is against #45.

> "when we turn on custom mode we [have] no buttons to create custom recipe or custom mod … we recipe we had to support fields for v2 and simple yaml editor with 'validate recipe' button"

Two faults behind that, and each is a dead end rather than a rough edge.

## 1. No way to create the first one

The **New Recipe** and **New Mod** buttons were rendered *inside* `{customRecipes.length > 0 && …}` — inside the branch that only runs once one already exists. The state everyone starts in showed an empty page reading "create a new recipe to get started" beside no button that would.

```tsx
{customRecipes.length > 0 && (          // ← the button lived in here
  <>
    <button onClick={() => setShowNewRecipe(true)}>New Recipe</button>
    …cards…
  </>
)}
{customRecipes.length === 0 && <p>No custom recipes</p>}
```

The buttons now sit outside that branch, in both tabs.

## 2. Every valid v2 recipe was refused

`POST /api/custom-files/recipes/validate` checked three fields of its own — `name`, `model` and `container` — and **`container` is a v1 field**. A v2 recipe names an `engine` and has no container, so the editor answered `container is required`, which is not a thing wrong with the recipe. Reproduced before changing anything:

```
v2 -> 400 {'detail': 'container is required'}
v1 -> 200
```

It goes through `recipe_schema.parse_recipe` now — the same parser a deploy uses — so both versions validate and errors come back **per field**:

```json
{"message": "Invalid recipe:\n  - container: field required\n  - command: field required",
 "errors": [{"path": "container", "message": "field required"},
            {"path": "command", "message": "field required"}]}
```

One sentence tells you something is wrong; a field tells you where.

## The editor follows

- Starts from a **v2** template — v1 puts the whole launch into one vLLM-specific command template, so a recipe written that way can only ever run on vLLM.
- Offers **v1** for the recipes still written that way; switching format replaces only an *untouched* starter, so a click never discards what somebody wrote.
- "Validate & Preview" → **"Validate recipe"**, which is what it does.
- The name shown after validating comes from the parser rather than `/^name:\s*(.+)$/m` — quoting, an anchor and a folded scalar all beat that regex, and the YAML is already parsed on the other side.

## What I deliberately did not change

Saving stays permissive: the write only requires the YAML to parse. That is the backend's existing stance — listing is lenient too (`parse_recipe(strict=False)`), so a half-written recipe an operator means to come back to still appears in the UI. The frontend comment claiming "backend validates again on save" was simply wrong, and now says what actually happens.

## Verification

3215 pytest, 1021 vitest, 53 Playwright, coverage above every threshold, black/ruff/eslint clean, `npm run build` green.

The five new backend tests were run against the unfixed validator first — all five fail, including both v2 cases. The full path was then exercised against a live simulation backend: a v2 recipe validates, saves, and appears in `GET /api/recipes`. The empty state and the editor were checked by screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV