### PR TITLE
fix: one lost race says nothing about the next table

### DIFF
--- a/spark_pulse/db.py
+++ b/spark_pulse/db.py
@@ -295,23 +295,38 @@ def _create_schema(engine: Engine) -> None:
     The loser's answer is not to fail. It is to look again: if the table it
     was told it could not create now exists, the schema is what it needed to
     be and somebody else did the work.
+
+    **The retry has to be a loop, not a second attempt.** Losing once says
+    nothing about the next table: ``create_all`` emits one statement per
+    table, so a starter that loses the race on ``blobs`` can re-inspect, still
+    find ``scheduled_deploys`` missing, and lose that one too — to the very
+    instance it was already racing. A single retry made that second loss fatal
+    and it grew likelier with every table added; six starters and nine tables
+    hit it about one run in eight, which is exactly the shape of flake that
+    reads as "CI is unreliable" rather than as a bug.
+
+    The loop ends when nothing is missing — the only condition that means the
+    schema is ready — and the last attempt is deliberately unguarded so a real
+    error (no permission, bad column type) reaches the caller as itself rather
+    than as "gave up after N tries".
     """
     from sqlalchemy import inspect as sa_inspect
     from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
 
-    try:
-        Base.metadata.create_all(engine)
-        return
-    except (IntegrityError, ProgrammingError, DBAPIError):
-        pass
+    #: Enough that a starter losing a race on every table still finishes,
+    #: bounded so a genuine failure cannot spin.
+    attempts = len(Base.metadata.tables) + 1
 
-    existing = set(sa_inspect(engine).get_table_names())
-    missing = [name for name in Base.metadata.tables if name not in existing]
-    if not missing:
-        return  # another instance created them while we were looking
-    # Something other than a race: create_all again so the real error is the
-    # one that reaches the caller, rather than a stale one from the retry.
-    Base.metadata.create_all(engine)
+    for remaining in range(attempts, 0, -1):
+        try:
+            Base.metadata.create_all(engine)
+            return
+        except (IntegrityError, ProgrammingError, DBAPIError):
+            existing = set(sa_inspect(engine).get_table_names())
+            if all(name in existing for name in Base.metadata.tables):
+                return  # another instance created them while we were looking
+            if remaining == 1:
+                raise
 
 
 def _session_factory() -> "sessionmaker[Session]":

--- a/tests/test_db_and_sessions.py
+++ b/tests/test_db_and_sessions.py
@@ -352,30 +352,115 @@ def test_concurrent_schema_creation_does_not_fail(tmp_path):
     immediately while this branch was being written.
 
     The loser's answer is to look again, not to fail.
+
+    **Started on a barrier, and repeated.** Six threads merely *launched*
+    together mostly do not collide — the first one through finishes the whole
+    schema while the rest are still starting, so the race the test is named
+    for never happens. Left that way it caught the original bug about one run
+    in eight, which is not a guard but a coin that lands green often enough to
+    look like a pass. The barrier holds every thread until all six are ready
+    so they enter ``create_all`` at once, and the rounds repeat because even
+    then the interleaving is the operating system's to choose.
+
+    It is still a probability, not a proof — measured at roughly half of runs
+    catching the single-retry bug, against one run in eight without the
+    barrier. :func:`test_the_retry_is_a_loop_not_one_more_attempt` is the
+    deterministic half; this one is the backstop that exercises real threads
+    against a real file.
     """
     import threading
 
     from sqlalchemy import create_engine
 
-    url = f"sqlite:///{tmp_path / 'race.db'}"
     db._load_models()
-    failures = []
+    failures: list[Exception] = []
+    rounds = 8
+    starters = 6
 
-    def build():
+    def build(url: str, gate: threading.Barrier) -> None:
         try:
             engine = create_engine(url)
+            gate.wait()
             db._create_schema(engine)
             engine.dispose()
         except Exception as exc:  # noqa: BLE001 — the point is to catch any
             failures.append(exc)
 
-    threads = [threading.Thread(target=build) for _ in range(6)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
+    for round_number in range(rounds):
+        # A new file each round: the race only exists while tables are
+        # missing, so reusing one database would test an empty no-op after
+        # the first pass.
+        url = f"sqlite:///{tmp_path / f'race-{round_number}.db'}"
+        gate = threading.Barrier(starters)
+        threads = [
+            threading.Thread(target=build, args=(url, gate)) for _ in range(starters)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
 
     assert failures == []
+
+
+def test_the_retry_is_a_loop_not_one_more_attempt(tmp_path, monkeypatch):
+    """Losing one race says nothing about the next table.
+
+    ``create_all`` emits one statement per table, so a starter that loses on
+    ``blobs``, re-inspects, and finds ``scheduled_deploys`` still missing can
+    lose that one too — to the very instance it was already racing. The
+    original code retried exactly once, which made that second loss fatal, and
+    it grew likelier with every table added.
+
+    Driven here rather than raced: ``create_all`` is made to fail twice before
+    succeeding, which is the case a single retry cannot survive and which no
+    amount of thread scheduling makes certain.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.exc import OperationalError
+
+    db._load_models()
+    engine = create_engine(f"sqlite:///{tmp_path / 'retry.db'}")
+    real_create_all = db.Base.metadata.create_all
+    attempts = {"n": 0}
+
+    def flaky(*args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] <= 2:
+            raise OperationalError(
+                "CREATE TABLE scheduled_deploys",
+                {},
+                Exception("table scheduled_deploys already exists"),
+            )
+        return real_create_all(*args, **kwargs)
+
+    monkeypatch.setattr(db.Base.metadata, "create_all", flaky)
+
+    db._create_schema(engine)  # must not raise
+
+    assert attempts["n"] == 3, "gave up before the schema was actually created"
+
+
+def test_a_real_error_still_reaches_the_caller(tmp_path, monkeypatch):
+    """The loop must not turn a genuine failure into a silent give-up.
+
+    No permission, a bad column type: those never resolve however many times
+    they are retried, and the caller has to see the error itself rather than a
+    database that quietly has no tables.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.exc import OperationalError
+
+    db._load_models()
+    engine = create_engine(f"sqlite:///{tmp_path / 'broken.db'}")
+
+    def always_fails(*_args, **_kwargs):
+        raise OperationalError("CREATE TABLE x", {}, Exception("permission denied"))
+
+    monkeypatch.setattr(db.Base.metadata, "create_all", always_fails)
+
+    with pytest.raises(OperationalError, match="permission denied"):
+        db._create_schema(engine)
 
 
 def test_schema_creation_is_idempotent(tmp_path):


### PR DESCRIPTION
> Replaces #43. See the note at the bottom — #43's feature is already on main; this is the only part that is not.

## The bug

CI failed on `test_concurrent_schema_creation_does_not_fail` with `table scheduled_deploys already exists`. It is a real race, not a flaky test.

`_create_schema` already tolerated losing a startup race — two control planes both see a table missing, both create it, the loser re-inspects and carries on. But it retried exactly **once**, and `create_all` emits one statement per table. A starter that loses on `blobs`, looks again, and finds `scheduled_deploys` still missing can lose *that* one too, to the very instance it was already racing. The second loss was fatal.

Every table added widened the window. Nine tables and six starters hit it about **1 run in 8** locally — reproduced before changing anything, **0 in 40** after.

## The fix

A bounded loop instead of one retry. It ends when nothing is missing — the only condition that means the schema is ready — and the final attempt is deliberately unguarded so a real error (no permission, a bad column type) reaches the caller as itself rather than as "gave up after N tries".

The bound is `len(tables) + 1`, and that is provably enough rather than merely generous: each failed attempt still creates every table it *can* before hitting the contested one, so progress is monotonic — after each attempt at least one more table exists, whether we created it or the racer did. Racing alone cannot exhaust N+1 attempts.

## The test was a poor guard, so it changed too

Six threads merely *launched* together mostly do not collide: the first one through finishes the whole schema while the rest are still starting. Left that way the test caught the bug about 1 run in 8 — a coin that lands green often enough to look like a pass.

It now holds every thread on a `threading.Barrier` so they enter `create_all` at once, and repeats over fresh databases. **Measured, not assumed:** that took detection from ~1 in 8 to about half. Still a probability, so I added the deterministic half — two tests that drive the retry directly instead of racing for it:

- `test_the_retry_is_a_loop_not_one_more_attempt` — `create_all` fails twice before succeeding, which is exactly what a single retry cannot survive. Verified red against main's `db.py`.
- `test_a_real_error_still_reaches_the_caller` — a permanent failure must propagate, not become a database that quietly has no tables.

## Why this replaces #43

PR #44's squash contained all of #43's work — 33 files including `tools/scheduled_deploys.py`, `routers/scheduled_deploys.py`, `tools/models.py`, `native_runtime.py` and `sse.py`, byte-identical to #43's branch. The download-and-deploy feature is therefore already on main and already translated by #47 (`recipes.missingModelTitle`, `models.scheduledTo`).

The cause was mine: creating the settings branch with `git checkout -b … origin/main 2>/dev/null || git checkout -b …`. `web/src/lib/types.ts` was committed in #43 and had uncommitted settings edits, so the first form was refused, stderr was discarded, and the fallback branched from HEAD (#43) instead of main. Everything stacked above inherited it.

`feat/deploy-behind-a-download` is now *behind* main — merging it would delete the 404 page and the i18n system and resurrect the removed import panel — so it should be closed rather than resolved. This branch is that commit cherry-picked onto current main; it applied cleanly.

## Verification

3217 pytest on current main, ruff and black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV