### PR TITLE
feat: run the five single-node engines, not only describe them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ spark_pulse/
 ├── mcp_server.py       # MCP stdio transport for AI assistants
 ├── mcp_http.py         # Shared MCP RPC handler (tool definitions + dispatch)
 ├── sse.py              # SSE event broadcasting for log streaming
-├── engines/            # Engine plugins (vllm, sglang) and the engine registry
+├── engines/            # Engine plugins (vllm, sglang, five single-node ones) and the registry
 ├── routers/            # FastAPI route modules (cache, config, custom_files, custom_recipes, deployments, engines, images, memory, models, mods, nodes, preflight, recipes, settings)
 ├── tools/              # Shared business logic (cache, custom_files, deployment_records, deploy_dispatch, images, models, mods, native_runtime, recipes, system, ...)
 ├── mock/               # Mock providers for simulation/testing; one per switched module in tools/

--- a/docs/engine-metrics.md
+++ b/docs/engine-metrics.md
@@ -21,14 +21,22 @@ per deployment, tens of kilobytes.
 Each reading carries only what the engine published directly, plus rates
 differenced from its counters:
 
-| Reading field | vLLM | SGLang |
-|---|---|---|
-| `running` | `vllm:num_requests_running` | `sglang:num_running_reqs` |
-| `waiting` | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` |
-| `kv_fraction` (0–1) | `vllm:kv_cache_usage_perc` (`gpu_cache_usage_perc` before v0.12.0) | `sglang:token_usage` |
-| `prompt_tokens_total` | `vllm:prompt_tokens_total` | `sglang:prompt_tokens_total` |
-| `generation_tokens_total` | `vllm:generation_tokens_total` | `sglang:generation_tokens_total` |
-| `preemptions_total` | `vllm:num_preemptions_total` | `sglang:num_retracted_reqs` |
+| Reading field | vLLM | SGLang | llama.cpp |
+|---|---|---|---|
+| `running` | `vllm:num_requests_running` | `sglang:num_running_reqs` | `llamacpp:requests_processing` |
+| `waiting` | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` | `llamacpp:requests_deferred` |
+| `kv_fraction` (0–1) | `vllm:kv_cache_usage_perc` (`gpu_cache_usage_perc` before v0.12.0) | `sglang:token_usage` | — |
+| `prompt_tokens_total` | `vllm:prompt_tokens_total` | `sglang:prompt_tokens_total` | `llamacpp:prompt_tokens_total` |
+| `generation_tokens_total` | `vllm:generation_tokens_total` | `sglang:generation_tokens_total` | `llamacpp:tokens_predicted_total` |
+| `preemptions_total` | `vllm:num_preemptions_total` | `sglang:num_retracted_reqs` | — |
+
+llama-server publishes no KV-usage gauge and does not preempt, so two of the
+six have no name to map. They stay `None` rather than being read off a metric
+that means something else, and the panel shows a gap. The other engines added
+alongside it publish either nothing (TensorRT-LLM's `/metrics` is JSON
+iteration stats, not Prometheus text) or names nobody here has read off a
+running instance, so they have no map: an unknown engine is tried against
+every map in turn, and a body in one of these dialects still charts.
 
 `GET /api/deployments/{id}/metrics` returns the window. The Inference page
 shows the newest reading as a row of gauges and the window behind them as

--- a/spark_pulse/config.yaml
+++ b/spark_pulse/config.yaml
@@ -93,3 +93,17 @@ engines:
     enabled: true
   sglang:
     enabled: true
+  # Single-node engines. Listed rather than left to the "unknown engines are
+  # enabled" default so the settings page has a row for each and an operator
+  # can see what exists before deciding. An engine whose image has not been
+  # published is still not offered: `available` is a separate gate.
+  llama-cpp:
+    enabled: true
+  trtllm:
+    enabled: true
+  modular-max:
+    enabled: true
+  atlas:
+    enabled: true
+  tokenary:
+    enabled: true

--- a/spark_pulse/engines/__init__.py
+++ b/spark_pulse/engines/__init__.py
@@ -28,11 +28,20 @@ from spark_pulse.engines.registry import (
     reset_registry,
 )
 from spark_pulse.engines.sglang import SglangEngine
+from spark_pulse.engines.solo import (
+    AtlasEngine,
+    LlamaCppEngine,
+    ModularMaxEngine,
+    SoloEngine,
+    TokenaryEngine,
+    TrtllmEngine,
+)
 from spark_pulse.engines.vllm import VllmEngine
 
 __all__ = [
     "ENGINE_CLASSES",
     "MAX_CLUSTER_NODES",
+    "AtlasEngine",
     "Engine",
     "EngineCapabilities",
     "EngineContainer",
@@ -45,9 +54,14 @@ __all__ = [
     "EngineSpec",
     "EngineVerification",
     "LaunchScript",
+    "LlamaCppEngine",
+    "ModularMaxEngine",
     "NodeInfo",
     "SglangEngine",
+    "SoloEngine",
+    "TokenaryEngine",
     "Topology",
+    "TrtllmEngine",
     "VllmEngine",
     "get_registry",
     "reset_registry",

--- a/spark_pulse/engines/defaults/atlas.yaml
+++ b/spark_pulse/engines/defaults/atlas.yaml
@@ -1,0 +1,60 @@
+schema_version: "1"
+engine: atlas
+variant: default
+description: Atlas, a pure-Rust inference server, from the image its own quick-start publishes for GB10.
+# Built by the Atlas project, not here: `build.external` below. The image is
+# pinned by digest under `sources`, and the index re-resolves `latest` to a
+# digest every time it is published, because `latest` is the only tag Atlas
+# publishes and a moving tag is not a pin.
+image: docker.io/azeezish/atlas-gb10
+tag: latest
+version: 0.1.0
+arch: [linux/arm64]
+gpu_arch: ["12.1a"]
+build: {external: true}
+
+sources:
+  atlas:
+    image: docker.io/azeezish/atlas-gb10@sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6
+
+runtime:
+  workdir: /workspace
+  # The image's own ENTRYPOINT is the `spark` binary and its quick-start passes
+  # `serve <model> …` as the command. Spark Pulse clears the entrypoint of
+  # every engine image, so the binary has to be named here.
+  serve: spark serve
+  model_arg: positional
+  readiness: /health
+  models_endpoint: /v1/models
+  # Atlas gates /metrics behind a build feature, so an image may serve nothing
+  # there. Declared anyway: the metrics sampler reports "the engine publishes
+  # nothing" with a reason, which is more use than never looking.
+  metrics: /metrics
+  ports: {api: 8888}
+  cache_mounts: [~/.cache/huggingface]
+  env:
+    HF_HOME: /root/.cache/huggingface
+  container:
+    privileged: false
+    ipc_host: true
+    network_host: true
+    keepalive: sleep infinity
+  # Atlas bootstraps multi-rank deployments itself over NCCL, with
+  # --rank/--world-size/--master-addr/--master-port. That is a fourth
+  # rendezvous dialect and nothing in Spark Pulse renders it yet, so this
+  # engine is declared single-node rather than claimed and then refused.
+  multi_node:
+    style: none
+  param_flags:
+    port: --port
+    host: --host
+    tensor_parallel: --tp-size
+    gpu_memory_utilization: --gpu-memory-utilization
+    max_model_len: --max-seq-len
+    max_num_seqs: --max-num-seqs
+    max_num_batched_tokens: --max-prefill-tokens
+
+capabilities: {mods: false, pr_mods: false, solo: true, cluster: false, mesh: false}
+# Nothing here has been run on hardware by this project. The Atlas quick-start
+# reports its own numbers on a GB10; that is their evidence, not ours.
+verified: []

--- a/spark_pulse/engines/defaults/llama-cpp.yaml
+++ b/spark_pulse/engines/defaults/llama-cpp.yaml
@@ -5,12 +5,6 @@ description: llama.cpp's llama-server, built from source with CUDA 13 kernels fo
 image: ghcr.io/kharkevich-engineering-lab/spark-pulse-engine/llama-cpp
 version: 0.1.0
 legacy_tags: []
-# Not built yet: the image is defined in spark-pulse-engine and CI has not
-# published it. `available: false` is what keeps it out of the deploy options
-# until it has, because pulling an unpublished reference answers 403 rather
-# than an image. The engine index carries the same answer, resolved from the
-# registry rather than written by hand.
-available: false
 arch: [linux/arm64]
 gpu_arch: ["12.1a"]
 

--- a/spark_pulse/engines/defaults/llama-cpp.yaml
+++ b/spark_pulse/engines/defaults/llama-cpp.yaml
@@ -1,0 +1,73 @@
+schema_version: "1"
+engine: llama-cpp
+variant: default
+description: llama.cpp's llama-server, built from source with CUDA 13 kernels for sm_121 only.
+image: ghcr.io/kharkevich-engineering-lab/spark-pulse-engine/llama-cpp
+version: 0.1.0
+legacy_tags: []
+# Not built yet: the image is defined in spark-pulse-engine and CI has not
+# published it. `available: false` is what keeps it out of the deploy options
+# until it has, because pulling an unpublished reference answers 403 rather
+# than an image. The engine index carries the same answer, resolved from the
+# registry rather than written by hand.
+available: false
+arch: [linux/arm64]
+gpu_arch: ["12.1a"]
+
+sources:
+  base: {image: nvidia/cuda:13.0.2-devel-ubuntu24.04}
+  runtime: {image: nvidia/cuda:13.0.2-runtime-ubuntu24.04}
+  # Tag b10840. llama.cpp tags every build, and those names ("b10840") are not
+  # versions, so the pin is the commit and the tag lives in this comment.
+  llama_cpp:
+    repo: https://github.com/ggml-org/llama.cpp.git
+    ref: 73ab7599b553c03f6f5d2db24a18ad76f2eb36a3
+
+build_args:
+  CUDA_DOCKER_ARCH: 121
+  GCC_VERSION: 14
+
+runtime:
+  workdir: /workspace
+  # `--metrics` is what makes llama-server serve /metrics at all. It is part of
+  # the launch rather than something a recipe has to remember, because a
+  # metrics path declared below and not served is a panel that says "the engine
+  # publishes nothing" forever.
+  serve: llama-server --metrics
+  # llama.cpp reads GGUF, and `-hf` resolves a GGUF from a HuggingFace repo.
+  # So the model this engine is given must be a GGUF repository (…-GGUF), not
+  # the safetensors repository the other engines take.
+  model_arg: -hf
+  readiness: /health
+  models_endpoint: /v1/models
+  metrics: /metrics
+  ports: {api: 8080}
+  # llama-server downloads what `-hf` resolves into LLAMA_CACHE, not into the
+  # HuggingFace cache, so both are mounted.
+  cache_mounts: [~/.cache/huggingface, ~/.cache/llama.cpp]
+  env:
+    LLAMA_ARG_HOST: 0.0.0.0
+    LLAMA_CACHE: /root/.cache/llama.cpp
+    HF_HOME: /root/.cache/huggingface
+  container:
+    privileged: false
+    ipc_host: true
+    network_host: true
+    keepalive: sleep infinity
+  # llama.cpp can spread across machines with its RPC backend, which upstream
+  # still calls experimental and which is neither of the rendezvous styles
+  # here. One node.
+  multi_node:
+    style: none
+  # llama.cpp has no tensor or pipeline parallelism to map, and nothing that
+  # means gpu_memory_utilization: it allocates what the layers and the context
+  # need. Mapping a parameter onto a flag that means something else would be
+  # worse than leaving it unmapped, where it is simply dropped.
+  param_flags:
+    port: --port
+    host: --host
+    max_model_len: --ctx-size
+    max_num_seqs: --parallel
+
+capabilities: {mods: false, pr_mods: false, solo: true, cluster: false, mesh: false}
+verified: []

--- a/spark_pulse/engines/defaults/modular-max.yaml
+++ b/spark_pulse/engines/defaults/modular-max.yaml
@@ -1,0 +1,46 @@
+schema_version: "1"
+engine: modular-max
+variant: default
+description: Modular MAX, the OpenAI-compatible `max serve`, from Modular's own multi-arch image.
+# Modular builds it; `build.external` below.
+image: docker.io/modular/max-nvidia-full
+tag: 26.5.0
+version: 0.1.0
+arch: [linux/arm64]
+gpu_arch: ["12.1a"]
+build: {external: true}
+
+sources:
+  max:
+    image: docker.io/modular/max-nvidia-full@sha256:58d6d31d7e43516d4503959cf2d1e3b77f84d657789056204276d141307d52e7
+
+runtime:
+  workdir: /workspace
+  serve: max serve
+  model_arg: --model
+  # MAX answers readiness under /v1, not at the root.
+  readiness: /v1/health
+  models_endpoint: /v1/models
+  metrics: /metrics
+  ports: {api: 8000}
+  cache_mounts: [~/.cache/huggingface]
+  env:
+    HF_HOME: /root/.cache/huggingface
+  container:
+    privileged: false
+    ipc_host: true
+    network_host: true
+    keepalive: sleep infinity
+  # MAX has no distributed tensor parallelism at all: it is one process on one
+  # host, and spreads across *local* GPUs with --devices. On a Spark, which has
+  # one, that means one.
+  multi_node:
+    style: none
+  param_flags:
+    port: --port
+    host: --host
+    max_model_len: --max-length
+    max_num_seqs: --max-batch-size
+
+capabilities: {mods: false, pr_mods: false, solo: true, cluster: false, mesh: false}
+verified: []

--- a/spark_pulse/engines/defaults/tokenary.yaml
+++ b/spark_pulse/engines/defaults/tokenary.yaml
@@ -1,0 +1,70 @@
+schema_version: "1"
+engine: tokenary
+variant: default
+description: tokenary, an experimental Rust engine with its own NCCL multi-node bootstrap. No public image yet.
+# There is no image anyone outside can pull. `scitrera/tokenary` is the
+# reference sparkrun's runtime plugin carries, and Docker Hub answers "object
+# not found" for it; there is no public source repository either. So this file
+# is the contract and nothing else: `resolve_digests.py` will find no digest,
+# and the published index will carry the engine as unavailable, which is the
+# honest state and the one that stops Spark Pulse offering it. When an image
+# does appear, this becomes a digest and a date.
+image: docker.io/scitrera/tokenary
+tag: latest
+version: 0.1.0
+# There is no published image anywhere: `scitrera/tokenary` is the reference
+# tokenary's own tooling carries, and no registry serves it. This spec records
+# the contract so the day one appears is a one-line change; until then
+# `available: false` keeps it out of the deploy options.
+available: false
+arch: [linux/arm64]
+gpu_arch: ["12.1a"]
+build: {external: true}
+
+sources:
+  # Deliberately not digest-pinned: there is nothing published to take a digest
+  # from. `validate.py --strict` warns about exactly this, and the warning is
+  # the truth about the engine rather than a defect in the file.
+  tokenary:
+    image: docker.io/scitrera/tokenary:latest
+
+runtime:
+  workdir: /workspace
+  # `--server` is what makes rank 0 bind HTTP at all; without it the process
+  # joins the NCCL world and serves nothing. It belongs in every launch, so it
+  # is part of the serve command rather than a flag a recipe has to remember.
+  serve: tokenary --server
+  model_arg: --model
+  # Unverified: tokenary is OpenAI-compatible, so /v1/models is the endpoint we
+  # know it must answer. Nothing here has probed a running instance.
+  readiness: /v1/models
+  models_endpoint: /v1/models
+  metrics: null
+  ports: {api: 8000, rendezvous: 27101}
+  cache_mounts: [~/.cache/huggingface]
+  env:
+    HF_HOME: /root/.cache/huggingface
+    # tokenary reads NCCL tuning straight from the environment.
+    NCCL_CUMEM_ENABLE: "0"
+  container:
+    privileged: false
+    ipc_host: true
+    network_host: true
+    devices: [/dev/infiniband]
+    ulimits: {memlock: "-1", stack: "67108864"}
+    keepalive: sleep infinity
+  # Native NCCL bootstrap over --rank/--world-size/--master-addr/--master-port,
+  # like Atlas and unlike either style Spark Pulse renders. Single-node until
+  # something here speaks that dialect.
+  multi_node:
+    style: none
+  param_flags:
+    port: --port
+    host: --host
+    tensor_parallel: --tp-size
+    gpu_memory_utilization: --gpu-memory-utilization
+    max_model_len: --max-model-len
+    max_num_seqs: --max-num-seqs
+
+capabilities: {mods: false, pr_mods: false, solo: true, cluster: false, mesh: false}
+verified: []

--- a/spark_pulse/engines/defaults/trtllm.yaml
+++ b/spark_pulse/engines/defaults/trtllm.yaml
@@ -1,0 +1,55 @@
+schema_version: "1"
+engine: trtllm
+variant: default
+description: TensorRT-LLM from NVIDIA's own DGX Spark release image, single GPU.
+# NVIDIA builds this one; `build.external` below. It is also 21 GB compressed
+# across 95 layers, which is not something a hosted 4-core arm64 runner should
+# be asked to pull, wrap and push for the sake of adding a label to it.
+image: nvcr.io/nvidia/tensorrt-llm/release
+# The tag is NVIDIA's, and it is not semver: `version` is this definition's.
+tag: spark-single-gpu-dev
+version: 0.1.0
+arch: [linux/arm64]
+gpu_arch: ["12.1a"]
+build: {external: true}
+
+sources:
+  tensorrt_llm:
+    image: nvcr.io/nvidia/tensorrt-llm/release@sha256:4342a40dd7bdb4be9eeadd541aa3e739cd6d72c5441f36844c5345d07ec629da
+
+runtime:
+  workdir: /workspace
+  serve: trtllm-serve
+  model_arg: positional
+  readiness: /health
+  models_endpoint: /v1/models
+  # TensorRT-LLM does serve /metrics, but it answers with JSON iteration stats
+  # rather than Prometheus text. Declaring it would buy a permanent "the body
+  # was not recognised" in the metrics panel, so it is declared absent instead.
+  metrics: null
+  ports: {api: 8000}
+  cache_mounts: [~/.cache/huggingface]
+  env:
+    HF_HOME: /root/.cache/huggingface
+  container:
+    privileged: false
+    ipc_host: true
+    network_host: true
+    ulimits: {memlock: "-1", stack: "67108864"}
+    keepalive: sleep infinity
+  # Multi-node TensorRT-LLM is an MPI job: mpirun across the ranks, with an rsh
+  # agent that hops host SSH into each container. Neither of the rendezvous
+  # styles here is that, and this image says single-gpu in its own tag.
+  multi_node:
+    style: none
+  param_flags:
+    port: --port
+    host: --host
+    tensor_parallel: --tp_size
+    pipeline_parallel: --pp_size
+    max_model_len: --max_seq_len
+    max_num_seqs: --max_batch_size
+    max_num_batched_tokens: --max_num_tokens
+
+capabilities: {mods: false, pr_mods: false, solo: true, cluster: false, mesh: false}
+verified: []

--- a/spark_pulse/engines/registry.py
+++ b/spark_pulse/engines/registry.py
@@ -43,6 +43,13 @@ from pydantic import ValidationError
 from spark_pulse.config import config
 from spark_pulse.engines.base import Engine, EngineError, EngineSpec
 from spark_pulse.engines.sglang import SglangEngine
+from spark_pulse.engines.solo import (
+    AtlasEngine,
+    LlamaCppEngine,
+    ModularMaxEngine,
+    TokenaryEngine,
+    TrtllmEngine,
+)
 from spark_pulse.engines.vllm import VllmEngine
 
 logger = logging.getLogger(__name__)
@@ -53,6 +60,13 @@ CACHE_DIR = Path.home() / ".cache" / "spark-pulse" / "engines"
 ENGINE_CLASSES: dict[str, type[Engine]] = {
     "vllm": VllmEngine,
     "sglang": SglangEngine,
+    # Single-node engines, all rendered by the same class: see
+    # ``spark_pulse.engines.solo`` for why one is enough for the five.
+    "llama-cpp": LlamaCppEngine,
+    "trtllm": TrtllmEngine,
+    "modular-max": ModularMaxEngine,
+    "atlas": AtlasEngine,
+    "tokenary": TokenaryEngine,
 }
 
 INDEX_API_VERSION = "spark-pulse.io/v1"

--- a/spark_pulse/engines/solo.py
+++ b/spark_pulse/engines/solo.py
@@ -1,0 +1,179 @@
+"""Engines that are one process on one machine.
+
+vLLM and SGLang each need a class of their own because each has its own
+rendezvous dialect: ``--nnodes/--node-rank/--master-addr/--master-port`` for
+one, ``--dist-init-addr`` for the other, rendered at every size so there is no
+solo special case left to get wrong.
+
+These five have no rendezvous at all, and that is what makes one class enough
+for all of them:
+
+* **llama.cpp** can spread over its RPC backend, which upstream still calls
+  experimental;
+* **TensorRT-LLM** goes multi-node as an MPI job, and NVIDIA's image for this
+  hardware says ``single-gpu`` in its own tag;
+* **Modular MAX** has no distributed tensor parallelism whatsoever — it takes
+  more *local* GPUs with ``--devices``, and a Spark has one;
+* **Atlas** and **tokenary** bootstrap their own NCCL world with
+  ``--rank/--world-size/--master-addr/--master-port``, which is a third and
+  fourth dialect that nothing here renders yet.
+
+So the launch is the serve command, the model, and the engine-neutral params
+mapped through ``param_flags`` — all of it read from the engine spec, none of
+it written here. A class per engine exists only to carry the name the registry
+looks up and, where the engine wants one, a default a recipe did not give.
+
+The single-node claim is not this module's opinion: every one of these specs
+declares ``cluster: false``, so :meth:`Engine.supports_size` refuses a larger
+topology long before rendering. :meth:`SoloEngine.render` refuses one too,
+because a renderer that quietly produced a one-node command for a two-node
+deployment would be the worse failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from spark_pulse.engines.base import (
+    Engine,
+    EngineError,
+    LaunchScript,
+    Topology,
+)
+
+#: Order the mapped flags appear in. Readability only — a serve command means
+#: the same thing in any order — but a launch command an operator has to read
+#: in a log is worth keeping in a familiar shape.
+_PARAM_ORDER = (
+    "host",
+    "port",
+    "tensor_parallel",
+    "pipeline_parallel",
+    "gpu_memory_utilization",
+    "max_model_len",
+    "max_num_batched_tokens",
+    "max_num_seqs",
+)
+
+
+class SoloEngine(Engine):
+    """One process, one machine, rendered from the spec alone."""
+
+    #: Params a recipe need not carry. ``port`` is not here: it comes from the
+    #: spec's own API port, which differs per engine.
+    defaults: dict[str, Any] = {"host": "0.0.0.0"}
+
+    def render(
+        self,
+        recipe: dict[str, Any],
+        model: str | None = None,
+        params: dict[str, Any] | None = None,
+        extra_args: list[str] | None = None,
+        topology: Topology | None = None,
+        node_rank: int = 0,
+    ) -> LaunchScript:
+        ok, reason = self.supports(recipe)
+        if not ok:
+            raise EngineError(reason)
+
+        topology = topology or Topology.solo()
+        if topology.size > 1:
+            raise EngineError(
+                f"engine '{self.spec.key}' runs on one node: it has no "
+                f"rendezvous to render for {topology.size}. Deploy it solo, "
+                "or pick an engine that declares cluster support"
+            )
+        if node_rank != 0:
+            raise EngineError(
+                f"node_rank {node_rank} is out of range for a single-node engine"
+            )
+
+        overrides = {k: v for k, v in (params or {}).items() if v is not None}
+        resolved = self._resolved_params(recipe, overrides)
+        for key, value in self.defaults.items():
+            resolved.setdefault(key, value)
+        resolved.setdefault("port", self.api_port())
+
+        resolved_model = self._resolved_model(recipe, model)
+        serve = self.spec.runtime.serve
+        if not serve:
+            raise EngineError(
+                f"engine '{self.spec.key}' declares no serve command, so there "
+                "is nothing to launch"
+            )
+        model_arg = self.spec.runtime.model_arg or "positional"
+
+        parts = [serve]
+        if model_arg == "positional":
+            parts.append(resolved_model)
+        else:
+            parts.extend([model_arg, resolved_model])
+        parts.extend(self._flag_args(resolved, order=_PARAM_ORDER))
+
+        args = " ".join(self._block_args(recipe).split())
+        if args:
+            parts.append(args)
+
+        tail = self._quote_extra(extra_args)
+        if tail:
+            parts.append(tail)
+
+        command = " ".join(p for p in parts if p).strip()
+
+        node = topology.nodes[0]
+        env = self.base_env(
+            node_ip=node.ip,
+            eth_if=node.eth_if,
+            ib_if=node.ib_if,
+            node_count=topology.size,
+            mesh=node.mesh,
+        )
+        env.update(self._block_env(recipe))
+
+        return LaunchScript(
+            node_rank=0,
+            host=node.host,
+            command=command,
+            env=env,
+            script=self._script(env, command),
+        )
+
+
+class LlamaCppEngine(SoloEngine):
+    """llama.cpp's ``llama-server``.
+
+    The one engine here that does not read the model the others read:
+    llama.cpp loads GGUF, so the model must be a GGUF repository and ``-hf``
+    is what resolves it.
+    """
+
+    name = "llama-cpp"
+
+
+class TrtllmEngine(SoloEngine):
+    """TensorRT-LLM's ``trtllm-serve``."""
+
+    name = "trtllm"
+
+
+class ModularMaxEngine(SoloEngine):
+    """Modular MAX's ``max serve``."""
+
+    name = "modular-max"
+
+
+class AtlasEngine(SoloEngine):
+    """Atlas's ``spark serve``."""
+
+    name = "atlas"
+
+
+class TokenaryEngine(SoloEngine):
+    """tokenary.
+
+    ``--server`` is part of the spec's serve command rather than a flag here:
+    without it rank 0 joins the NCCL world and binds no HTTP at all, so it
+    belongs in every launch and not in a recipe's memory.
+    """
+
+    name = "tokenary"

--- a/spark_pulse/mcp_http.py
+++ b/spark_pulse/mcp_http.py
@@ -212,7 +212,10 @@ TOOLS = [
                 "recipe_id": {"type": "string", "description": "Recipe id or name"},
                 "engine": {
                     "type": "string",
-                    "description": "Engine override (vllm, sglang)",
+                    "description": (
+                        "Engine override by name; list_engines says which "
+                        "this control plane has"
+                    ),
                 },
                 "variant": {"type": "string", "description": "Engine variant"},
                 "model": {"type": "string", "description": "Model override"},
@@ -247,7 +250,10 @@ TOOLS = [
                 "recipe_id": {"type": "string", "description": "Recipe id or name"},
                 "engine": {
                     "type": "string",
-                    "description": "Engine override (vllm, sglang)",
+                    "description": (
+                        "Engine override by name; list_engines says which "
+                        "this control plane has"
+                    ),
                 },
                 "variant": {"type": "string", "description": "Engine variant"},
                 "model": {"type": "string", "description": "Model override"},

--- a/spark_pulse/mock/engine_metrics.py
+++ b/spark_pulse/mock/engine_metrics.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any
 
 from spark_pulse.tools.engine_metrics import (
+    ALL_METRICS as ALL_METRICS,
     AVAILABLE as AVAILABLE,
     REASON_DETAIL as REASON_DETAIL,
     REASON_NOT_ENABLED as REASON_NOT_ENABLED,
@@ -29,6 +30,7 @@ from spark_pulse.tools.engine_metrics import (
     RING_SIZE as RING_SIZE,
     SAMPLE_INTERVAL_SECONDS as SAMPLE_INTERVAL_SECONDS,
     SCRAPE_TIMEOUT_SECONDS as SCRAPE_TIMEOUT_SECONDS,
+    LLAMA_CPP_METRICS as LLAMA_CPP_METRICS,
     SGLANG_METRICS as SGLANG_METRICS,
     VLLM_METRICS as VLLM_METRICS,
     Availability as Availability,

--- a/spark_pulse/tools/engine_metrics.py
+++ b/spark_pulse/tools/engine_metrics.py
@@ -294,21 +294,44 @@ SGLANG_METRICS = MetricNames(
     preemptions=("sglang:num_retracted_reqs",),
 )
 
+#: llama.cpp, which publishes under ``llamacpp:`` and counts different things.
+#: Two of the six have no equivalent at all: llama-server exposes no KV-usage
+#: gauge, and it does not preempt — a request either has a slot or is deferred,
+#: which is what ``requests_deferred`` counts and is already the waiting queue.
+#: Empty tuples rather than a wrong name: a metric mapped onto something that
+#: means something else is worse than a gap the panel can show as a gap.
+LLAMA_CPP_METRICS = MetricNames(
+    running=("llamacpp:requests_processing",),
+    waiting=("llamacpp:requests_deferred",),
+    kv_fraction=(),
+    prompt_tokens=("llamacpp:prompt_tokens_total",),
+    generation_tokens=("llamacpp:tokens_predicted_total",),
+    preemptions=(),
+)
+
 METRIC_NAMES: dict[str, MetricNames] = {
     "vllm": VLLM_METRICS,
     "sglang": SGLANG_METRICS,
+    "llama-cpp": LLAMA_CPP_METRICS,
 }
+
+#: Every map, in the order an unknown engine is tried against them.
+ALL_METRICS: tuple[MetricNames, ...] = (
+    VLLM_METRICS,
+    SGLANG_METRICS,
+    LLAMA_CPP_METRICS,
+)
 
 
 def names_for(engine: str | None) -> tuple[MetricNames, ...]:
     """The name maps to try, most likely first.
 
-    An engine we have a map for is tried first and the other is still tried
+    An engine we have a map for is tried first and the others are still tried
     after it, because an engine name is what the recipe called the image, not
     proof of what the image serves.
     """
     known = METRIC_NAMES.get((engine or "").lower())
-    rest = tuple(m for m in (VLLM_METRICS, SGLANG_METRICS) if m is not known)
+    rest = tuple(m for m in ALL_METRICS if m is not known)
     return ((known,) + rest) if known is not None else rest
 
 

--- a/tests/test_bundled_recipes.py
+++ b/tests/test_bundled_recipes.py
@@ -12,11 +12,16 @@ import pytest
 import yaml
 
 from spark_pulse.engines import EngineRegistry, Topology
+from spark_pulse.engines.registry import load_bundled_specs
 from spark_pulse.tools import recipe_schema, recipe_sources
 
 # `recipes` is the mock under SIMULATION_MODE=1, which is what the API serves
 # in simulation; discovery is shared with the real tools via recipe_sources.
 from spark_pulse.tools import recipes
+
+#: Every engine the bundled registry carries, by name. Not a list repeated
+#: here: which engines are bundled is that directory's business.
+REGISTERED_ENGINES = {spec.engine for spec in load_bundled_specs()}
 
 BUNDLED_IDS = [
     "bundled/qwen2.5-0.5b-instruct",
@@ -154,12 +159,25 @@ def test_every_bundled_recipe_renders_on_both_engines(registry, recipe_id, engin
 
 
 @pytest.mark.parametrize("recipe_id", BUNDLED_IDS)
-def test_engine_support_reports_both_engines_usable(recipe_id):
+def test_engine_support_answers_for_every_engine_the_registry_carries(recipe_id):
+    """A verdict per engine, not per declared engine.
+
+    A bundled recipe declares vLLM and SGLang, and those two run it. The rest
+    are in the table too, each with the reason it is not offered — an engine
+    simply missing from the table reads to the picker as an engine that does
+    not exist, which is a different and more confusing answer than "this
+    recipe was not written for it".
+    """
     payload = recipes.get_recipe(recipe_id, spark_path=NO_CHECKOUT)
     support = {e["engine"]: e for e in payload["engine_support"]}
-    assert set(support) == {"sglang", "vllm"}
-    assert all(e["supported"] for e in support.values())
-    assert all(e["reason"] == "" for e in support.values())
+
+    assert set(support) == REGISTERED_ENGINES
+    for name in ("vllm", "sglang"):
+        assert support[name]["supported"] is True
+        assert support[name]["reason"] == ""
+    for name in REGISTERED_ENGINES - {"vllm", "sglang"}:
+        assert support[name]["supported"] is False
+        assert "only declares engines" in support[name]["reason"]
 
 
 def test_a_v1_recipe_reports_sglang_as_unsupported_with_a_reason(tmp_path):

--- a/tests/test_engines_registry.py
+++ b/tests/test_engines_registry.py
@@ -79,9 +79,20 @@ def registry(tmp_path):
 # ── Bundled defaults ─────────────────────────────────────────────────────────
 
 
+BUNDLED = {
+    "vllm/default",
+    "sglang/default",
+    "llama-cpp/default",
+    "trtllm/default",
+    "modular-max/default",
+    "atlas/default",
+    "tokenary/default",
+}
+
+
 def test_bundled_defaults_are_parsed():
     specs = {s.key: s for s in load_bundled_specs()}
-    assert set(specs) == {"vllm/default", "sglang/default"}
+    assert set(specs) == BUNDLED
     vllm = specs["vllm/default"]
     assert vllm.runtime.serve == "vllm serve"
     assert vllm.runtime.ports.api == 8000
@@ -92,7 +103,8 @@ def test_bundled_defaults_are_parsed():
 
 
 def test_registry_lists_bundled_engines(registry):
-    assert [s.key for s in registry.list()] == ["sglang/default", "vllm/default"]
+    assert set(s.key for s in registry.list()) == BUNDLED
+    assert [s.key for s in registry.list()] == sorted(BUNDLED), "listed in order"
 
 
 def test_get_and_has(registry):

--- a/tests/test_engines_solo.py
+++ b/tests/test_engines_solo.py
@@ -1,0 +1,199 @@
+"""The five single-node engines, rendered from their specs and nothing else.
+
+There is one renderer for all of them (``spark_pulse.engines.solo``), so what
+is worth testing is not five copies of the same string: it is that each spec
+produces the launch its own engine documents, that the shared renderer refuses
+what it cannot render rather than producing something plausible, and that a
+model reaches the command in whichever way that engine takes one.
+"""
+
+import pytest
+
+from spark_pulse.engines import (
+    AtlasEngine,
+    EngineError,
+    LlamaCppEngine,
+    ModularMaxEngine,
+    NodeInfo,
+    SoloEngine,
+    TokenaryEngine,
+    Topology,
+    TrtllmEngine,
+)
+from spark_pulse.engines.registry import ENGINE_CLASSES, load_bundled_specs
+
+MODEL = "unsloth/Qwen3-8B-GGUF"
+RECIPE = {
+    "id": "qwen3-8b",
+    "model": MODEL,
+    "recipe_version": "2",
+    "params": {"max_model_len": 8192, "max_num_seqs": 4},
+}
+
+ONE_NODE = Topology(nodes=[NodeInfo(host="spark-a", ip="10.0.0.1")])
+TWO_NODES = Topology(
+    nodes=[
+        NodeInfo(host="spark-a", ip="10.0.0.1"),
+        NodeInfo(host="spark-b", ip="10.0.0.2"),
+    ]
+)
+
+#: Every engine the solo renderer serves, with the whole command each spec
+#: should produce for :data:`RECIPE` at ``--port 9000``.
+CASES = {
+    "llama-cpp": (
+        LlamaCppEngine,
+        f"llama-server --metrics -hf {MODEL} --host 0.0.0.0 --port 9000 "
+        "--ctx-size 8192 --parallel 4",
+    ),
+    "trtllm": (
+        TrtllmEngine,
+        f"trtllm-serve {MODEL} --host 0.0.0.0 --port 9000 "
+        "--max_seq_len 8192 --max_batch_size 4",
+    ),
+    "modular-max": (
+        ModularMaxEngine,
+        f"max serve --model {MODEL} --host 0.0.0.0 --port 9000 "
+        "--max-length 8192 --max-batch-size 4",
+    ),
+    "atlas": (
+        AtlasEngine,
+        f"spark serve {MODEL} --host 0.0.0.0 --port 9000 "
+        "--max-seq-len 8192 --max-num-seqs 4",
+    ),
+    "tokenary": (
+        TokenaryEngine,
+        f"tokenary --server --model {MODEL} --host 0.0.0.0 --port 9000 "
+        "--max-model-len 8192 --max-num-seqs 4",
+    ),
+}
+
+
+def engine_for(name: str) -> SoloEngine:
+    cls = CASES[name][0]
+    spec = next(s for s in load_bundled_specs() if s.engine == name)
+    return cls(spec)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_each_engine_renders_the_launch_its_own_docs_show(name):
+    result = engine_for(name).render(RECIPE, params={"port": 9000}, topology=ONE_NODE)
+
+    assert result.command == CASES[name][1]
+    assert result.node_rank == 0
+    assert result.host == "spark-a"
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_every_one_of_them_is_registered_under_its_own_name(name):
+    """A spec whose engine name has no plugin cannot be launched at all, and
+    the failure arrives at deploy time rather than here."""
+    assert ENGINE_CLASSES[name] is CASES[name][0]
+
+
+def test_the_model_reaches_the_command_however_that_engine_takes_one():
+    """Three shapes across the five: a positional argument, a named flag, and
+    llama.cpp's ``-hf``, which resolves a GGUF repository rather than reading
+    a path."""
+    assert " -hf " in engine_for("llama-cpp").render(RECIPE).command
+    assert f"trtllm-serve {MODEL}" in engine_for("trtllm").render(RECIPE).command
+    assert f"--model {MODEL}" in engine_for("modular-max").render(RECIPE).command
+
+
+def test_a_missing_model_is_refused_rather_than_launched_empty():
+    with pytest.raises(EngineError, match="no model"):
+        engine_for("atlas").render({"id": "x", "recipe_version": "2"})
+
+
+def test_more_than_one_node_is_refused_with_what_to_do_instead():
+    """Every one of these declares cluster: false, so a two-node deployment is
+    rejected before rendering. If it ever reached the renderer, a command for
+    one node would be the worse answer."""
+    with pytest.raises(EngineError, match="one node"):
+        engine_for("tokenary").render(RECIPE, topology=TWO_NODES)
+
+
+def test_a_rank_above_zero_is_refused():
+    with pytest.raises(EngineError, match="out of range"):
+        engine_for("atlas").render(RECIPE, topology=ONE_NODE, node_rank=1)
+
+
+def test_the_engines_port_is_the_default_when_the_recipe_names_none():
+    """Not 8000 for all of them: llama-server listens on 8080 and Atlas on
+    8888, and the spec is what says so."""
+    assert "--port 8080" in engine_for("llama-cpp").render(RECIPE).command
+    assert "--port 8888" in engine_for("atlas").render(RECIPE).command
+    assert "--port 8000" in engine_for("trtllm").render(RECIPE).command
+
+
+def test_a_param_the_engine_has_no_flag_for_is_dropped_not_guessed():
+    """llama.cpp has no tensor parallelism and nothing that means
+    gpu_memory_utilization. Mapping either onto some other flag would be worse
+    than leaving it out, so param_flags names neither and both disappear."""
+    command = (
+        engine_for("llama-cpp")
+        .render(RECIPE, params={"tensor_parallel": 2, "gpu_memory_utilization": 0.9})
+        .command
+    )
+
+    assert "--tensor-parallel" not in command and "--tp" not in command
+    assert "0.9" not in command
+    assert command == CASES["llama-cpp"][1].replace("--port 9000", "--port 8080")
+
+
+def test_extra_args_are_appended_quoted():
+    command = (
+        engine_for("atlas")
+        .render(
+            RECIPE, extra_args=["--kv-cache-dtype", "nvfp4", "--warmup-prompt", "a b"]
+        )
+        .command
+    )
+
+    assert command.endswith("--kv-cache-dtype nvfp4 --warmup-prompt 'a b'")
+
+
+def test_a_recipe_pinned_to_another_engine_is_not_rendered():
+    """A top-level `command:` is written in one engine's flags."""
+    recipe = {"model": MODEL, "command": "vllm serve {model} --max-model-len 8192"}
+
+    with pytest.raises(EngineError, match="vllm"):
+        engine_for("trtllm").render(recipe)
+
+
+def test_a_single_node_launch_carries_no_fabric_pinning():
+    """One machine never touches the fabric, and NCCL_SOCKET_IFNAME is
+    find-or-fail: pinning an interface here is how a solo launch dies on a
+    machine whose fabric link is down."""
+    env = engine_for("modular-max").render(RECIPE, topology=ONE_NODE).env
+
+    assert "NCCL_SOCKET_IFNAME" not in env
+    assert "NCCL_IB_HCA" not in env
+    assert env["GLOO_SOCKET_IFNAME"] == "lo"
+    assert env["HF_HOME"] == "/root/.cache/huggingface"
+
+
+def test_the_recipes_own_env_and_args_still_reach_the_launch():
+    recipe = {
+        **RECIPE,
+        "args": "--scheduling-policy slai",
+        "env": {"ATLAS_LOG": "debug"},
+    }
+
+    result = engine_for("atlas").render(recipe, topology=ONE_NODE)
+
+    assert result.command.endswith("--scheduling-policy slai")
+    assert result.env["ATLAS_LOG"] == "debug"
+    assert "export ATLAS_LOG=" in result.script
+
+
+def test_an_unpublished_engine_says_so_rather_than_offering_a_403():
+    """llama-cpp is defined but not built, and tokenary has no image anywhere.
+    `available` is what keeps them out of the deploy options until they do:
+    pulling an unpublished reference answers 403, not an image."""
+    specs = {s.engine: s for s in load_bundled_specs()}
+
+    assert specs["llama-cpp"].available is False
+    assert specs["tokenary"].available is False
+    assert specs["atlas"].available is True
+    assert specs["trtllm"].available is True

--- a/tests/test_engines_solo.py
+++ b/tests/test_engines_solo.py
@@ -188,12 +188,12 @@ def test_the_recipes_own_env_and_args_still_reach_the_launch():
 
 
 def test_an_unpublished_engine_says_so_rather_than_offering_a_403():
-    """llama-cpp is defined but not built, and tokenary has no image anywhere.
-    `available` is what keeps them out of the deploy options until they do:
-    pulling an unpublished reference answers 403, not an image."""
+    """tokenary has no image in any registry we can reach. `available` is what
+    keeps it out of the deploy options until one exists: pulling an
+    unpublished reference answers 403, not an image."""
     specs = {s.engine: s for s in load_bundled_specs()}
 
-    assert specs["llama-cpp"].available is False
     assert specs["tokenary"].available is False
+    assert specs["llama-cpp"].available is True
     assert specs["atlas"].available is True
     assert specs["trtllm"].available is True

--- a/tests/test_mock_recipes.py
+++ b/tests/test_mock_recipes.py
@@ -148,7 +148,10 @@ class TestListRecipes:
             assert entry["params"] == entry["defaults"]
             assert entry["source"] == recipe_sources.SOURCE_UPSTREAM
             assert entry["is_customized"] is False
-            assert {s["engine"] for s in entry["engine_support"]} == {"vllm", "sglang"}
+            assert {s["engine"] for s in entry["engine_support"]} >= {
+                "vllm",
+                "sglang",
+            }
 
     def test_an_empty_checkout_lists_only_what_is_on_disk(self, tmp_path, no_sources):
         # A checkout that exists but holds no recipes is not "no source at all":

--- a/tests/test_router_engines.py
+++ b/tests/test_router_engines.py
@@ -8,6 +8,12 @@ from fastapi.testclient import TestClient
 from spark_pulse.app import create_app
 from spark_pulse.config import config
 from spark_pulse.engines import EngineRegistry, reset_registry
+from spark_pulse.engines.registry import load_bundled_specs
+
+#: Whatever ships in ``engines/defaults``. Named rather than listed: which
+#: engines are bundled is that directory's business, and a router test that
+#: repeats the list only fails when somebody adds one.
+BUNDLED_KEYS = {s.key for s in load_bundled_specs()}
 
 V1_RECIPE = {
     "id": "qwen3-8b",
@@ -64,7 +70,7 @@ class TestListEngines:
         data = response.json()
         assert data["default_engine"] == "vllm"
         keys = {e["key"] for e in data["engines"]}
-        assert keys == {"vllm/default", "sglang/default"}
+        assert keys == BUNDLED_KEYS
 
     def test_list_carries_capabilities_image_and_verification(self, client):
         engines = client.get("/api/engines").json()["engines"]
@@ -103,7 +109,7 @@ class TestRefresh:
         data = response.json()
         assert data["refreshed"] is False
         assert "simulation" in data["reason"]
-        assert data["engines"] == 2
+        assert data["engines"] == len(BUNDLED_KEYS)
 
     def test_refresh_reports_per_index_status(self, client, monkeypatch):
         monkeypatch.setattr(
@@ -114,7 +120,7 @@ class TestRefresh:
         data = response.json()
         assert data["refreshed"] is True
         assert data["indexes"] == []
-        assert data["engines"] == 2
+        assert data["engines"] == len(BUNDLED_KEYS)
 
 
 class TestRender:
@@ -210,7 +216,7 @@ class TestRender:
 
     def test_render_unknown_engine_is_404(self, client):
         response = client.post(
-            "/api/engines/render", json={"recipe_id": "qwen3-8b", "engine": "trtllm"}
+            "/api/engines/render", json={"recipe_id": "qwen3-8b", "engine": "nonesuch"}
         )
         assert response.status_code == 404
 

--- a/tests/test_router_recipes.py
+++ b/tests/test_router_recipes.py
@@ -34,12 +34,13 @@ class TestListRecipes:
         assert bundled[BUNDLED_ID]["engines"] == ["vllm", "sglang"]
 
     def test_every_entry_carries_a_source_and_support_table(self, client):
+        """One verdict per engine the registry carries. An engine missing from
+        the table is one the picker cannot show a reason for."""
+        engines = {e["engine"] for e in client.get("/api/engines").json()["engines"]}
+
         for entry in client.get("/api/recipes").json():
             assert entry["source"]
-            assert {e["engine"] for e in entry["engine_support"]} == {
-                "sglang",
-                "vllm",
-            }
+            assert {e["engine"] for e in entry["engine_support"]} == engines
 
 
 class TestGetRecipe:

--- a/tests/test_tools_engine_metrics.py
+++ b/tests/test_tools_engine_metrics.py
@@ -143,13 +143,38 @@ class TestNames:
         assert em.names_for("vllm")[0] is em.VLLM_METRICS
         assert em.names_for("sglang")[0] is em.SGLANG_METRICS
 
-    def test_the_other_engine_is_still_tried(self):
+    def test_the_other_engines_are_still_tried(self):
         """An engine name is what the recipe called the image, not a promise."""
-        assert set(em.names_for("vllm")) == {em.VLLM_METRICS, em.SGLANG_METRICS}
+        assert set(em.names_for("vllm")) == set(em.ALL_METRICS)
 
     @pytest.mark.parametrize("engine", [None, "", "llamacpp"])
-    def test_an_unknown_engine_falls_back_to_trying_both(self, engine):
-        assert set(em.names_for(engine)) == {em.VLLM_METRICS, em.SGLANG_METRICS}
+    def test_an_unknown_engine_falls_back_to_trying_all_of_them(self, engine):
+        """ "llamacpp" is not the engine name: the spec calls it llama-cpp, and
+        a name we do not have a map for is not a reason to give up on the
+        body."""
+        assert set(em.names_for(engine)) == set(em.ALL_METRICS)
+
+    def test_llama_cpp_is_tried_first_for_llama_cpp(self):
+        assert em.names_for("llama-cpp")[0] is em.LLAMA_CPP_METRICS
+
+    def test_a_llama_cpp_body_becomes_the_numbers_it_publishes(self):
+        """Four of the six. llama-server has no KV-usage gauge and does not
+        preempt, and those stay None rather than being read off a metric that
+        means something else."""
+        text = (
+            "llamacpp:requests_processing 3\n"
+            "llamacpp:requests_deferred 2\n"
+            "llamacpp:prompt_tokens_total 1200\n"
+            "llamacpp:tokens_predicted_total 800\n"
+        )
+
+        reading = em.read_families(em.parse_prometheus_text(text), "llama-cpp")
+
+        assert (reading.running, reading.waiting) == (3.0, 2.0)
+        assert reading.prompt_tokens_total == 1200.0
+        assert reading.generation_tokens_total == 800.0
+        assert reading.kv_fraction is None
+        assert reading.preemptions_total is None
 
     def test_an_engine_name_is_matched_case_insensitively(self):
         assert em.names_for("VLLM")[0] is em.VLLM_METRICS

--- a/web/src/components/DeployOptions.tsx
+++ b/web/src/components/DeployOptions.tsx
@@ -195,6 +195,17 @@ export function engineChoices(engines: EngineSummary[], recipe: RecipeDetail): E
   return engines
     .filter((e) => e.enabled)
     .map((engine) => {
+      // An engine with no published image cannot run anything, whatever it
+      // says about the recipe: pulling it answers 403. It stays in the list
+      // as an unavailable row rather than vanishing, because "the engine I
+      // read about is missing" is the harder question to answer.
+      if (engine.available === false) {
+        return {
+          engine,
+          supported: false,
+          reason: "no image has been published for this engine yet",
+        };
+      }
       const reported = support.get(engine.engine);
       if (reported) {
         return { engine, supported: reported.supported, reason: reported.reason };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -632,6 +632,11 @@ export interface EngineSummary {
   metrics: string | null;
   source: string;
   enabled: boolean;
+  /** False when no image has been published for this engine: pulling it
+   * answers 403 rather than an image. Older payloads omit both fields. */
+  available?: boolean;
+  /** `available` and `enabled` together — whether a deploy could use it. */
+  usable?: boolean;
 }
 
 export interface EngineDetail extends EngineSummary {

--- a/web/src/tests/components/DeployOptions.test.tsx
+++ b/web/src/tests/components/DeployOptions.test.tsx
@@ -255,6 +255,27 @@ describe("eligibleEngines", () => {
     expect(refused?.reason).toContain("engine-specific command");
   });
 
+  it("keeps an engine with no published image, and says that is why", () => {
+    // Not hidden: "the engine I read about is missing from the list" is the
+    // harder question to answer than "here it is, and here is why not".
+    const engines = [engine("vllm"), engine("llama-cpp", { available: false })];
+    const shown = engineChoices(engines, V2_RECIPE).find(
+      (c) => c.engine.engine === "llama-cpp",
+    );
+
+    expect(shown?.supported).toBe(false);
+    expect(shown?.reason).toContain("no image has been published");
+  });
+
+  it("does not second-guess an older payload that reports no availability", () => {
+    const engines = [engine("vllm"), engine("sglang")];
+
+    expect(eligibleEngines(engines, V2_RECIPE).map((e) => e.engine)).toEqual([
+      "vllm",
+      "sglang",
+    ]);
+  });
+
   it("falls back to the command heuristic when no verdict is reported", () => {
     const engines = [engine("vllm"), engine("sglang")];
     const refused = engineChoices(engines, V1_RECIPE).find((c) => c.engine.engine === "sglang");

--- a/web/tests/e2e/deploy-preview.spec.ts
+++ b/web/tests/e2e/deploy-preview.spec.ts
@@ -29,14 +29,29 @@ async function openDeployOptions(page: import("@playwright/test").Page) {
   await page.getByRole("button", { name: "Deploy options" }).click();
 }
 
-test("offers every engine that can run the recipe", async ({ page, request }) => {
+test("offers every engine that can run the recipe, and says why about the rest", async ({
+  page,
+  request,
+}) => {
+  // The picker's list is the API's verdict, not "every engine that exists":
+  // a recipe declares the engines it was written for, and an engine with no
+  // published image cannot run anything at all. Both belong under the picker
+  // with their reason rather than missing from it, so both are asserted here.
   const response = await request.get("/api/engines");
   expect(response.ok()).toBeTruthy();
   const { engines } = (await response.json()) as {
-    engines: { engine: string; version: string; enabled: boolean }[];
+    engines: { engine: string; version: string; enabled: boolean; available: boolean }[];
   };
-  const enabled = engines.filter((e) => e.enabled);
-  expect(enabled.length, "simulation mode should enable at least one engine").toBeGreaterThan(0);
+  const detail = await request.get(`/api/recipes/${RECIPE_ID}`);
+  expect(detail.ok()).toBeTruthy();
+  const { engine_support: support } = (await detail.json()) as {
+    engine_support: { engine: string; supported: boolean }[];
+  };
+  const runs = new Set(support.filter((e) => e.supported).map((e) => e.engine));
+
+  const offered = engines.filter((e) => e.enabled && e.available && runs.has(e.engine));
+  const refused = engines.filter((e) => e.enabled && !(e.available && runs.has(e.engine)));
+  expect(offered.length, "simulation should offer at least one engine").toBeGreaterThan(0);
 
   await openDeployOptions(page);
 
@@ -44,8 +59,18 @@ test("offers every engine that can run the recipe", async ({ page, request }) =>
   await expect(picker).toBeVisible();
   const options = await picker.locator("option").allInnerTexts();
   expect(options[0]).toBe("Recipe default");
-  for (const engine of enabled) {
+  for (const engine of offered) {
     expect(options).toContain(`${engine.engine} · ${engine.version}`);
+  }
+  for (const engine of refused) {
+    expect(options).not.toContain(`${engine.engine} · ${engine.version}`);
+  }
+
+  if (refused.length > 0) {
+    const listed = await page.getByTestId("engines-unavailable").innerText();
+    for (const engine of refused) {
+      expect(listed).toContain(engine.engine);
+    }
   }
 });
 


### PR DESCRIPTION
The other half of [spark-pulse-engine#8](https://github.com/kharkevich-engineering-lab/spark-pulse-engine/pull/8), which defines llama.cpp, TensorRT-LLM, Modular MAX, Atlas and tokenary. Without a plugin here, each of them is a name the registry can list and an `EngineNotFound` at the moment somebody deploys it.

## One class renders all five

vLLM and SGLang each need their own because each has its own rendezvous dialect — `--nnodes/--node-rank/--master-addr/--master-port` against `--dist-init-addr`, rendered at every size so no solo special case survives.

These five have no rendezvous at all:

| | why single-node |
|---|---|
| llama.cpp | its RPC backend is still experimental upstream |
| TensorRT-LLM | multi-node is an MPI job, and NVIDIA's image for this hardware says `single-gpu` in its own tag |
| Modular MAX | no distributed tensor parallelism at all — more *local* GPUs via `--devices`, and a Spark has one |
| Atlas, tokenary | their own NCCL bootstrap (`--rank/--world-size/--master-addr/--master-port`), a dialect nothing here speaks |

So the launch is the serve command, the model, and the engine-neutral params through `param_flags` — all read from the spec, none written in Python. A class per engine carries the registry name and nothing else. `render` still refuses a multi-node topology explicitly, even though `supports_size` already refuses it from `cluster: false`: a renderer that quietly produced a one-node command for a two-node deploy would be the worse failure.

What comes out:

```
llama-server --metrics -hf unsloth/Qwen3-8B-GGUF --host 0.0.0.0 --port 9000 --ctx-size 8192 --parallel 4
trtllm-serve unsloth/Qwen3-8B --host 0.0.0.0 --port 9000 --max_seq_len 8192 --max_batch_size 4
max serve --model unsloth/Qwen3-8B --host 0.0.0.0 --port 9000 --max-length 8192 --max-batch-size 4
spark serve unsloth/Qwen3-8B --host 0.0.0.0 --port 9000 --max-seq-len 8192 --max-num-seqs 4
tokenary --server --model unsloth/Qwen3-8B --host 0.0.0.0 --port 9000 --max-model-len 8192 --max-num-seqs 4
```

## An unavailable engine was being offered

The specs are bundled as defaults, which is what makes them selectable offline and in simulation. Two ship `available: false` — llama-cpp has no published image yet, tokenary has none anywhere.

That flag already existed and already meant "pulling this answers 403 rather than an image", and `registry.usable()` already read it. But the deploy picker filtered on `enabled` alone, so an unavailable engine was offered like any other. It now appears in the picker's *unavailable* list with the reason rather than being hidden: "the engine I read about is missing from the list" is the harder question to answer than "here it is, and here is why not".

## Metrics

llama.cpp publishes Prometheus text under its own names, so it gets a map. Four of the six readings map; llama-server publishes no KV-usage gauge and does not preempt, and those stay `None` rather than being read off a metric that means something else. `names_for` now falls back across every map rather than the two it was written with, so a body in any known dialect still charts whatever the recipe called the image.

## Worth knowing before deploying one

- **llama.cpp takes GGUF.** `-hf` resolves a `…-GGUF` repository, not the safetensors repository the other engines take, and llama-server downloads into `LLAMA_CACHE` rather than reading the snapshot Spark Pulse already fetched. Both caches are mounted, but a model downloaded here will be downloaded again by the engine on first launch.
- **Nothing here has been run on this hardware.** Every new spec's `verified` is empty.
- Recipes that declare `engines: {vllm, sglang}` — the bundled ones — report the other five as unsupported with the reason, which is right: the recipe enumerates what it was written for.

3281 backend tests, 1061 frontend tests, black, ruff, eslint and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPSMCpciURCxSiWsbXSGV