### PR TITLE
ci: run the browser suite against PostgreSQL too, and stop lying about which one

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -183,12 +183,51 @@ jobs:
         working-directory: web
         run: npm run test:run
 
+  # The browser suite, once per storage backend.
+  #
+  # The unit suite already runs every router test against a real PostgreSQL,
+  # so what a second browser run adds is not "do the queries work" — it is the
+  # part a TestClient never reaches: the application's *startup* against a
+  # server (lifespan, schema creation, `reconcile_all`, the scheduled-deploy
+  # reconcile) and its behaviour under a real connection pool serving
+  # concurrent requests from a browser. Those are exactly the paths that fail
+  # on the day somebody first sets SPARK_PULSE_DATABASE_URL, and until now
+  # nothing exercised them.
   e2e-tests:
-    name: Run E2E tests
+    name: Run E2E tests (${{ matrix.backend }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    strategy:
+      # Both legs always run: a failure on one backend and not the other is
+      # the single most useful thing this job can tell us, and fail-fast would
+      # throw exactly that away.
+      fail-fast: false
+      matrix:
+        include:
+          - backend: sqlite
+            database_url: ""
+          - backend: postgresql
+            database_url: postgresql+psycopg://pulse:pulse@127.0.0.1:5432/spark_pulse
+    services:
+      # Started for both legs — a service cannot be declared per-matrix-value.
+      # postgres:16-alpine costs a few seconds to pull and the SQLite leg
+      # simply never connects to it, which is cheaper than splitting this into
+      # two near-identical jobs that then drift apart.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pulse
+          POSTGRES_PASSWORD: pulse
+          POSTGRES_DB: spark_pulse
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pulse -d spark_pulse"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -207,7 +246,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,postgres]"
       - name: Install frontend dependencies
         working-directory: web
         run: npm ci
@@ -223,12 +262,35 @@ jobs:
         working-directory: web
         run: npx playwright install --with-deps chromium
       - name: Start mock backend for Playwright
+        env:
+          # Empty on the SQLite leg, which is what `config.database_url`
+          # already treats as "use the default file".
+          SPARK_PULSE_DATABASE_URL: ${{ matrix.database_url }}
         run: |
-          SIMULATION_MODE=1 uvicorn spark_pulse.app:app --host 0.0.0.0 --port 8100 --workers 1 &
-          for i in $(seq 1 30); do curl -sf http://localhost:8100/health && break; sleep 1; done || exit 1
+          SIMULATION_MODE=1 uvicorn spark_pulse.app:app --host 0.0.0.0 --port 8100 --workers 1 \
+            > /tmp/backend.log 2>&1 &
+          for i in $(seq 1 30); do curl -sf http://localhost:8100/health && break; sleep 1; done || {
+            echo "::error::the backend never became healthy on ${{ matrix.backend }}"
+            cat /tmp/backend.log
+            exit 1
+          }
+      - name: Confirm the backend is on the backend this leg is named for
+        run: |
+          # Without this the PostgreSQL leg would pass by silently falling back
+          # to SQLite, which is the failure mode the job exists to rule out.
+          reported=$(curl -sf http://localhost:8100/api/settings \
+            | python -c 'import json,sys; print(json.load(sys.stdin)["environment"]["database_backend"])')
+          echo "backend reports: $reported"
+          case "${{ matrix.backend }}" in
+            sqlite) [ "$reported" = "sqlite" ] ;;
+            postgresql) [ "$reported" = "postgresql+psycopg" ] ;;
+          esac || { echo "::error::expected ${{ matrix.backend }}, got $reported"; exit 1; }
       - name: Run Playwright e2e tests
         working-directory: web
         run: npm run test:e2e
+      - name: Backend log
+        if: failure()
+        run: cat /tmp/backend.log
   rust-agent:
     name: Run node agent tests
     runs-on: ubuntu-latest

--- a/spark_pulse/routers/settings.py
+++ b/spark_pulse/routers/settings.py
@@ -133,16 +133,24 @@ def _docker_block() -> dict:
 
 
 def _environment_block() -> dict:
-    """How this process is configured. Reported, never written from here."""
+    """How this process is configured. Reported, never written from here.
+
+    The database comes from :func:`spark_pulse.db.database_url`, not from
+    ``config.database_url``, because those are two different answers and only
+    one of them is true. ``config`` reads settings.json alone; the *engine*
+    resolves ``SPARK_PULSE_DATABASE_URL`` first, then settings.json, then the
+    default file. Reporting config's view meant a process told to use
+    PostgreSQL by its environment — which is how a systemd unit or a container
+    sets it — displayed "sqlite" on the very page an operator opens to find out
+    which database they are on. Every table was in PostgreSQL while this said
+    otherwise; the e2e job's backend check is what caught it.
+    """
+    from spark_pulse import db
+
+    resolved = db.database_url()
     return {
-        "database_url": _redacted(config.database_url),
-        "database_backend": (
-            (
-                config.database_url.split("://", 1)[0]
-                if config.database_url
-                else "sqlite"
-            )
-        ),
+        "database_url": _redacted(resolved),
+        "database_backend": resolved.split("://", 1)[0] if resolved else "sqlite",
         "external_url": config.external_url,
         "cors_allowed_origins": config.cors_allowed_origins,
         "auth_enabled": config.auth_enabled,

--- a/tests/test_router_settings.py
+++ b/tests/test_router_settings.py
@@ -358,22 +358,46 @@ class TestTheEnvironmentReport:
         assert key in response.json()["detail"]
         assert not private_config_files["settings"].exists()
 
-    def test_a_database_password_is_not_put_on_the_page(self, client):
+    def test_a_database_password_is_not_put_on_the_page(self, client, monkeypatch):
         """The host and database answer "which database am I on". The password
         is a credential, and this page is readable over a shoulder."""
-        config._data["database_url"] = "postgresql+psycopg://pulse:hunter2@db/pulse"
+        monkeypatch.setenv(
+            "SPARK_PULSE_DATABASE_URL", "postgresql+psycopg://pulse:hunter2@db/pulse"
+        )
 
         reported = client.get("/api/settings").json()["environment"]["database_url"]
 
         assert "hunter2" not in reported
         assert "db/pulse" in reported
 
-    def test_a_url_with_no_password_is_left_alone(self, client):
-        config._data["database_url"] = "sqlite:////var/lib/spark-pulse/db.sqlite"
+    def test_a_url_with_no_password_is_left_alone(self, client, monkeypatch):
+        monkeypatch.setenv(
+            "SPARK_PULSE_DATABASE_URL", "sqlite:////var/lib/spark-pulse/db.sqlite"
+        )
 
         reported = client.get("/api/settings").json()["environment"]["database_url"]
 
         assert reported == "sqlite:////var/lib/spark-pulse/db.sqlite"
+
+    def test_the_environment_wins_over_settings_json(self, client, monkeypatch):
+        """The bug the e2e backend check caught.
+
+        ``config.database_url`` reads settings.json alone; the engine resolves
+        ``SPARK_PULSE_DATABASE_URL`` first. Reporting config's view meant a
+        process told to use PostgreSQL by its environment — how a systemd unit
+        or a container sets it — showed "sqlite" on the page an operator opens
+        to find out which database they are on, while every table sat in
+        PostgreSQL.
+        """
+        config._data["database_url"] = "sqlite:////wrong/answer.db"
+        monkeypatch.setenv(
+            "SPARK_PULSE_DATABASE_URL", "postgresql+psycopg://pulse@db/spark_pulse"
+        )
+
+        environment = client.get("/api/settings").json()["environment"]
+
+        assert environment["database_backend"] == "postgresql+psycopg"
+        assert "wrong/answer.db" not in environment["database_url"]
 
     def test_the_image_registry_is_reported(self, client):
         """How a worker node gets an engine image without every node pulling


### PR DESCRIPTION
> "add PostgreSQL e2e in github actions"

## What it adds over the existing PostgreSQL job

The unit suite has run against a real PostgreSQL since #42, so a second browser run is not about "do the queries work". It is the part a `TestClient` never reaches:

- the application's **startup** against a server — lifespan, schema creation, `reconcile_all`, the scheduled-deploy reconcile;
- its behaviour under a **real connection pool** serving concurrent requests from a browser.

Those are the paths that fail on the day somebody first sets `SPARK_PULSE_DATABASE_URL`, and nothing exercised them.

The e2e job is now a matrix over `sqlite` and `postgresql` — one definition rather than two jobs that drift apart — with `fail-fast: false`, because a failure on one backend and not the other is the single most useful thing this job can say. The service container is declared for both legs (a service cannot be declared per-matrix-value); the SQLite leg simply never connects to it.

## The check that makes the leg mean something

A PostgreSQL leg that silently fell back to SQLite would pass while proving nothing — green, and worse than not having the job. So each leg asks `/api/settings` what backend it is on and fails if the answer is not what it was named for.

**That check failed on its first local run, and it was right:**

```
reported: sqlite     ← while all ten tables sat in PostgreSQL
```

## The bug it found

`config.database_url` reads `settings.json` alone. The engine — `db.database_url()` — resolves `SPARK_PULSE_DATABASE_URL` first, then `settings.json`, then the default file. The Environment tab (added in #44) reported config's view.

So a process told to use PostgreSQL **by its environment**, which is exactly how a systemd unit or a container sets it, displayed `sqlite` on the very page an operator opens to find out which database they are on — while every table sat in PostgreSQL. It reports the resolved URL now, still redacted.

`test_the_environment_wins_over_settings_json` pins it; verified red against the old code. The two existing redaction tests moved from poking `config._data` to setting the environment variable, which is the realistic path and the one that was broken.

## Verification

Not just "the YAML parses" — I ran the leg locally against a real `postgres:16-alpine`:

- all ten tables created on the server
- backend check reports `postgresql+psycopg`, password redacted
- **53 Playwright specs pass** against that backend
- 3218 pytest, ruff and black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV